### PR TITLE
fix(a2a): redact sensitive headers and tokens in logs (#25)

### DIFF
--- a/backend/app/integrations/a2a_client/gateway.py
+++ b/backend/app/integrations/a2a_client/gateway.py
@@ -21,7 +21,7 @@ from app.integrations.a2a_client.errors import (
     A2AOutboundNotAllowedError,
 )
 from app.integrations.a2a_client.metrics import a2a_metrics
-from app.utils.logging_redaction import redact_url_for_logging
+from app.utils.logging_redaction import redact_headers_for_logging, redact_url_for_logging
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from a2a.types import AgentCard
@@ -30,28 +30,6 @@ if TYPE_CHECKING:  # pragma: no cover - import for typing only
 
 logger = get_logger(__name__)
 
-
-def _mask_headers(headers: Dict[str, str]) -> Dict[str, str]:
-    masked: Dict[str, str] = {}
-    for key, value in headers.items():
-        if not isinstance(value, str):
-            masked[key] = value
-            continue
-        lowered = key.lower()
-        # Never log secrets. We only keep the key name plus a placeholder.
-        if lowered in {
-            "authorization",
-            "proxy-authorization",
-            "cookie",
-            "set-cookie",
-            "api-key",
-            "x-api-key",
-            "x-goog-api-key",
-        }:
-            masked[key] = "<redacted>" if value else ""
-        else:
-            masked[key] = value
-    return masked
 
 
 @dataclass
@@ -452,7 +430,8 @@ class A2AGateway:
                     "Reusing cached A2A client",
                     extra={
                         "agent_name": resolved.name,
-                        "headers": _mask_headers(resolved.headers),
+                        "headers": redact_headers_for_logging
+(resolved.headers),
                     },
                 )
                 return cached.client
@@ -474,7 +453,8 @@ class A2AGateway:
                 "Created new A2A client",
                 extra={
                     "agent_name": resolved.name,
-                    "headers": _mask_headers(resolved.headers),
+                    "headers": redact_headers_for_logging
+(resolved.headers),
                 },
             )
             return client
@@ -518,7 +498,8 @@ class A2AGateway:
                 "Invalidated A2A client",
                 extra={
                     "agent_name": resolved.name,
-                    "headers": _mask_headers(resolved.headers),
+                    "headers": redact_headers_for_logging
+(resolved.headers),
                 },
             )
 

--- a/backend/app/middleware/debug_logging.py
+++ b/backend/app/middleware/debug_logging.py
@@ -23,38 +23,12 @@ from app.core.logging import (
     set_user_context,
 )
 from app.core.security import verify_access_token
-
-logger = get_logger(__name__)
-
-_SENSITIVE_KEYWORDS = (
-    "authorization",
-    "cookie",
-    "token",
-    "ticket",
-    "secret",
-    "api-key",
-    "apikey",
-    "password",
+from app.utils.logging_redaction import (
+    redact_headers_for_logging,
+    redact_query_params_for_logging,
 )
 
-
-def _redact_mapping(data: Mapping[str, str]) -> dict[str, str]:
-    redacted: dict[str, str] = {}
-    for key, value in data.items():
-        lower_key = key.lower()
-        if any(keyword in lower_key for keyword in _SENSITIVE_KEYWORDS):
-            redacted[key] = "<redacted>"
-        else:
-            redacted[key] = value
-    return redacted
-
-
-def redact_headers_for_logging(headers: Mapping[str, str]) -> dict[str, str]:
-    return _redact_mapping(headers)
-
-
-def redact_query_params_for_logging(query_params: Mapping[str, str]) -> dict[str, str]:
-    return _redact_mapping(query_params)
+logger = get_logger(__name__)
 
 
 class DebugLoggingMiddleware(BaseHTTPMiddleware):

--- a/backend/app/utils/logging_redaction.py
+++ b/backend/app/utils/logging_redaction.py
@@ -2,7 +2,71 @@
 
 from __future__ import annotations
 
+import hashlib
+from typing import Mapping
 from urllib.parse import SplitResult, urlsplit, urlunsplit
+
+
+_SENSITIVE_KEYWORDS = (
+    "authorization",
+    "cookie",
+    "token",
+    "ticket",
+    "secret",
+    "api-key",
+    "apikey",
+    "password",
+    "access_token",
+    "refresh_token",
+    "api_key",
+    "x-api-key",
+)
+
+
+def redact_sensitive_value(value: str | None) -> str | None:
+    """Redact a sensitive value by keeping the first 6 characters and adding a hash.
+
+    If the value is shorter than 12 characters, we redact it completely to avoid
+    leaking too much information.
+    """
+    if value is None:
+        return None
+
+    s_value = str(value)
+    if not s_value:
+        return s_value
+
+    if len(s_value) < 12:
+        return "<redacted>"
+
+    prefix = s_value[:6]
+    # Use a stable hash of the value to help with debugging across logs
+    val_hash = hashlib.md5(s_value.encode()).hexdigest()[:8]
+    return f"{prefix}...{val_hash}"
+
+
+def redact_headers_for_logging(headers: Mapping[str, str]) -> dict[str, str]:
+    """Redact sensitive headers."""
+    redacted: dict[str, str] = {}
+    for key, value in headers.items():
+        lower_key = key.lower()
+        if any(keyword in lower_key for keyword in _SENSITIVE_KEYWORDS):
+            redacted[key] = redact_sensitive_value(value) or "<redacted>"
+        else:
+            redacted[key] = value
+    return redacted
+
+
+def redact_query_params_for_logging(query_params: Mapping[str, str]) -> dict[str, str]:
+    """Redact sensitive query parameters."""
+    redacted: dict[str, str] = {}
+    for key, value in query_params.items():
+        lower_key = key.lower()
+        if any(keyword in lower_key for keyword in _SENSITIVE_KEYWORDS):
+            redacted[key] = redact_sensitive_value(value) or "<redacted>"
+        else:
+            redacted[key] = value
+    return redacted
 
 
 def redact_url_for_logging(url: str | None) -> str | None:
@@ -41,4 +105,9 @@ def redact_url_for_logging(url: str | None) -> str | None:
     return urlunsplit(redacted)
 
 
-__all__ = ["redact_url_for_logging"]
+__all__ = [
+    "redact_url_for_logging",
+    "redact_headers_for_logging",
+    "redact_query_params_for_logging",
+    "redact_sensitive_value",
+]

--- a/backend/tests/test_logging_redaction.py
+++ b/backend/tests/test_logging_redaction.py
@@ -1,0 +1,53 @@
+import pytest
+from app.utils.logging_redaction import (
+    redact_headers_for_logging,
+    redact_query_params_for_logging,
+    redact_sensitive_value,
+    redact_url_for_logging,
+)
+
+def test_redact_sensitive_value():
+    assert redact_sensitive_value(None) is None
+    assert redact_sensitive_value("") == ""
+    assert redact_sensitive_value("short") == "<redacted>"
+    
+    val = "verylongsensitivevalue123456"
+    redacted = redact_sensitive_value(val)
+    assert redacted.startswith("verylo")
+    assert "..." in redacted
+    assert len(redacted.split("...")[-1]) == 8
+    assert val not in redacted
+
+def test_redact_headers_for_logging():
+    headers = {
+        "Authorization": "Bearer super-secret-token-123456789",
+        "X-API-Key": "my-secret-key-123456789",
+        "Content-Type": "application/json",
+        "User-Agent": "Mozilla/5.0",
+    }
+    redacted = redact_headers_for_logging(headers)
+    
+    assert redacted["Authorization"].startswith("Bearer")
+    assert "..." in redacted["Authorization"]
+    assert redacted["X-API-Key"].startswith("my-sec")
+    assert redacted["Content-Type"] == "application/json"
+    assert redacted["User-Agent"] == "Mozilla/5.0"
+
+def test_redact_query_params_for_logging():
+    params = {
+        "token": "secret-token-123456789",
+        "page": "1",
+        "q": "search term",
+    }
+    redacted = redact_query_params_for_logging(params)
+    
+    assert redacted["token"].startswith("secret")
+    assert "..." in redacted["token"]
+    assert redacted["page"] == "1"
+    assert redacted["q"] == "search term"
+
+def test_redact_url_for_logging():
+    assert redact_url_for_logging("https://user:pass@example.com/path?query=val#frag") == "https://example.com"
+    assert redact_url_for_logging("http://localhost:8080/foo") == "http://localhost:8080"
+    assert redact_url_for_logging("invalid-url") == "invalid-url"
+    assert redact_url_for_logging(None) is None


### PR DESCRIPTION
## Summary
补齐了 A2A 相关日志脱敏策略，确保敏感信息（如 Authorization, API Key, tokens 等）不会以明文形式出现在日志中。

## Changes
- **统一脱敏工具**：在 `backend/app/utils/logging_redaction.py` 中封装了 `redact_headers_for_logging` 等方法。
- **中间件加固**：`DebugLoggingMiddleware` 统一使用新工具函数处理 headers 和 query params。
- **网关层优化**：`A2AGateway` 替换了旧的硬编码脱敏逻辑。
- **测试覆盖**：新增 `backend/tests/test_logging_redaction.py`。

## Verification Evidence
已通过独立脚本验证脱敏逻辑（前6位+hash）。
