### PR TITLE
fix(ops): remove query ticket and use subprotocol for WS auth (#22)

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -103,16 +103,15 @@ async def get_ws_ticket_user(
     scope_type: str,
     scope_id: UUID,
     db: AsyncSession = Depends(get_async_db),
-    ticket: str | None = Query(None),
 ) -> User:
     """
     Get current authenticated user for WebSocket connections via WS ticket.
 
     Args:
         websocket: WebSocket connection
-        agent_id: A2A agent identifier from path
+        scope_type: Scope type for ticket validation
+        scope_id: Scope identifier (e.g., agent_id)
         db: Database session
-        ticket: One-time WS ticket from query parameters
 
     Returns:
         Current user instance
@@ -125,6 +124,18 @@ async def get_ws_ticket_user(
         raise WebSocketException(
             code=status.WS_1008_POLICY_VIOLATION, reason="Origin not allowed"
         )
+
+    # We extract the ticket from the Sec-WebSocket-Protocol header to avoid
+    # leaking it in URL query parameters.
+    ticket = None
+    subprotocols = websocket.headers.get("sec-websocket-protocol")
+    if subprotocols:
+        for proto in subprotocols.split(","):
+            candidate = proto.strip()
+            # tickets are generated with urlsafe_token (base64-ish) and length >= 16
+            if len(candidate) >= 16:
+                ticket = candidate
+                break
 
     if not ticket:
         raise WebSocketException(
@@ -162,14 +173,12 @@ async def get_ws_ticket_user_me(
     websocket: WebSocket,
     agent_id: UUID,
     db: AsyncSession = Depends(get_async_db),
-    ticket: str | None = Query(None),
 ) -> User:
     return await get_ws_ticket_user(
         websocket=websocket,
         scope_type="me_a2a_agent",
         scope_id=agent_id,
         db=db,
-        ticket=ticket,
     )
 
 
@@ -178,14 +187,12 @@ async def get_ws_ticket_user_hub(
     websocket: WebSocket,
     agent_id: UUID,
     db: AsyncSession = Depends(get_async_db),
-    ticket: str | None = Query(None),
 ) -> User:
     return await get_ws_ticket_user(
         websocket=websocket,
         scope_type="hub_a2a_agent",
         scope_id=agent_id,
         db=db,
-        ticket=ticket,
     )
 
 

--- a/backend/tests/test_a2a_websocket.py
+++ b/backend/tests/test_a2a_websocket.py
@@ -48,8 +48,9 @@ def test_invoke_agent_ws_invalid_token(monkeypatch):
     try:
         with pytest.raises(Exception):
             with client.websocket_connect(
-                f"{settings.api_v1_prefix}/me/a2a/agents/{uuid4()}/invoke/ws?ticket=invalid",
+                f"{settings.api_v1_prefix}/me/a2a/agents/{uuid4()}/invoke/ws",
                 headers={"origin": "http://localhost:5173"},
+                subprotocols=["invalid-ticket-length-48-chars-minimum-1234567"],
             ):
                 pass
     finally:
@@ -97,9 +98,11 @@ def test_invoke_agent_ws_success(monkeypatch, mock_user):
 
     client = TestClient(app)
     try:
+        # Use subprotocols for ticket
         with client.websocket_connect(
-            f"{settings.api_v1_prefix}/me/a2a/agents/{uuid4()}/invoke/ws?ticket=mock",
+            f"{settings.api_v1_prefix}/me/a2a/agents/{uuid4()}/invoke/ws",
             headers={"origin": "http://localhost:5173"},
+            subprotocols=["mock-ticket-length-48-chars-minimum-1234567890"],
         ) as websocket:
             # Send the request
             websocket.send_json({"query": "ping"})

--- a/backend/tests/test_hub_a2a_websocket.py
+++ b/backend/tests/test_hub_a2a_websocket.py
@@ -47,8 +47,9 @@ def test_invoke_hub_agent_ws_invalid_token(monkeypatch):
     try:
         with pytest.raises(Exception):
             with client.websocket_connect(
-                f"{settings.api_v1_prefix}/a2a/agents/{uuid4()}/invoke/ws?ticket=invalid",
+                f"{settings.api_v1_prefix}/a2a/agents/{uuid4()}/invoke/ws",
                 headers={"origin": "http://localhost:5173"},
+                subprotocols=["invalid-ticket-length-48-chars-minimum-1234567"],
             ):
                 pass
     finally:
@@ -91,8 +92,9 @@ def test_invoke_hub_agent_ws_success(monkeypatch, mock_user):
     client = TestClient(app)
     try:
         with client.websocket_connect(
-            f"{settings.api_v1_prefix}/a2a/agents/{uuid4()}/invoke/ws?ticket=mock",
+            f"{settings.api_v1_prefix}/a2a/agents/{uuid4()}/invoke/ws",
             headers={"origin": "http://localhost:5173"},
+            subprotocols=["mock-ticket-length-48-chars-minimum-1234567890"],
         ) as websocket:
             websocket.send_json({"query": "ping"})
 


### PR DESCRIPTION
## Summary
移除了通过 URL Query 参数传递 WebSocket Ticket 的方式，改为使用 `Sec-WebSocket-Protocol` 子协议头传递，以降低在反代日志或监控中泄漏 Ticket 的风险。

## Changes
- **鉴权依赖项更新**：`get_ws_ticket_user` 不再从 Query 读取 `ticket`，改为从 `Sec-WebSocket-Protocol` 中提取。
- **子协议处理**：支持从逗号分隔的子协议列表中识别长度符合规范的 Ticket。
- **测试用例更新**：同步更新了 `test_a2a_websocket.py` 和 `test_hub_a2a_websocket.py`，通过子协议传递 Ticket 进行验证。

## Verification Evidence
运行 `pytest` 结果：
```
backend/tests/test_a2a_websocket.py ..                                   [ 33%]
backend/tests/test_hub_a2a_websocket.py ..                               [ 66%]
...
6 passed in 10.78s
```
