### PR TITLE
chore(frontend): limit memory usage for check-types (#40)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ After any code change, you must run the relevant regressions and fix all failure
 - **Frontend changes (`frontend/`)**
   - `cd frontend && npm install`
   - `cd frontend && npm run lint`
-  - `cd frontend && npm run check-types`
+  - `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
   - `cd frontend && npm test`
 
 Notes:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint app components hooks lib screens services store --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "test": "jest",
-    "check-types": "tsc --noEmit"
+    "check-types": "export NODE_OPTIONS=\"--max-old-space-size=1024\" && tsc --noEmit"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary
限制了前端 `check-types` 脚本的内存占用，以减轻小服务器的性能压力。

## Changes
- **AGENTS.md**: 更新了前端回归测试的指令，增加了 `NODE_OPTIONS="--max-old-space-size=1024"`。
- **frontend/package.json**: 在 `check-types` 脚本中直接集成了内存限制。
