### PR TITLE
fix(frontend): implement automatic refresh for admin shared agents list (#27)

### DIFF
--- a/frontend/lib/queryKeys.ts
+++ b/frontend/lib/queryKeys.ts
@@ -1,3 +1,7 @@
 export const queryKeys = {
   me: (token?: string | null) => ["auth", "me", token ?? "anonymous"] as const,
+  admin: {
+    hubAgents: () => ["admin", "hub-agents"] as const,
+    hubAgent: (id: string) => ["admin", "hub-agents", id] as const,
+  },
 };

--- a/frontend/screens/admin/AdminHubAgentDetailScreen.tsx
+++ b/frontend/screens/admin/AdminHubAgentDetailScreen.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -35,6 +36,7 @@ import { confirmAction } from "@/lib/confirm";
 import { blurActiveElement } from "@/lib/focus";
 import { generateId } from "@/lib/id";
 import { backOrHome } from "@/lib/navigation";
+import { queryKeys } from "@/lib/queryKeys";
 import { toast } from "@/lib/toast";
 import {
   type HeaderRow,
@@ -62,6 +64,7 @@ export function AdminHubAgentDetailScreen({
   agentId,
 }: AdminHubAgentDetailScreenProps) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { isReady, isAdmin } = useRequireAdmin();
   const { loading, refreshing, run } = useAsyncListLoad();
 
@@ -243,6 +246,7 @@ export function AdminHubAgentDetailScreen({
     setSaving(true);
     try {
       await updateHubAgentAdmin(agentId, buildUpdatePayload());
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.hubAgents() });
       toast.success("Saved", "Shared agent updated.");
       await load("refreshing");
     } catch (error) {
@@ -281,6 +285,7 @@ export function AdminHubAgentDetailScreen({
     setDeleting(true);
     try {
       await deleteHubAgentAdmin(agentId);
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.hubAgents() });
       toast.success("Deleted", `${agent.name} has been removed.`);
       router.replace("/admin/hub-a2a");
     } catch (error) {

--- a/frontend/screens/admin/AdminHubAgentNewScreen.tsx
+++ b/frontend/screens/admin/AdminHubAgentNewScreen.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import { useCallback, useMemo, useState } from "react";
 import { Pressable, ScrollView, Switch, Text, View } from "react-native";
@@ -18,6 +19,7 @@ import {
 import { blurActiveElement } from "@/lib/focus";
 import { generateId } from "@/lib/id";
 import { backOrHome } from "@/lib/navigation";
+import { queryKeys } from "@/lib/queryKeys";
 import { toast } from "@/lib/toast";
 import {
   type HeaderRow,
@@ -39,6 +41,7 @@ const policies: { label: string; value: HubA2AAvailabilityPolicy }[] = [
 
 export function AdminHubAgentNewScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { isReady, isAdmin } = useRequireAdmin();
 
   const [name, setName] = useState("");
@@ -138,6 +141,7 @@ export function AdminHubAgentNewScreen() {
     setSaving(true);
     try {
       const created = await createHubAgentAdmin(buildPayload());
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.hubAgents() });
       toast.success("Shared agent created", created.name);
       router.replace(`/admin/hub-a2a/${created.id}`);
     } catch (error) {

--- a/frontend/screens/admin/AdminHubAgentsScreen.tsx
+++ b/frontend/screens/admin/AdminHubAgentsScreen.tsx
@@ -1,6 +1,7 @@
 import { Ionicons } from "@expo/vector-icons";
+import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Pressable,
   RefreshControl,
@@ -13,13 +14,12 @@ import { Button } from "@/components/ui/Button";
 import { FullscreenLoader } from "@/components/ui/FullscreenLoader";
 import { IconButton } from "@/components/ui/IconButton";
 import { PageHeader } from "@/components/ui/PageHeader";
-import { useAsyncListLoad } from "@/hooks/useAsyncListLoad";
 import { useRequireAdmin } from "@/hooks/useRequireAdmin";
 import {
   listHubAgentsAdmin,
-  type HubA2AAgentAdminResponse,
 } from "@/lib/api/hubA2aAgentsAdmin";
 import { blurActiveElement } from "@/lib/focus";
+import { queryKeys } from "@/lib/queryKeys";
 
 const pill = (label: string, variant: "primary" | "muted") => (
   <View
@@ -40,40 +40,27 @@ const pill = (label: string, variant: "primary" | "muted") => (
 export function AdminHubAgentsScreen() {
   const router = useRouter();
   const { isReady, isAdmin } = useRequireAdmin();
-  const { refreshing, run } = useAsyncListLoad();
-  const [items, setItems] = useState<HubA2AAgentAdminResponse[]>([]);
 
-  const load = useCallback(
-    async (mode: "loading" | "refreshing" = "loading") => {
-      await run(
-        async () => {
-          const response = await listHubAgentsAdmin(1, 200);
-          setItems(response.items);
-        },
-        {
-          mode,
-          errorTitle: "Load shared agents failed",
-          fallbackMessage: "Could not load shared agents.",
-        },
-      );
-    },
-    [run],
-  );
+  const {
+    data,
+    isLoading,
+    isRefetching,
+    refetch,
+  } = useQuery({
+    queryKey: queryKeys.admin.hubAgents(),
+    queryFn: () => listHubAgentsAdmin(1, 200),
+    enabled: isReady && isAdmin,
+  });
 
-  useEffect(() => {
-    if (!isReady || !isAdmin) return;
-    load().catch(() => {
-      // Error already handled
-    });
-  }, [isReady, isAdmin, load]);
+  const items = data?.items ?? [];
 
   const enabledCount = useMemo(
     () => items.filter((item) => item.enabled).length,
     [items],
   );
 
-  if (!isReady) {
-    return <FullscreenLoader message="Checking permissions..." />;
+  if (!isReady || (isLoading && !isRefetching)) {
+    return <FullscreenLoader message="Loading shared agents..." />;
   }
   if (!isAdmin) {
     return null;
@@ -118,8 +105,8 @@ export function AdminHubAgentsScreen() {
         contentContainerStyle={{ paddingBottom: 32 }}
         refreshControl={
           <RefreshControl
-            refreshing={refreshing}
-            onRefresh={() => load("refreshing")}
+            refreshing={isRefetching}
+            onRefresh={refetch}
             tintColor="#5c6afb"
             colors={["#5c6afb"]}
           />
@@ -131,7 +118,7 @@ export function AdminHubAgentsScreen() {
           </Text>
           <Pressable
             className="flex-row items-center gap-1 rounded-lg px-3 py-2 active:bg-slate-800/40"
-            onPress={() => load("refreshing")}
+            onPress={() => refetch()}
             accessibilityRole="button"
             accessibilityLabel="Refresh"
           >


### PR DESCRIPTION
## Summary
解决了 admin shared agent 列表页在新增或编辑后返回不自动刷新的问题。

## Changes
- **接入 React Query**：将 `AdminHubAgentsScreen` 的数据拉取从本地 `useState` 模式改为 `useQuery` 模式。
- **缓存失效机制**：
    - 在 `AdminHubAgentNewScreen`（新增页）保存成功后调用 `invalidateQueries`。
    - 在 `AdminHubAgentDetailScreen`（详情页）保存或删除成功后调用 `invalidateQueries`。
- **Query Keys 规范**：在 `frontend/lib/queryKeys.ts` 中新增了 `admin.hubAgents` 相关的 key 定义。

## Verification Evidence
由于 React Query 默认在页面获得焦点（Focus）时会根据 `staleTime` 自动触发 Refetch，配合手动的 `invalidateQueries`，可以确保用户从详情页/新增页返回列表页时看到的是最新数据。
