### PR TITLE
fix(config): enforce asymmetric JWT whitelist and align production baseline (#87)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,7 +5,7 @@
 # If true, the first registered user becomes a superuser.
 FIRST_USER_SUPERUSER=1
 
-# JWT (RS256 recommended)
+# JWT (RS*/ES* only; RS256 recommended)
 JWT_ALGORITHM=RS256
 JWT_ISSUER=a2a-client-hub
 
@@ -20,9 +20,9 @@ JWT_REFRESH_TOKEN_TTL_SECONDS=1209600
 JWT_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"
 JWT_PUBLIC_KEY_PEM="-----BEGIN PUBLIC KEY-----\\n...\\n-----END PUBLIC KEY-----\\n"
 
-# Note: HS256 is not supported in this repository. Use RS256 and provide the PEM keys above.
-# JWT_SECRET_KEY is only required when using symmetric JWT signing.
-# With the default RS256 setup, JWT signing uses PEM keys above.
+# Note: symmetric algorithms (HS*) are not supported in this repository.
+# JWT signing uses the PEM keys above.
+# JWT_SECRET_KEY is retained for compatibility and should not be relied on for JWT signing.
 # Generate a strong secret if needed:
 # python -c "import secrets; print(secrets.token_urlsafe(48))"
 JWT_SECRET_KEY=change-me-32-chars-minimum-secret-key

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -14,6 +14,17 @@ from sqlalchemy.engine.url import make_url
 
 load_dotenv(override=True)
 
+SUPPORTED_JWT_ALGORITHMS = frozenset(
+    {
+        "RS256",
+        "RS384",
+        "RS512",
+        "ES256",
+        "ES384",
+        "ES512",
+    }
+)
+
 
 class Settings(BaseSettings):
     """
@@ -144,7 +155,7 @@ class Settings(BaseSettings):
     jwt_secret_key: str = Field(
         default="change-me-32-chars-minimum-secret-key",
         alias="JWT_SECRET_KEY",
-        description="Secret key for JWT token signing",
+        description="Legacy compatibility secret; JWT signing uses asymmetric PEM keys",
     )
     jwt_algorithm: str = Field(
         default="RS256",
@@ -327,20 +338,17 @@ class Settings(BaseSettings):
             )
 
         algorithm = (self.jwt_algorithm or "").upper()
-        uses_asymmetric_jwt = algorithm.startswith(("RS", "ES"))
-        if algorithm == "HS256":
+        if algorithm not in SUPPORTED_JWT_ALGORITHMS:
+            allowed = ", ".join(sorted(SUPPORTED_JWT_ALGORITHMS))
             raise ValueError(
-                "JWT_ALGORITHM=HS256 is not supported. Use RS256 instead. "
-                "Generate keys and set JWT_PRIVATE_KEY_PEM/JWT_PUBLIC_KEY_PEM "
-                "(e.g. `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -out jwt_private_key.pem` "
-                "and `openssl rsa -in jwt_private_key.pem -pubout -out jwt_public_key.pem`)."
+                "JWT_ALGORITHM must be one of: "
+                f"{allowed}. Symmetric algorithms (HS*) are not supported."
             )
-        if uses_asymmetric_jwt:
-            if not self.jwt_private_key_pem or not self.jwt_public_key_pem:
-                raise ValueError(
-                    "JWT_PRIVATE_KEY_PEM and JWT_PUBLIC_KEY_PEM are required for "
-                    f"JWT_ALGORITHM={self.jwt_algorithm}"
-                )
+        if not self.jwt_private_key_pem or not self.jwt_public_key_pem:
+            raise ValueError(
+                "JWT_PRIVATE_KEY_PEM and JWT_PUBLIC_KEY_PEM are required for "
+                f"JWT_ALGORITHM={self.jwt_algorithm}"
+            )
 
         if self.jwt_access_token_ttl_seconds <= 0:
             raise ValueError("JWT_ACCESS_TOKEN_TTL_SECONDS must be positive")
@@ -365,11 +373,6 @@ class Settings(BaseSettings):
         if self.is_production:
             baseline_errors: list[str] = []
 
-            if not uses_asymmetric_jwt and self._is_weak_secret(self.jwt_secret_key):
-                baseline_errors.append(
-                    "JWT_SECRET_KEY must be set to a strong non-default value in production "
-                    "when using symmetric JWT signing"
-                )
             if self._is_weak_secret(self.ws_ticket_secret_key):
                 baseline_errors.append(
                     "WS_TICKET_SECRET_KEY must be set to a strong non-default value in production"

--- a/backend/tests/test_settings_security_baseline.py
+++ b/backend/tests/test_settings_security_baseline.py
@@ -38,6 +38,16 @@ def test_production_allows_default_jwt_secret_for_asymmetric_jwt(
     assert settings.jwt_algorithm == "RS256"
 
 
+def test_rejects_unsupported_symmetric_jwt_algorithm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_base_env(monkeypatch)
+    monkeypatch.setenv("JWT_ALGORITHM", "HS512")
+
+    with pytest.raises(ValueError, match="JWT_ALGORITHM must be one of"):
+        Settings()
+
+
 def test_production_rejects_relaxed_network_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -10,7 +10,8 @@ The backend will refuse to start when baseline checks fail.
 
 When `APP_ENV=production`, the backend enforces:
 
-- `JWT_SECRET_KEY` is not a weak/default placeholder when symmetric JWT signing is used.
+- `JWT_ALGORITHM` is restricted to asymmetric algorithms (`RS*`/`ES*`) with
+  explicit `JWT_PRIVATE_KEY_PEM` and `JWT_PUBLIC_KEY_PEM`.
 - `WS_TICKET_SECRET_KEY` is not a weak/default placeholder.
 - `AUTH_REFRESH_COOKIE_SECURE=true`.
 - `A2A_PROXY_ALLOWED_HOSTS` is non-empty and does not contain literal `*`.


### PR DESCRIPTION
## 变更目标
围绕 `#87` 修正 JWT 生产基线与实际实现语义不一致的问题：
- 避免在默认非对称签名路径下误将 `JWT_SECRET_KEY` 作为硬性生产拦截条件。
- 在配置阶段明确限制 JWT 算法范围，提前阻断不受支持配置。

## 按模块说明
### backend/app/core/config.py
- 新增 `SUPPORTED_JWT_ALGORITHMS` 白名单，仅允许 `RS256/RS384/RS512/ES256/ES384/ES512`。
- 将 `JWT_ALGORITHM` 校验改为白名单校验，明确拒绝 `HS*` 对称算法。
- 统一要求非对称签名密钥对：`JWT_PRIVATE_KEY_PEM` 与 `JWT_PUBLIC_KEY_PEM`。
- 生产基线中移除对 `JWT_SECRET_KEY` 的强制弱口令拦截（避免与非对称主路径语义冲突）。
- 保持其他生产安全基线校验不变（Cookie/CORS/WS/A2A allowlist）。

### backend/tests/test_settings_security_baseline.py
- 调整用例：`RS256` 场景下默认占位 `JWT_SECRET_KEY` 不再触发生产校验失败。
- 新增用例：`JWT_ALGORITHM=HS512` 在配置阶段被拒绝。

### backend/.env.example
- 明确 `JWT_ALGORITHM` 为 `RS*/ES*` 范围。
- 增加 `JWT_SECRET_KEY` 兼容性说明，避免误导为当前 JWT 主签名路径必需项。

### docs/security-baseline.md
- 更新生产基线说明：JWT 侧强调“非对称算法 + 显式 PEM key pair”。

## 相关提交
- `0725f8c` `fix(config): align JWT production baseline checks with actual usage (#87)`
- `310e9f8` `fix(config): restrict JWT algorithms to asymmetric whitelist (#87)`

## Issue 关联
- Closes #87

## 验证证据
- `cd backend && uv sync --extra dev --locked` 通过
- `cd backend && uv run pre-commit run --all-files --config ../.pre-commit-config.yaml` 通过
- `cd backend && uv run pytest` 通过（`113 passed in 29.86s`）
