### PR TITLE
fix(scheduled-tasks): filter out shared agents from agent selection (#153)

### DIFF
--- a/frontend/screens/ScheduledJobFormScreen.tsx
+++ b/frontend/screens/ScheduledJobFormScreen.tsx
@@ -113,7 +113,10 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
 
   const { data: agents = [] } = useAgentsCatalogQuery(true);
   const agentOptions = useMemo(
-    () => agents.map((agent) => ({ id: agent.id, name: agent.name })),
+    () =>
+      agents
+        .filter((agent) => agent.source === "personal")
+        .map((agent) => ({ id: agent.id, name: agent.name })),
     [agents],
   );
 


### PR DESCRIPTION
## Summary
过滤定时任务添加界面中的 Shared Agent。

- 仅允许显示 `source: "personal"` 的 Agent。
- 如果一个 Agent 既存在于 Shared 列表，又存在于用户自己的 Personal 列表，由于它在 Personal 列表中具有 `source: "personal"`，因此它仍会被保留在选择列表中。
- 这样确保了用户只能为自己拥有访问凭证的 Agent 创建定时任务。

## Verification Evidence
- 运行了前端 Lint、类型检查和所有 Jest 测试，全部通过。
- 确认后端已存在 `_ensure_agent_owned` 校验，确保了安全性。

Linked Issue: #153