### PR TITLE
fix(frontend): restore iOS PWA standalone mode and harden meta tags (#162)

### DIFF
--- a/frontend/app/+html.tsx
+++ b/frontend/app/+html.tsx
@@ -9,9 +9,14 @@ export default function Root({ children }: { children: ReactNode }) {
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
         <meta name="apple-mobile-web-app-title" content="A2AClientHub" />
         <meta name="theme-color" content="#05070a" />
+        <link rel="manifest" href="/manifest.json" />
+        <link rel="apple-touch-icon" href="/favicon.ico" />
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -16,6 +16,11 @@ export default function RootLayout() {
     Platform.OS === "web" ? (
       <Head>
         <title>A2AClientHub</title>
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content="black-translucent"
+        />
       </Head>
     ) : null;
 


### PR DESCRIPTION
## Summary
- Restored iOS PWA standalone mode by hardening meta tags in both `+html.tsx` and `_layout.tsx`.
- Added `apple-touch-icon` and `manifest` links to `+html.tsx`.
- Updated status bar style to `black-translucent` for better immersive experience on iOS.

## Verification
- Lint and type checks passed.
- (Manual verification on iOS device required for PWA behavior)