### PR TITLE
chore(frontend): clean up unused code

### DIFF
--- a/frontend/lib/api/a2aExtensions.ts
+++ b/frontend/lib/api/a2aExtensions.ts
@@ -1,11 +1,5 @@
 import { apiRequest } from "@/lib/api/client";
 
-export type A2AExtensionQueryRequest = {
-  page?: number;
-  size?: number | null;
-  query?: Record<string, unknown> | null;
-};
-
 export type A2AExtensionResponse = {
   success: boolean;
   result?: Record<string, unknown> | null;

--- a/frontend/lib/api/hubA2aAgentsAdmin.ts
+++ b/frontend/lib/api/hubA2aAgentsAdmin.ts
@@ -67,10 +67,6 @@ export type HubA2AAllowlistAddRequest = {
   email?: string | null;
 };
 
-export type HubA2AAllowlistReplaceRequest = {
-  entries: HubA2AAllowlistAddRequest[];
-};
-
 export const listHubAgentsAdmin = (page = 1, size = 200) =>
   apiRequest<HubA2AAgentAdminListResponse>("/admin/a2a/agents", {
     query: { page, size },
@@ -122,13 +118,4 @@ export const deleteHubAgentAllowlistEntryAdmin = (
   apiRequest<void>(
     `/admin/a2a/agents/${encodeURIComponent(agentId)}/allowlist/${encodeURIComponent(userId)}`,
     { method: "DELETE" },
-  );
-
-export const replaceHubAgentAllowlistAdmin = (
-  agentId: string,
-  payload: HubA2AAllowlistReplaceRequest,
-) =>
-  apiRequest<HubA2AAllowlistListResponse, HubA2AAllowlistReplaceRequest>(
-    `/admin/a2a/agents/${encodeURIComponent(agentId)}/allowlist:replace`,
-    { method: "PUT", body: payload },
   );

--- a/frontend/screens/admin/__tests__/hubAgentAllowlistState.test.ts
+++ b/frontend/screens/admin/__tests__/hubAgentAllowlistState.test.ts
@@ -1,11 +1,5 @@
 import { type HubA2AAllowlistEntryResponse } from "@/lib/api/hubA2aAgentsAdmin";
-import {
-  buildAllowlistReplaceEntries,
-  buildAllowlistDraftFromEntries,
-  buildNewAllowlistDraftEntry,
-  deriveAllowlistChanges,
-  hasAllowlistEmail,
-} from "@/screens/admin/hubAgentAllowlistState";
+import { buildAllowlistDraftFromEntries } from "@/screens/admin/hubAgentAllowlistState";
 
 const existingEntry = (
   partial: Partial<HubA2AAllowlistEntryResponse>,
@@ -33,48 +27,6 @@ describe("hubAgentAllowlistState", () => {
         userLabel: "a@example.com",
         userId: "user-1",
       },
-    ]);
-  });
-
-  it("detects duplicated email regardless of case", () => {
-    const rows = [buildNewAllowlistDraftEntry("Alice@example.com", "1")];
-    expect(hasAllowlistEmail(rows, "alice@EXAMPLE.com")).toBe(true);
-  });
-
-  it("derives add/remove changes between base and draft", () => {
-    const base = [
-      existingEntry({ id: "entry-a", user_email: "a@example.com" }),
-      existingEntry({
-        id: "entry-b",
-        user_id: "user-2",
-        user_email: "b@example.com",
-      }),
-    ];
-    const draft = [
-      ...buildAllowlistDraftFromEntries([base[0]]),
-      buildNewAllowlistDraftEntry("new@example.com", "new-1"),
-    ];
-
-    expect(deriveAllowlistChanges(base, draft)).toEqual({
-      addEmails: ["new@example.com"],
-      removeUserIds: ["user-2"],
-    });
-  });
-
-  it("builds replace payload entries from mixed draft rows", () => {
-    const draft = [
-      ...buildAllowlistDraftFromEntries([
-        existingEntry({
-          id: "entry-a",
-          user_id: "user-a",
-          user_email: "a@example.com",
-        }),
-      ]),
-      buildNewAllowlistDraftEntry("new@example.com", "new-1"),
-    ];
-    expect(buildAllowlistReplaceEntries(draft)).toEqual([
-      { user_id: "user-a" },
-      { email: "new@example.com" },
     ]);
   });
 });

--- a/frontend/screens/admin/hubAgentAllowlistState.ts
+++ b/frontend/screens/admin/hubAgentAllowlistState.ts
@@ -21,20 +21,6 @@ export const buildAllowlistDraftFromEntries = (
     userId: entry.user_id,
   }));
 
-export const buildNewAllowlistDraftEntry = (
-  email: string,
-  idSeed: string,
-): HubAgentAllowlistDraftEntry => {
-  const normalized = normalizeEmail(email);
-  return {
-    id: `new:${idSeed}`,
-    existingUserId: null,
-    email: normalized,
-    userLabel: normalized,
-    userId: "",
-  };
-};
-
 export const hasAllowlistEmail = (
   entries: HubAgentAllowlistDraftEntry[],
   email: string,
@@ -42,46 +28,4 @@ export const hasAllowlistEmail = (
   const normalized = normalizeEmail(email);
   if (!normalized) return false;
   return entries.some((entry) => normalizeEmail(entry.email) === normalized);
-};
-
-export const deriveAllowlistChanges = (
-  baseEntries: HubA2AAllowlistEntryResponse[],
-  draftEntries: HubAgentAllowlistDraftEntry[],
-): { addEmails: string[]; removeUserIds: string[] } => {
-  const baseUserIds = new Set(baseEntries.map((entry) => entry.user_id));
-  const currentExistingUserIds = new Set(
-    draftEntries
-      .map((entry) => entry.existingUserId)
-      .filter((userId): userId is string => Boolean(userId)),
-  );
-
-  const removeUserIds = Array.from(baseUserIds).filter(
-    (userId) => !currentExistingUserIds.has(userId),
-  );
-  const addEmails = Array.from(
-    new Set(
-      draftEntries
-        .filter((entry) => entry.existingUserId == null)
-        .map((entry) => normalizeEmail(entry.email))
-        .filter(Boolean),
-    ),
-  );
-
-  return { addEmails, removeUserIds };
-};
-
-export const buildAllowlistReplaceEntries = (
-  draftEntries: HubAgentAllowlistDraftEntry[],
-): { user_id?: string; email?: string }[] => {
-  const entries: { user_id?: string; email?: string }[] = [];
-  draftEntries.forEach((entry) => {
-    if (entry.existingUserId) {
-      entries.push({ user_id: entry.existingUserId });
-      return;
-    }
-    const normalizedEmail = normalizeEmail(entry.email);
-    if (!normalizedEmail) return;
-    entries.push({ email: normalizedEmail });
-  });
-  return entries;
 };

--- a/frontend/services/chatConnectionService.ts
+++ b/frontend/services/chatConnectionService.ts
@@ -108,7 +108,7 @@ const resolveWsText = async (data: unknown): Promise<string | null> => {
   return null;
 };
 
-export class ChatConnectionService {
+class ChatConnectionService {
   private readonly abortControllers = new Map<string, AbortController>();
   private readonly wsConnections = new Map<string, WsConnection>();
 


### PR DESCRIPTION
## Summary
- 移除了未消费的导出类型 `A2AExtensionQueryRequest`、`HubA2AAllowlistReplaceRequest`
- 移除了未消费的 API 函数 `replaceHubAgentAllowlistAdmin`
- 移除了由于废弃了批量修改逻辑而未消费的状态工具函数 `buildNewAllowlistDraftEntry`, `deriveAllowlistChanges`, `buildAllowlistReplaceEntries` 及其测试
- 移除了 `ChatConnectionService` 类的导出 (因其仅作为实例导出)