### PR TITLE
fix(backend): fail-fast on critical lifespan service initialization

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,18 +42,13 @@ async def app_lifespan(_: FastAPI):
     start_scheduler()
     ensure_a2a_schedule_job()
     ensure_ws_ticket_cleanup_job()
-    try:
-        get_a2a_service()
-        logger.info("A2A service initialised during startup")
-    except Exception as exc:  # pragma: no cover - defensive startup logging
-        logger.error("Failed to initialise A2A service: %s", exc, exc_info=exc)
-    try:
-        get_a2a_extensions_service()
-        logger.info("A2A extensions service initialised during startup")
-    except Exception as exc:  # pragma: no cover - defensive startup logging
-        logger.error(
-            "Failed to initialise A2A extensions service: %s", exc, exc_info=exc
-        )
+
+    get_a2a_service()
+    logger.info("A2A service initialised during startup")
+
+    get_a2a_extensions_service()
+    logger.info("A2A extensions service initialised during startup")
+
     try:
         yield
     finally:


### PR DESCRIPTION
## 概览

### backend
- `backend/app/main.py`
  - 修改 `app_lifespan` 启动阶段：移除 `get_a2a_service()` 与 `get_a2a_extensions_service()` 的广义异常捕获。
  - 保持初始化调用与日志输出，但改为让异常直接向上抛出，实现启动失败快速退出（fail-fast）。
  - `yield` 与 `finally` 关闭阶段保持不变，未变更资源回收逻辑。

## 变更原因
- 对齐 issue #100 的问题背景：当前服务在关键依赖初始化失败时仍可能“半启动”对外提供接口，掩盖故障并误导探针判断。
- 该改动让应用在关键依赖初始化失败时直接启动失败，避免进入不一致状态。

## 相关提交（PR 185）
- `dfd220d`: refactor(backend): remove defensive exception catching in app lifespan (#100)

## 关联 Issue
- Closes: #100

## 验证记录
- 待补充
