### PR TITLE
refactor(backend): clean up unused variables and redundant methods

### DIFF
--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -80,7 +80,6 @@ class A2AClient:
         *,
         timeout: Optional[httpx.Timeout] = None,
         timeout_seconds: Optional[float] = None,
-        max_connections: int = 20,
         interceptors: Optional[List[ClientCallInterceptor]] = None,
         consumers: Optional[List[Consumer]] = None,
         use_client_preference: bool = False,
@@ -91,7 +90,6 @@ class A2AClient:
         self.agent_url = agent_url.rstrip("/")
         self._agent_card: Optional[AgentCard] = None
         self._timeout = timeout or self._build_timeout(timeout_seconds)
-        self._max_connections = max_connections
 
         self._interceptors = list(interceptors or [])
         self._consumers = list(consumers or [])

--- a/backend/app/integrations/a2a_client/config.py
+++ b/backend/app/integrations/a2a_client/config.py
@@ -10,7 +10,6 @@ class A2ASettings:
     """Runtime settings for the A2A integration layer."""
 
     default_timeout: float
-    max_connections: int
     use_client_preference: bool
     card_fetch_timeout: float = 5.0
     invoke_watchdog_interval: float = 5.0
@@ -22,7 +21,6 @@ def load_settings(raw_settings) -> A2ASettings:
 
     return A2ASettings(
         default_timeout=float(getattr(raw_settings, "a2a_default_timeout", 30.0)),
-        max_connections=int(getattr(raw_settings, "a2a_max_connections", 20)),
         use_client_preference=bool(
             getattr(raw_settings, "a2a_use_client_preference", False)
         ),

--- a/backend/app/integrations/a2a_client/gateway.py
+++ b/backend/app/integrations/a2a_client/gateway.py
@@ -372,7 +372,6 @@ class A2AGateway:
             client = A2AClient(
                 resolved.url,
                 timeout=timeout,
-                max_connections=self.settings.max_connections,
                 use_client_preference=self.settings.use_client_preference,
                 interceptors=self._build_interceptors(resolved),
                 default_headers=resolved.headers,

--- a/backend/app/services/opencode_session_directory.py
+++ b/backend/app/services/opencode_session_directory.py
@@ -403,27 +403,6 @@ class OpencodeSessionDirectoryService:
         }
         return page_items, {"pagination": pagination, "meta": meta}
 
-    async def list_directory_all(
-        self,
-        db: AsyncSession,
-        *,
-        user_id: UUID,
-        refresh: bool,
-    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
-        directory_items, meta = await self._build_directory_snapshot(
-            db,
-            user_id=user_id,
-            refresh=refresh,
-        )
-        total = len(directory_items)
-        pagination = {
-            "page": 1,
-            "size": total,
-            "total": total,
-            "pages": 1 if total > 0 else 0,
-        }
-        return directory_items, {"pagination": pagination, "meta": meta}
-
     async def _list_visible_agents(
         self, db: AsyncSession, *, user_id: UUID
     ) -> List[_AgentRef]:


### PR DESCRIPTION
## 概要
执行后端冗余代码的审查与清理工作，移除不再使用的属性和方法，提升代码库的整洁度。

## 变更内容

### Integrations (A2A Client)
- 移除 `A2AClient` 及其配置 `A2ASettings` 中废弃的 `max_connections` 初始化参数。目前并发连接数限制已由全局的 `http_client.py` 统一接管，在此处声明和传递属于冗余设计。

### Services (OpenCode)
- 移除 `OpencodeSessionDirectoryService` 中未被调用的冗余方法 `list_directory_all`。前端当前已通过带分页机制的 `list_directory` 接口完全满足需求，移除了不必要的死代码。

## 关联 Issue
Closes #191