### PR TITLE
fix(frontend): lock external_session_id against overwrite #202

### DIFF
--- a/frontend/lib/__tests__/chat-utils.test.ts
+++ b/frontend/lib/__tests__/chat-utils.test.ts
@@ -32,6 +32,24 @@ describe("chat store utils", () => {
 
     expect(next).toEqual({
       provider: "opencode",
+      externalSessionId: "ext-1",
+    });
+  });
+
+  it("falls back to incoming external session id when existing is empty", () => {
+    const next = mergeExternalSessionRef(
+      {
+        provider: null,
+        externalSessionId: null,
+      },
+      {
+        provider: "opencode",
+        externalSessionId: "ext-2",
+      },
+    );
+
+    expect(next).toEqual({
+      provider: "opencode",
       externalSessionId: "ext-2",
     });
   });

--- a/frontend/lib/chat-utils.ts
+++ b/frontend/lib/chat-utils.ts
@@ -50,9 +50,9 @@ export const mergeExternalSessionRef = (
     externalSessionId?: string | null;
   },
 ): ExternalSessionRef => ({
-  provider: incoming.provider ?? current?.provider ?? null,
+  provider: current?.provider ?? incoming.provider ?? null,
   externalSessionId:
-    incoming.externalSessionId ?? current?.externalSessionId ?? null,
+    current?.externalSessionId ?? incoming.externalSessionId ?? null,
 });
 
 export const buildInvokePayload = (


### PR DESCRIPTION
## 变更说明
- Closes #202：会话内首次拿到 external session 后不再被后续流式元数据覆盖。
- 调整 frontend/lib/chat-utils.ts 中的 mergeExternalSessionRef 合并策略：以现有 externalSessionRef 为优先，保留已锁定 externalSessionId。
- 更新 frontend/lib/__tests__/chat-utils.test.ts：
  - 校验已有 externalSessionId 不会被新的流式 meta 覆盖。
  - 增加现有会话为空时，允许首次写入 incoming 的 fallback 场景。

## 验证（串行低负载）
- cd frontend && npm run lint
- cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types
- cd frontend && npm test -- --findRelatedTests lib/__tests__/chat-utils.test.ts --maxWorkers=25%
