### PR TITLE
feat(frontend): add agent session list and switch capability (#127)

### DIFF
--- a/frontend/screens/ChatScreen.tsx
+++ b/frontend/screens/ChatScreen.tsx
@@ -1,7 +1,13 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
 import { useFocusEffect, useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   FlatList,
   KeyboardAvoidingView,
@@ -37,6 +43,7 @@ import {
 import { type ChatMessage, type MessageBlock } from "@/lib/api/chat-utils";
 import { ApiRequestError } from "@/lib/api/client";
 import { continueSession } from "@/lib/api/sessions";
+import { type AgentSession } from "@/lib/chat-utils";
 import { shouldStickToBottom } from "@/lib/chatScroll";
 import { blurActiveElement } from "@/lib/focus";
 import { buildChatRoute } from "@/lib/routes";
@@ -107,11 +114,140 @@ const shouldCollapseByLength = (value: string) => {
   return value.length > COLLAPSED_TEXT_CHAR_LIMIT;
 };
 
+function SessionItem({
+  conversationId,
+  session,
+  isActive,
+  onSelect,
+}: {
+  conversationId: string;
+  session: AgentSession;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const messages = useMessageStore((state) => state.messages[conversationId]);
+  const firstUserMessage = messages?.find((m) => m.role === "user");
+  const title = firstUserMessage?.content?.trim() || "New Session";
+  const date = new Date(session.lastActiveAt).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <Pressable
+      className={`mb-2 flex-row items-center justify-between rounded-xl border p-3 ${
+        isActive
+          ? "border-primary bg-primary/10"
+          : "border-slate-800 bg-slate-900"
+      }`}
+      onPress={() => onSelect(conversationId)}
+    >
+      <Text className="flex-1 text-sm font-medium text-white" numberOfLines={1}>
+        {title}
+      </Text>
+      <Text className="ml-2 text-[10px] text-slate-400">{date}</Text>
+    </Pressable>
+  );
+}
+
+function SessionPickerModal({
+  visible,
+  onClose,
+  agentId,
+  currentConversationId,
+  onSelect,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  agentId?: string | null;
+  currentConversationId?: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const generateConversationId = useChatStore(
+    (state) => state.generateConversationId,
+  );
+  const getSessionsByAgentId = useChatStore(
+    (state) => state.getSessionsByAgentId,
+  );
+  const sessions = useChatStore((state) => state.sessions);
+
+  const agentSessions = React.useMemo(() => {
+    if (!agentId) return [];
+    return getSessionsByAgentId(agentId);
+  }, [agentId, getSessionsByAgentId, sessions]);
+
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 justify-end bg-black/60 sm:items-center sm:justify-center">
+        <Pressable
+          className="absolute inset-0"
+          accessibilityRole="button"
+          accessibilityLabel="Close session picker"
+          onPress={onClose}
+        />
+        <View className="w-full max-h-[80%] min-h-[50%] rounded-t-3xl border-t border-slate-800 bg-slate-950 p-6 sm:w-[480px] sm:rounded-3xl sm:border">
+          <View className="mb-6 flex-row items-center justify-between">
+            <Text className="text-lg font-semibold text-white">
+              Chat History
+            </Text>
+            <Pressable
+              onPress={onClose}
+              className="rounded-full bg-slate-800 p-2"
+              accessibilityRole="button"
+              accessibilityLabel="Close session picker"
+            >
+              <Ionicons name="close" size={20} color="#cbd5e1" />
+            </Pressable>
+          </View>
+          <Button
+            className="mb-4"
+            label="New Session"
+            iconLeft="add"
+            onPress={() => {
+              onSelect(generateConversationId());
+              onClose();
+            }}
+          />
+          {agentSessions.length === 0 ? (
+            <View className="py-8 items-center">
+              <Text className="text-slate-400">No previous sessions.</Text>
+            </View>
+          ) : (
+            <FlatList
+              data={agentSessions}
+              keyExtractor={(item) => item[0]}
+              renderItem={({ item }) => (
+                <SessionItem
+                  conversationId={item[0]}
+                  session={item[1]}
+                  isActive={item[0] === currentConversationId}
+                  onSelect={(id) => {
+                    onSelect(id);
+                    onClose();
+                  }}
+                />
+              )}
+              contentContainerStyle={{ paddingBottom: 24 }}
+            />
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
 export function ChatScreen({
   agentId: routeAgentId,
   conversationId,
 }: {
-  agentId?: string;
+  agentId?: string | null;
   conversationId?: string;
 }) {
   const router = useRouter();
@@ -128,9 +264,6 @@ export function ChatScreen({
     [agents, activeAgentId],
   );
   const ensureSession = useChatStore((state) => state.ensureSession);
-  const generateConversationId = useChatStore(
-    (state) => state.generateConversationId,
-  );
   const sendMessage = useChatStore((state) => state.sendMessage);
   const clearPendingInterrupt = useChatStore(
     (state) => state.clearPendingInterrupt,
@@ -159,6 +292,7 @@ export function ChatScreen({
   );
   const [showDetails, setShowDetails] = useState(false);
   const [showShortcutManager, setShowShortcutManager] = useState(false);
+  const [showSessionPicker, setShowSessionPicker] = useState(false);
   const [shortcutManagerMode, setShortcutManagerMode] = useState<
     "list" | "create" | "edit"
   >("list");
@@ -712,6 +846,14 @@ export function ChatScreen({
   const openShortcutManager = () => {
     setShortcutManagerMode("list");
     setShowShortcutManager(true);
+  };
+
+  const openSessionPicker = () => {
+    setShowSessionPicker(true);
+  };
+
+  const closeSessionPicker = () => {
+    setShowSessionPicker(false);
   };
 
   const closeShortcutManager = () => {
@@ -1367,16 +1509,12 @@ export function ChatScreen({
             <BackButton />
             <Pressable
               className="h-10 w-10 items-center justify-center rounded-full bg-primary"
-              onPress={() => {
-                const nextConversationId = generateConversationId();
-                blurActiveElement();
-                router.replace(buildChatRoute(agent.id, nextConversationId));
-              }}
+              onPress={openSessionPicker}
               accessibilityRole="button"
-              accessibilityLabel="Start new session"
-              accessibilityHint="Clear the current chat session"
+              accessibilityLabel="Show sessions"
+              accessibilityHint="View and switch chat sessions"
             >
-              <Ionicons name="add" size={20} color="#ffffff" />
+              <Ionicons name="list" size={20} color="#ffffff" />
             </Pressable>
             <Pressable
               className={`h-10 w-10 items-center justify-center rounded-full border border-slate-700 ${
@@ -1759,6 +1897,17 @@ export function ChatScreen({
             </View>
           </View>
         </Modal>
+
+        <SessionPickerModal
+          visible={showSessionPicker}
+          onClose={closeSessionPicker}
+          agentId={activeAgentId}
+          currentConversationId={conversationId}
+          onSelect={(nextConversationId) => {
+            blurActiveElement();
+            router.replace(buildChatRoute(agent.id, nextConversationId));
+          }}
+        />
 
         <View className="flex-row items-end gap-2 bg-slate-900/50 p-2 rounded-3xl border border-slate-800">
           <Pressable

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -108,6 +108,7 @@ const mockChatState: {
   sendMessage: jest.Mock;
   clearPendingInterrupt: jest.Mock;
   bindExternalSession: jest.Mock;
+  getSessionsByAgentId: jest.Mock;
 } = {
   sessions: {},
   ensureSession: jest.fn(),
@@ -115,6 +116,7 @@ const mockChatState: {
   sendMessage: jest.fn(),
   clearPendingInterrupt: jest.fn(),
   bindExternalSession: jest.fn(),
+  getSessionsByAgentId: jest.fn(() => []),
 };
 
 const mockMessageState: {


### PR DESCRIPTION
## 背景
当前用户在与特定 Agent 交互时，往往需要查看与该 Agent 相关的历史会话，并在不同会话间快速切换。目前缺乏在会话界面直接访问该 Agent 专属会话列表的便捷入口。

Closes #127

## 目标与实现
### 弹窗设计与切换功能 (ChatScreen.tsx)
- 在会话界面的 header 右侧，将原来的新建按钮更换为列表按钮（`list` 图标）。点击可展开会话选择器（Modal）。
- 提取并新增了 `SessionPickerModal` 和 `SessionItem` 组件，用于在会话列表中展示当前 Agent 的所有历史会话。
- 支持点击列表项快速切换至对应会话，内部利用原有的 React Router `replace` 加载历史消息。

### 新建功能 (ChatScreen.tsx)
- 在 `SessionPickerModal` 的顶部提供显著的 `New Session` 按钮，保留原有的快捷新建体验。

### 数据同步 (ChatScreen.tsx & ChatScreen.interrupt.test.tsx)
- 直接利用 `useChatStore` 中的 `getSessionsByAgentId` 方法过滤并获取当前 Agent 的会话列表。
- 修复了 `ChatScreen.interrupt.test.tsx` 中的 mock 状态，确保测试环境包含 `getSessionsByAgentId` 从而通过测试。
- 约定：本次迭代为 MVP 重点，暂未支持搜索或复杂的会话管理操作。

## 验收证据
- 所有组件都经过了 TypeScript 强类型校验 (`npm run check-types` passed)。
- 前端测试全部通过 (`npm test` passed)。
- Linter 没有暴露错误 (`npm run lint` passed)。