### PR TITLE
fix(invoke): propagate a2a invoke payload serialization exceptions (#236)

### DIFF
--- a/backend/app/services/a2a_invoke_service.py
+++ b/backend/app/services/a2a_invoke_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import logging
 import re
 import time
 from contextlib import suppress
@@ -25,6 +26,8 @@ from app.utils.payload_extract import (
     extract_context_id,
     extract_provider_and_external_session_id,
 )
+
+logger = logging.getLogger(__name__)
 
 StreamEvent = ClientEvent | Message
 ValidateMessageFn = Callable[[dict[str, Any]], list[Any]]
@@ -398,8 +401,9 @@ class A2AInvokeService:
         if hasattr(resolved_payload, "model_dump"):
             try:
                 dumped = resolved_payload.model_dump(exclude_none=True)
-            except Exception:
-                return {}
+            except Exception as exc:
+                logger.error("Failed to dump A2A payload", exc_info=True)
+                raise ValueError("Payload serialization failed") from exc
             if isinstance(dumped, dict):
                 return dumped
         return {}

--- a/backend/tests/test_a2a_invoke_service.py
+++ b/backend/tests/test_a2a_invoke_service.py
@@ -1011,3 +1011,16 @@ def test_extract_usage_hints_from_invoke_result_prefers_raw_payload():
         "total_tokens": 77,
         "cost": 0.0077,
     }
+
+
+def test_coerce_payload_to_dict_raises_exception(caplog):
+    class MockUnserializablePayload:
+        def model_dump(self, exclude_none=True):
+            raise ValueError("Cannot serialize this mock payload")
+
+    payload = MockUnserializablePayload()
+    with pytest.raises(ValueError, match="Payload serialization failed"):
+        with caplog.at_level(logging.ERROR):
+            a2a_invoke_service._coerce_payload_to_dict(payload)
+
+    assert "Failed to dump A2A payload" in caplog.text


### PR DESCRIPTION
## Description

Closes #236

This PR fixes the issue where A2A invoke payload serialization errors were silently swallowed by returning an empty dict. It introduces explicit error logging and raises a `ValueError` with the underlying exception, so the calling code can properly handle and surface serialization failures.

### Changes:
- Added `logger.error` to capture the stack trace when `model_dump()` fails.
- Replaced the silent `return {}` with `raise ValueError("Payload serialization failed") from exc`.
- Added a unit test `test_coerce_payload_to_dict_raises_exception` to verify that serialization errors are propagated and logged.

## Verification Evidence

**Pre-commit checks passed**:
```text
black....................................................................Passed
isort....................................................................Passed
autoflake................................................................Passed
ruff.....................................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
```

**Unit tests passed**:
```text
$ cd backend && UV_CACHE_DIR=/tmp/uv_cache uv run pytest tests/test_a2a_invoke_service.py
................................                                         [100%]
32 passed in 0.96s
```
