### PR TITLE
fix: job editing while running (#228)

### DIFF
--- a/backend/app/api/routers/a2a_schedules.py
+++ b/backend/app/api/routers/a2a_schedules.py
@@ -21,6 +21,7 @@ from app.schemas.a2a_schedule import (
     A2AScheduleToggleResponse,
 )
 from app.services.a2a_schedule_service import (
+    A2AScheduleConflictError,
     A2AScheduleNotFoundError,
     A2AScheduleQuotaError,
     A2AScheduleValidationError,
@@ -130,6 +131,10 @@ async def patch_schedule_task(
     except A2AScheduleQuotaError as exc:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)
+        ) from exc
+    except A2AScheduleConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
         ) from exc
     except A2AScheduleNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc

--- a/backend/app/services/a2a_schedule_service.py
+++ b/backend/app/services/a2a_schedule_service.py
@@ -38,6 +38,10 @@ class A2AScheduleQuotaError(A2AScheduleError):
     """Raised when a schedule task operation exceeds user quotas."""
 
 
+class A2AScheduleConflictError(A2AScheduleError):
+    """Raised when a schedule task operation is in conflict with its current state."""
+
+
 @dataclass(frozen=True)
 class ClaimedA2AScheduleTask:
     """Snapshot describing a due task claimed by the scheduler."""
@@ -177,6 +181,11 @@ class A2AScheduleService:
         enabled: Optional[bool] = None,
     ) -> A2AScheduleTask:
         task = await self._get_task(db, user_id=user_id, task_id=task_id)
+
+        if task.last_run_status == A2AScheduleTask.STATUS_RUNNING:
+            raise A2AScheduleConflictError(
+                "Task is currently running and cannot be edited."
+            )
 
         if enabled is True and not task.enabled:
             await self._ensure_active_quota(

--- a/frontend/components/scheduled/ScheduledJobForm.tsx
+++ b/frontend/components/scheduled/ScheduledJobForm.tsx
@@ -27,6 +27,7 @@ type ScheduledJobFormProps = {
   onCancel: () => void;
   showTitle?: boolean;
   timeZone?: string;
+  lastRunStatus?: string | null;
 };
 
 export function ScheduledJobForm({
@@ -39,6 +40,7 @@ export function ScheduledJobForm({
   onCancel,
   showTitle = true,
   timeZone,
+  lastRunStatus,
 }: ScheduledJobFormProps) {
   const intervalStartAt = (() => {
     const startAt = (form.time_point as { start_at?: unknown })?.start_at;
@@ -116,8 +118,19 @@ export function ScheduledJobForm({
     };
   };
 
+  const isCurrentlyRunning = lastRunStatus === "running";
+
   return (
     <View className="mb-4 rounded-3xl border border-slate-800 bg-slate-900/40 p-4">
+      {isCurrentlyRunning && (
+        <View className="mb-4 rounded-lg bg-yellow-500/10 p-3 border border-yellow-500/20">
+          <Text className="text-sm font-medium text-yellow-500">
+            Cannot edit a job while it is currently running. Please wait for it
+            to finish or disable it first.
+          </Text>
+        </View>
+      )}
+
       {showTitle ? (
         <Text className="text-sm font-semibold text-white">
           {editing ? "Edit Job" : "Create Job"}
@@ -347,6 +360,7 @@ export function ScheduledJobForm({
           label={editing ? "Save" : "Create"}
           size="sm"
           loading={saving}
+          disabled={isCurrentlyRunning}
           onPress={onSubmit}
         />
       </View>

--- a/frontend/screens/ScheduledJobFormScreen.tsx
+++ b/frontend/screens/ScheduledJobFormScreen.tsx
@@ -131,6 +131,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
   const [saving, setSaving] = useState(false);
   const [loadingJob, setLoadingJob] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [lastRunStatus, setLastRunStatus] = useState<string | null>(null);
 
   const initialSnapshotRef = useRef<Snapshot | null>(null);
 
@@ -161,6 +162,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
           enabled: found.enabled,
         };
         setForm(next);
+        setLastRunStatus(found.last_run_status ?? null);
         initialSnapshotRef.current = buildSnapshot(next);
       })
       .catch((error) => {
@@ -343,8 +345,15 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
       });
       goBackOrHome();
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Save failed.";
-      toast.error("Save failed", message);
+      if (error instanceof ApiRequestError && error.status === 409) {
+        toast.error(
+          "Save failed",
+          "Task is currently running and cannot be edited. Please wait.",
+        );
+      } else {
+        const message = error instanceof Error ? error.message : "Save failed.";
+        toast.error("Save failed", message);
+      }
     } finally {
       setSaving(false);
     }
@@ -377,6 +386,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
             editing={editing}
             agentOptions={agentOptions}
             timeZone={userTimeZone}
+            lastRunStatus={lastRunStatus}
             onChange={(patch) => setForm((prev) => ({ ...prev, ...patch }))}
             onSubmit={handleSubmit}
             onCancel={handleCancel}


### PR DESCRIPTION
## Description

Fixes #228.

Implemented restrictions when trying to edit a scheduled job that is currently in the `running` state to prevent concurrent modifications and race conditions.

**Backend**:
- Added `A2AScheduleConflictError` to be thrown when attempting to update a running task.
- Mapped this error to `HTTP 409 Conflict` in the router endpoints.

**Frontend**:
- UI: Disabled the 'Save' button when a job's `last_run_status` is `running`.
- UI: Added a clear yellow warning message instructing users to wait for the job to finish.
- Logic: Added explicit `409` catch logic to gracefully show a toast message if the job starts running while the form is open and the user clicks Save.
