### PR TITLE
fix(a2a): add stringent URL validation and internal IP blacklisting (#240)

### DIFF
--- a/backend/alembic/versions/20260222_1600_1a2b3c4d5e6f_add_agent_id_to_shortcut.py
+++ b/backend/alembic/versions/20260222_1600_1a2b3c4d5e6f_add_agent_id_to_shortcut.py
@@ -5,6 +5,7 @@ Revises: 0f2a8b8f5e11
 Create Date: 2026-02-22 16:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/backend/app/api/routers/a2a_agents.py
+++ b/backend/app/api/routers/a2a_agents.py
@@ -79,9 +79,9 @@ def _build_response(record: A2AAgentRecord) -> A2AAgentResponse:
     return A2AAgentResponse.model_validate(payload)
 
 
-def _normalize_card_url(value: str) -> str:
+def _normalize_card_url(value: Any) -> str:
     return normalize_card_url(
-        value,
+        str(value),
         allowed_hosts=settings.a2a_proxy_allowed_hosts,
     )
 

--- a/backend/app/api/routers/shortcuts.py
+++ b/backend/app/api/routers/shortcuts.py
@@ -65,8 +65,9 @@ def _list_shortcuts_error(
 
 @router.get("", response_model=ShortcutListResponse)
 async def list_shortcuts(
-    agent_id: UUID
-    | None = Query(None, description="Optional agent ID to filter shortcuts"),
+    agent_id: UUID | None = Query(
+        None, description="Optional agent ID to filter shortcuts"
+    ),
     db: AsyncSession = Depends(get_async_db),
     current_user: User = Depends(get_current_user),
 ) -> ShortcutListResponse:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -421,7 +421,7 @@ class Settings(BaseSettings):
             if baseline_errors:
                 joined_errors = "; ".join(baseline_errors)
                 raise ValueError(
-                    "Production security baseline checks failed: " f"{joined_errors}"
+                    f"Production security baseline checks failed: {joined_errors}"
                 )
         return self
 

--- a/backend/app/schemas/a2a_agent.py
+++ b/backend/app/schemas/a2a_agent.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Dict, List, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field
 
 from app.schemas.pagination import ListResponse, Pagination
 
@@ -15,7 +15,7 @@ A2AAuthType = Literal["none", "bearer"]
 
 class A2AAgentBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
-    card_url: str = Field(..., min_length=4, max_length=1024)
+    card_url: AnyHttpUrl = Field(..., description="Must be a valid HTTP/HTTPS URL")
     auth_type: A2AAuthType = Field(default="none")
     auth_header: Optional[str] = Field(default=None)
     auth_scheme: Optional[str] = Field(default=None)
@@ -34,7 +34,9 @@ class A2AAgentCreate(A2AAgentBase):
 
 class A2AAgentUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=120)
-    card_url: Optional[str] = Field(default=None, min_length=4, max_length=1024)
+    card_url: Optional[AnyHttpUrl] = Field(
+        default=None, description="Must be a valid HTTP/HTTPS URL"
+    )
     auth_type: Optional[A2AAuthType] = None
     auth_header: Optional[str] = None
     auth_scheme: Optional[str] = None

--- a/backend/app/schemas/a2a_agent_card.py
+++ b/backend/app/schemas/a2a_agent_card.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import AnyHttpUrl, BaseModel, Field
 
 from app.schemas.a2a_agent import A2AAuthType
 
 
 class A2AAgentCardProxyRequest(BaseModel):
-    card_url: str = Field(..., min_length=4, max_length=1024)
+    card_url: AnyHttpUrl = Field(..., description="Must be a valid HTTP/HTTPS URL")
     auth_type: A2AAuthType = Field(default="none")
     auth_header: Optional[str] = Field(default=None)
     auth_scheme: Optional[str] = Field(default=None)

--- a/backend/app/services/a2a_invoke_service.py
+++ b/backend/app/services/a2a_invoke_service.py
@@ -683,9 +683,9 @@ class A2AInvokeService:
                 and last.get("is_finished") is False
             ):
                 current = last.get("content")
-                last[
-                    "content"
-                ] = f"{current if isinstance(current, str) else ''}{delta}"
+                last["content"] = (
+                    f"{current if isinstance(current, str) else ''}{delta}"
+                )
                 last["is_finished"] = done
                 return
 

--- a/backend/app/services/agent_common.py
+++ b/backend/app/services/agent_common.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ipaddress
 from typing import Any, Optional, Type
+from urllib.parse import urlparse
 
 from app.core.secret_vault import SecretVaultNotConfiguredError
 from app.utils.auth_headers import resolve_stored_auth_fields
@@ -93,11 +95,37 @@ class AgentValidationMixin:
         )
 
     def _normalize_card_url(self, value: str) -> str:
-        return normalize_required_text(
+        trimmed = normalize_required_text(
             value=value,
             field_label="Card URL",
             validation_error_cls=self._validation_error_cls,
         )
+        parsed = urlparse(trimmed)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise self._validation_error_cls("Card URL must be a valid http(s) address")
+
+        host = parsed.hostname or ""
+        if host == "localhost" or host.endswith(".localhost"):
+            raise self._validation_error_cls("Card URL host is not allowed")
+
+        try:
+            ip_value = ipaddress.ip_address(host)
+        except ValueError:
+            ip_value = None
+
+        if ip_value and (
+            ip_value.is_private
+            or ip_value.is_loopback
+            or ip_value.is_link_local
+            or ip_value.is_multicast
+            or ip_value.is_reserved
+            or ip_value.is_unspecified
+        ):
+            raise self._validation_error_cls(
+                "Card URL points to a private or reserved IP address"
+            )
+
+        return trimmed
 
     def _normalize_auth_type(self, value: str) -> str:
         return normalize_auth_type(

--- a/backend/tests/test_a2a_agent_validation.py
+++ b/backend/tests/test_a2a_agent_validation.py
@@ -1,0 +1,53 @@
+from typing import Type
+
+import pytest
+
+from app.services.agent_common import AgentValidationMixin
+
+
+class DummyValidationException(Exception):
+    pass
+
+
+class DummyAgentService(AgentValidationMixin):
+    _validation_error_cls: Type[Exception] = DummyValidationException
+    _allowed_auth_types = {"none", "bearer"}
+
+
+@pytest.fixture
+def agent_service() -> DummyAgentService:
+    return DummyAgentService()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost",
+        "http://localhost:8000/",
+        "http://127.0.0.1/abc",
+        "http://192.168.1.1",
+        "http://169.254.169.254",
+        "http://10.0.0.1",
+    ],
+)
+def test_normalize_card_url_blocks_internal_ips(
+    agent_service: DummyAgentService, url: str
+) -> None:
+    with pytest.raises(DummyValidationException) as exc:
+        agent_service._normalize_card_url(url)
+    assert "not allowed" in str(exc.value) or "private or reserved" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/card",
+        "http://some-public-domain.org",
+        "https://1.1.1.1",
+    ],
+)
+def test_normalize_card_url_allows_public_ips(
+    agent_service: DummyAgentService, url: str
+) -> None:
+    normalized = agent_service._normalize_card_url(url)
+    assert normalized == url

--- a/backend/tests/test_a2a_client.py
+++ b/backend/tests/test_a2a_client.py
@@ -12,7 +12,9 @@ from app.integrations.a2a_client.client import A2AClient, ClientCacheEntry
 
 
 @pytest.mark.asyncio
-async def test_a2a_client_close_does_not_close_shared_transport_when_http_client_is_owned() -> None:
+async def test_a2a_client_close_does_not_close_shared_transport_when_http_client_is_owned() -> (
+    None
+):
     a2a_client = A2AClient("http://example-agent.internal:24020")
     close_mock = AsyncMock()
     a2a_client._agent_card = Mock()

--- a/backend/tests/test_invoke_route_runner.py
+++ b/backend/tests/test_invoke_route_runner.py
@@ -53,7 +53,9 @@ async def test_close_open_transaction_commits_read_only_session() -> None:
 
 
 @pytest.mark.asyncio
-async def test_close_open_transaction_does_not_commit_when_session_has_pending_writes() -> None:
+async def test_close_open_transaction_does_not_commit_when_session_has_pending_writes() -> (
+    None
+):
     class _DirtySession:
         def __init__(self) -> None:
             self.committed = 0


### PR DESCRIPTION
## 💡 Issue Linked

Fixes #240 

## 📝 Implementation Details

- **Pydantic Validation**: Updated `A2AAgentBase` and `A2AAgentCardProxyRequest` to use `AnyHttpUrl` rather than `str` to enforce valid HTTP/HTTPS formatting on the schema level.
- **Service-level SSRF Protection**: In `AgentValidationMixin._normalize_card_url` (which is called consistently during Agent Creation/Update by both personal and hub agents), introduced strict IP validation:
  - Validates `http` or `https` schemes.
  - Blocks `localhost` or `*.localhost`.
  - Blocks IP resolutions that fall under `is_private`, `is_loopback`, `is_link_local`, `is_multicast`, `is_reserved`, or `is_unspecified` ranges.
- **Verification Evidence**: Tested via new robust tests in `backend/tests/test_a2a_agent_validation.py` passing seamlessly. Pre-commit hooks (`ruff`, `isort`, `black`) all executed properly.
