### PR TITLE
 feat(schedule): support conversation policy (#225)

### DIFF
--- a/backend/alembic/versions/20260223_1200_5a1b2c3d4e5f_add_conversation_policy.py
+++ b/backend/alembic/versions/20260223_1200_5a1b2c3d4e5f_add_conversation_policy.py
@@ -1,0 +1,41 @@
+"""add conversation_policy
+
+Revision ID: 5a1b2c3d4e5f
+Revises: 4f8c9d2e7a11
+Create Date: 2026-02-23 12:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from app.db.models.base import SCHEMA_NAME
+
+
+# revision identifiers, used by Alembic.
+revision: str = "5a1b2c3d4e5f"
+down_revision: Union[str, None] = "4f8c9d2e7a11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "a2a_schedule_tasks",
+        sa.Column(
+            "conversation_policy",
+            sa.String(length=32),
+            nullable=False,
+            server_default="new_each_run",
+            comment="Session policy: new_each_run / reuse_single",
+        ),
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("a2a_schedule_tasks", "conversation_policy", schema=SCHEMA_NAME)

--- a/backend/app/db/models/a2a_schedule_task.py
+++ b/backend/app/db/models/a2a_schedule_task.py
@@ -44,6 +44,9 @@ class A2AScheduleTask(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
     STATUS_SUCCESS: ClassVar[str] = "success"
     STATUS_FAILED: ClassVar[str] = "failed"
 
+    POLICY_NEW: ClassVar[str] = "new_each_run"
+    POLICY_REUSE: ClassVar[str] = "reuse_single"
+
     CYCLE_DAILY: ClassVar[str] = "daily"
     CYCLE_WEEKLY: ClassVar[str] = "weekly"
     CYCLE_MONTHLY: ClassVar[str] = "monthly"
@@ -67,6 +70,13 @@ class A2AScheduleTask(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
         nullable=True,
         index=True,
         comment="Scheduled conversation thread used to store recurring messages",
+    )
+    conversation_policy = Column(
+        String(32),
+        nullable=False,
+        default=POLICY_NEW,
+        server_default=POLICY_NEW,
+        comment="Session policy: new_each_run / reuse_single",
     )
     prompt = Column(
         Text,

--- a/backend/app/schemas/a2a_schedule.py
+++ b/backend/app/schemas/a2a_schedule.py
@@ -13,6 +13,7 @@ from app.schemas.pagination import ListResponse, Pagination
 A2AScheduleCycleType = Literal["daily", "weekly", "monthly", "interval"]
 A2AScheduleRunStatus = Literal["idle", "running", "success", "failed"]
 A2AScheduleExecutionStatus = Literal["running", "success", "failed"]
+A2AScheduleConversationPolicy = Literal["new_each_run", "reuse_single"]
 
 
 class A2AScheduleTaskBase(BaseModel):
@@ -34,6 +35,7 @@ class A2AScheduleTaskBase(BaseModel):
 
 class A2AScheduleTaskCreate(A2AScheduleTaskBase):
     enabled: bool = True
+    conversation_policy: A2AScheduleConversationPolicy = "new_each_run"
 
 
 class A2AScheduleTaskUpdate(BaseModel):
@@ -43,11 +45,13 @@ class A2AScheduleTaskUpdate(BaseModel):
     cycle_type: Optional[A2AScheduleCycleType] = None
     time_point: Optional[Dict[str, Any]] = None
     enabled: Optional[bool] = None
+    conversation_policy: Optional[A2AScheduleConversationPolicy] = None
 
 
 class A2AScheduleTaskResponse(A2AScheduleTaskBase):
     id: UUID
     conversation_id: Optional[UUID] = None
+    conversation_policy: A2AScheduleConversationPolicy
     enabled: bool
     next_run_at: Optional[datetime] = None
     last_run_at: Optional[datetime] = None
@@ -119,6 +123,7 @@ class A2AScheduleManualFailRequest(BaseModel):
 
 
 __all__ = [
+    "A2AScheduleConversationPolicy",
     "A2AScheduleCycleType",
     "A2AScheduleExecutionListMeta",
     "A2AScheduleExecutionListResponse",

--- a/backend/app/services/a2a_schedule_job.py
+++ b/backend/app/services/a2a_schedule_job.py
@@ -57,6 +57,15 @@ def _execution_metadata(
 
 async def _ensure_task_session(*, db, task: A2AScheduleTask) -> ConversationThread:
     now = utc_now()
+    
+    # Check conversation_policy
+    if task.conversation_policy == A2AScheduleTask.POLICY_REUSE and task.conversation_id:
+        stmt = select(ConversationThread).where(ConversationThread.id == task.conversation_id)
+        existing_thread = await db.scalar(stmt)
+        if existing_thread and existing_thread.status != ConversationThread.STATUS_ARCHIVED:
+            existing_thread.last_active_at = now
+            return existing_thread
+
     thread = ConversationThread(
         id=uuid4(),
         user_id=task.user_id,

--- a/frontend/components/scheduled/ScheduledJobForm.tsx
+++ b/frontend/components/scheduled/ScheduledJobForm.tsx
@@ -325,6 +325,35 @@ export function ScheduledJobForm({
         </>
       )}
 
+      <Text className="mt-3 text-xs text-muted">Session Policy</Text>
+      <View className="mt-1 flex-row flex-wrap gap-2">
+        {(
+          [
+            { value: "new_each_run", label: "New Each Run" },
+            { value: "reuse_single", label: "Reuse Single Session" },
+          ] as const
+        ).map((option) => {
+          const selected = form.conversation_policy === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              className={`rounded-lg border px-2 py-1 ${
+                selected
+                  ? "border-primary bg-primary/20"
+                  : "border-slate-700 bg-slate-900"
+              }`}
+              onPress={() => onChange({ conversation_policy: option.value })}
+            >
+              <Text
+                className={`text-xs ${selected ? "text-primary" : "text-slate-300"}`}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
       <Text className="mt-3 text-xs text-muted">Prompt</Text>
       <TextInput
         className="mt-1 min-h-[100px] rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white"

--- a/frontend/components/scheduled/__tests__/ScheduledJobForm.test.tsx
+++ b/frontend/components/scheduled/__tests__/ScheduledJobForm.test.tsx
@@ -14,6 +14,7 @@ describe("ScheduledJobForm", () => {
       minutes: 10,
     },
     enabled: true,
+    conversation_policy: "new_each_run",
   };
 
   it("preserves typed characters while editing start datetime input", () => {

--- a/frontend/lib/api/scheduledJobs.ts
+++ b/frontend/lib/api/scheduledJobs.ts
@@ -24,6 +24,7 @@ export type ScheduledJob = {
   cycle_type: ScheduleCycleType;
   time_point: ScheduleTimePoint | Record<string, unknown>;
   enabled: boolean;
+  conversation_policy: "new_each_run" | "reuse_single";
   conversation_id?: string | null;
   next_run_at?: string | null;
   last_run_at?: string | null;
@@ -54,6 +55,7 @@ export type ScheduledJobPayload = {
   cycle_type: ScheduleCycleType;
   time_point: ScheduleTimePoint;
   enabled: boolean;
+  conversation_policy: "new_each_run" | "reuse_single";
 };
 
 export type MarkScheduledJobFailedPayload = {

--- a/frontend/screens/ScheduledJobFormScreen.tsx
+++ b/frontend/screens/ScheduledJobFormScreen.tsx
@@ -33,6 +33,7 @@ const initialForm: ScheduledJobPayload = {
   cycle_type: "daily",
   time_point: { time: "07:00" },
   enabled: true,
+  conversation_policy: "new_each_run",
 };
 
 const isValidHHMM = (value: string) => {
@@ -96,6 +97,7 @@ type Snapshot = {
   cycle_type: ScheduleCycleType;
   time_point: unknown;
   enabled: boolean;
+  conversation_policy: "new_each_run" | "reuse_single";
 };
 
 const buildSnapshot = (form: ScheduledJobPayload): Snapshot => ({
@@ -105,6 +107,7 @@ const buildSnapshot = (form: ScheduledJobPayload): Snapshot => ({
   cycle_type: form.cycle_type,
   time_point: normalizeTimePoint(form.cycle_type, form.time_point),
   enabled: form.enabled,
+  conversation_policy: form.conversation_policy,
 });
 
 export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
@@ -159,6 +162,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
           cycle_type: found.cycle_type,
           time_point: normalizeTimePoint(found.cycle_type, found.time_point),
           enabled: found.enabled,
+          conversation_policy: found.conversation_policy || "new_each_run",
         };
         setForm(next);
         initialSnapshotRef.current = buildSnapshot(next);

--- a/frontend/screens/__tests__/ScheduledJobFormScreen.test.tsx
+++ b/frontend/screens/__tests__/ScheduledJobFormScreen.test.tsx
@@ -201,6 +201,7 @@ describe("ScheduledJobFormScreen", () => {
       cycle_type: "daily",
       time_point: { time: "07:00" },
       enabled: true,
+      conversation_policy: "new_each_run",
     });
     expect(mockAllowNextNavigation).toHaveBeenCalledTimes(1);
   });
@@ -267,6 +268,7 @@ describe("ScheduledJobFormScreen", () => {
         start_at: expectedStartAt,
       },
       enabled: true,
+      conversation_policy: "new_each_run",
     });
     expect(capturedTimeZone).toBe("Asia/Shanghai");
   });


### PR DESCRIPTION
## Description
Closes #225

支持定时任务会话策略：
- 后端增加 `conversation_policy` 字段并支持 `new_each_run` 和 `reuse_single` 两种策略
- 后端在分配会话时根据策略重用关联会话或新建
- 前端添加 UI 支持并在 API Payload 中包含策略配置

## Verification
- 添加了对应的数据模型与 Alembic Migration 脚本
- 完善了 API schema 类型，前端增加了表单选项
- 已补充并跑通前端单测
