### PR TITLE
feat(frontend): add prompt expansion and interval details to scheduled job card (#249)

### DIFF
--- a/frontend/components/scheduled/ScheduledJobCard.tsx
+++ b/frontend/components/scheduled/ScheduledJobCard.tsx
@@ -5,6 +5,7 @@ import { Pressable, Switch, Text, View } from "react-native";
 
 import { Button } from "@/components/ui/Button";
 import {
+  type IntervalTimePoint,
   type ScheduledJob,
   type ScheduledJobExecution,
 } from "@/lib/api/scheduledJobs";
@@ -87,8 +88,14 @@ export function ScheduledJobCard({
   const tone = getCardTone(job);
   const historyLabel = executionsOpen ? "Hide" : "History";
   const historyIcon = executionsOpen ? "time" : "time-outline";
+  const intervalTimePoint =
+    job.cycle_type === "interval" &&
+    typeof (job.time_point as IntervalTimePoint)?.minutes === "number"
+      ? (job.time_point as IntervalTimePoint)
+      : null;
   const [togglingEnabled, setTogglingEnabled] = useState(false);
   const [markingFailed, setMarkingFailed] = useState(false);
+  const [promptExpanded, setPromptExpanded] = useState(false);
   const canMarkFailed = job.last_run_status === "running";
 
   const openExecutionSession = (execution: ScheduledJobExecution) => {
@@ -141,6 +148,12 @@ export function ScheduledJobCard({
             <Text className={`mt-1 text-xs ${tone.text}`}>
               {job.cycle_type}
             </Text>
+            {intervalTimePoint ? (
+              <Text className={`mt-1 text-xs ${tone.text}`}>
+                Interval: every {intervalTimePoint.minutes} min, start{" "}
+                {formatLocalDateTime(intervalTimePoint.start_at)}
+              </Text>
+            ) : null}
             <Text className={`mt-1 text-xs ${tone.text}`}>
               Next: {formatLocalDateTime(job.next_run_at)}
             </Text>
@@ -174,9 +187,24 @@ export function ScheduledJobCard({
           </View>
         </View>
 
-        <Text className={`mt-3 text-xs ${tone.prompt}`} numberOfLines={2}>
+        <Text
+          className={`mt-3 text-xs ${tone.prompt}`}
+          numberOfLines={promptExpanded ? undefined : 2}
+        >
           {job.prompt}
         </Text>
+        <View className="mt-1 items-end">
+          <Pressable
+            className="rounded px-1 py-1 active:bg-slate-800/30"
+            onPress={() => setPromptExpanded((value) => !value)}
+            accessibilityRole="button"
+            accessibilityLabel="Toggle prompt expansion"
+          >
+            <Text className={`text-xs font-medium ${tone.text}`}>
+              {promptExpanded ? "Show less" : "Read more"}
+            </Text>
+          </Pressable>
+        </View>
       </View>
 
       <View className="flex-row items-center justify-start gap-3 border-t border-slate-800/50 bg-slate-900/50 px-4 py-3">

--- a/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
+++ b/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent, render } from "@testing-library/react-native";
 import { act, create } from "react-test-renderer";
 
 import { ScheduledJobCard } from "@/components/scheduled/ScheduledJobCard";
@@ -129,5 +130,51 @@ describe("ScheduledJobCard visuals", () => {
     });
     const tree = root.toJSON();
     expect(JSON.stringify(tree)).not.toContain("Stop Running");
+  });
+
+  it("toggles prompt expansion with Read more and Show less", () => {
+    const job = {
+      id: "6",
+      name: "Job",
+      enabled: true,
+      prompt:
+        "This is a long scheduled prompt text used to verify expand and collapse behavior in card UI.",
+      cycle_type: "daily" as const,
+      time_point: { time: "09:00" },
+      last_run_status: "success" as const,
+      next_run_at: "2026-02-23T10:00:00Z",
+    };
+    const { getByLabelText, getByText } = render(
+      <ScheduledJobCard {...defaultProps} job={job as any} />,
+    );
+
+    expect(getByText("Read more")).toBeTruthy();
+    expect(getByText(job.prompt).props.numberOfLines).toBe(2);
+
+    fireEvent.press(getByLabelText("Toggle prompt expansion"));
+
+    expect(getByText("Show less")).toBeTruthy();
+    expect(getByText(job.prompt).props.numberOfLines).toBeUndefined();
+  });
+
+  it("shows interval details including minutes and start time", () => {
+    const job = {
+      id: "7",
+      name: "Interval Job",
+      enabled: true,
+      prompt: "Interval prompt",
+      cycle_type: "interval" as const,
+      time_point: {
+        minutes: 15,
+        start_at: "2026-02-23T10:00:00Z",
+      },
+      last_run_status: "success" as const,
+      next_run_at: "2026-02-23T10:00:00Z",
+    };
+    const { getByText } = render(
+      <ScheduledJobCard {...defaultProps} job={job as any} />,
+    );
+
+    expect(getByText(/Interval: every 15 min, start/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## 变更概述
增强 Scheduled Jobs 卡片可读性：支持 prompt 展开/收起，并补充 interval 类型的关键信息展示。

## 模块变更
### `frontend/components/scheduled/ScheduledJobCard.tsx`
- 新增 `promptExpanded` 状态与交互入口：`Read more / Show less`
- `prompt` 文本支持折叠与展开
- interval 任务新增详情展示：`Interval: every {minutes} min, start {start_at}`

### `frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx`
- 新增 prompt 展开/收起行为测试
- 新增 interval 详情渲染测试

## 关联 Issue
- Closes #249

## 回归验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/scheduled/ScheduledJobCard.tsx components/scheduled/__tests__/ScheduledJobCard.test.tsx --maxWorkers=25%`
