### PR TITLE
refactor(frontend): consolidate scheduled jobs cache keys and invalidation (#227)

### DIFF
--- a/frontend/hooks/__tests__/useScheduledJobs.test.ts
+++ b/frontend/hooks/__tests__/useScheduledJobs.test.ts
@@ -7,15 +7,24 @@ import {
   markScheduledJobFailed,
 } from "@/lib/api/scheduledJobs";
 
+const mockInvalidateQueries = jest.fn();
+
 jest.mock("@/lib/api/scheduledJobs", () => ({
   disableScheduledJob: jest.fn(),
   enableScheduledJob: jest.fn(),
   markScheduledJobFailed: jest.fn(),
 }));
 
+jest.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}));
+
 describe("useScheduledJobs", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockInvalidateQueries.mockResolvedValue(undefined);
   });
 
   it("toggles enabled job to disabled", async () => {
@@ -28,6 +37,13 @@ describe("useScheduledJobs", () => {
 
     expect(disableScheduledJob).toHaveBeenCalledWith("job-1");
     expect(enableScheduledJob).not.toHaveBeenCalled();
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenNthCalledWith(1, {
+      queryKey: ["scheduled-jobs", "list"],
+    });
+    expect(mockInvalidateQueries).toHaveBeenNthCalledWith(2, {
+      queryKey: ["scheduled-jobs", "executions", "job-1"],
+    });
   });
 
   it("toggles disabled job to enabled", async () => {
@@ -40,6 +56,13 @@ describe("useScheduledJobs", () => {
 
     expect(enableScheduledJob).toHaveBeenCalledWith("job-2");
     expect(disableScheduledJob).not.toHaveBeenCalled();
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenNthCalledWith(1, {
+      queryKey: ["scheduled-jobs", "list"],
+    });
+    expect(mockInvalidateQueries).toHaveBeenNthCalledWith(2, {
+      queryKey: ["scheduled-jobs", "executions", "job-2"],
+    });
   });
 
   it("marks a job as failed with reason", async () => {
@@ -54,6 +77,13 @@ describe("useScheduledJobs", () => {
 
     expect(markScheduledJobFailed).toHaveBeenCalledWith("job-3", {
       reason: "Manual stop from scheduled jobs UI",
+    });
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
+    expect(mockInvalidateQueries).toHaveBeenNthCalledWith(1, {
+      queryKey: ["scheduled-jobs", "list"],
+    });
+    expect(mockInvalidateQueries).toHaveBeenNthCalledWith(2, {
+      queryKey: ["scheduled-jobs", "executions", "job-3"],
     });
   });
 });

--- a/frontend/hooks/useScheduledJobExecutionsQuery.ts
+++ b/frontend/hooks/useScheduledJobExecutionsQuery.ts
@@ -28,7 +28,7 @@ export function useScheduledJobExecutionsQuery(options: {
   );
 
   return usePaginatedList<ScheduledJobExecution>({
-    queryKey: queryKeys.sessions.scheduledJobExecutions(taskId ?? "missing"),
+    queryKey: queryKeys.schedules.executions(taskId ?? "missing"),
     fetchPage,
     getKey: (item) => item.id,
     errorTitle: "Load executions failed",

--- a/frontend/hooks/useScheduledJobs.ts
+++ b/frontend/hooks/useScheduledJobs.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 import {
@@ -6,21 +7,43 @@ import {
   markScheduledJobFailed,
   type ScheduledJob,
 } from "@/lib/api/scheduledJobs";
+import { queryKeys } from "@/lib/queryKeys";
 
 export function useScheduledJobs() {
-  const toggleJobStatus = useCallback(async (job: ScheduledJob) => {
-    if (job.enabled) {
-      await disableScheduledJob(job.id);
-      return;
-    }
-    await enableScheduledJob(job.id);
-  }, []);
+  const queryClient = useQueryClient();
+
+  const toggleJobStatus = useCallback(
+    async (job: ScheduledJob) => {
+      if (job.enabled) {
+        await disableScheduledJob(job.id);
+      } else {
+        await enableScheduledJob(job.id);
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.schedules.listRoot(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.schedules.executionsRoot(job.id),
+        }),
+      ]);
+    },
+    [queryClient],
+  );
 
   const markJobFailed = useCallback(
     async (job: ScheduledJob, reason?: string) => {
       await markScheduledJobFailed(job.id, { reason });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.schedules.listRoot(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.schedules.executionsRoot(job.id),
+        }),
+      ]);
     },
-    [],
+    [queryClient],
   );
 
   return {

--- a/frontend/hooks/useScheduledJobsQuery.ts
+++ b/frontend/hooks/useScheduledJobsQuery.ts
@@ -24,7 +24,7 @@ export function useScheduledJobsQuery(options?: { enabled?: boolean }) {
   }, []);
 
   return usePaginatedList<ScheduledJob>({
-    queryKey: queryKeys.sessions.scheduledJobs(),
+    queryKey: queryKeys.schedules.list(),
     fetchPage,
     getKey: (item) => item.id,
     errorTitle: "Load jobs failed",

--- a/frontend/lib/queryKeys.ts
+++ b/frontend/lib/queryKeys.ts
@@ -3,6 +3,26 @@ export const queryKeys = {
   agents: {
     catalog: () => ["agents", "catalog"] as const,
   },
+  schedules: {
+    listRoot: () => ["scheduled-jobs", "list"] as const,
+    list: (filters?: Record<string, unknown>) =>
+      filters
+        ? (["scheduled-jobs", "list", filters] as const)
+        : (["scheduled-jobs", "list"] as const),
+    executionsRoot: (taskId?: string) =>
+      taskId
+        ? (["scheduled-jobs", "executions", taskId] as const)
+        : (["scheduled-jobs", "executions"] as const),
+    executions: (
+      taskId: string,
+      options?: {
+        page?: number;
+      },
+    ) =>
+      typeof options?.page === "number"
+        ? (["scheduled-jobs", "executions", taskId, options.page] as const)
+        : (["scheduled-jobs", "executions", taskId] as const),
+  },
   sessions: {
     directory: () => ["sessions", "directory"] as const,
     scheduledJobs: () => ["scheduled-jobs", "list"] as const,

--- a/frontend/screens/ScheduledJobFormScreen.tsx
+++ b/frontend/screens/ScheduledJobFormScreen.tsx
@@ -345,7 +345,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
       );
       allowNextNavigation();
       await queryClient.invalidateQueries({
-        queryKey: queryKeys.sessions.scheduledJobs(),
+        queryKey: queryKeys.schedules.listRoot(),
       });
       goBackOrHome();
     } catch (error) {

--- a/frontend/screens/ScheduledJobsScreen.tsx
+++ b/frontend/screens/ScheduledJobsScreen.tsx
@@ -1,6 +1,5 @@
-import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { RefreshControl, ScrollView, Text, View } from "react-native";
 
 import { ScreenContainer } from "@/components/layout/ScreenContainer";
@@ -39,7 +38,7 @@ export function ScheduledJobsScreen() {
     loadingMore,
     loadFirstPage,
     loadMore,
-  } = useScheduledJobsQuery({ enabled: false });
+  } = useScheduledJobsQuery({ enabled: true });
 
   const sortedJobs = useMemo(() => {
     return [...jobs].sort((a, b) => {
@@ -68,27 +67,8 @@ export function ScheduledJobsScreen() {
     enabled: Boolean(expandedExecutionsTaskId),
   });
 
-  const hasLoadedRef = useRef(false);
-  useFocusEffect(
-    useCallback(() => {
-      const mode = hasLoadedRef.current ? "refreshing" : "loading";
-      loadFirstPage(mode)
-        .then((succeeded) => {
-          if (succeeded) {
-            hasLoadedRef.current = true;
-          }
-        })
-        .catch((err) => {
-          console.error("Scheduled jobs load error:", err);
-        });
-    }, [loadFirstPage]),
-  );
-
   const onRefresh = async () => {
-    const succeeded = await loadFirstPage("refreshing");
-    if (succeeded) {
-      hasLoadedRef.current = true;
-    }
+    await loadFirstPage("refreshing");
   };
 
   const toggleExecutionsPanel = (taskId: string) => {
@@ -172,13 +152,6 @@ export function ScheduledJobsScreen() {
                 onToggleEnabled={async () => {
                   try {
                     await toggleJobStatus(job);
-                    const succeeded = await loadFirstPage("refreshing");
-                    if (succeeded) {
-                      hasLoadedRef.current = true;
-                    }
-                    if (expandedExecutionsTaskId === job.id) {
-                      await executionsQuery.loadFirstPage("refreshing");
-                    }
                   } catch (error) {
                     const message =
                       error instanceof Error ? error.message : "Update failed.";
@@ -192,13 +165,6 @@ export function ScheduledJobsScreen() {
                 onMarkFailed={async () => {
                   try {
                     await markJobFailed(job);
-                    const succeeded = await loadFirstPage("refreshing");
-                    if (succeeded) {
-                      hasLoadedRef.current = true;
-                    }
-                    if (expandedExecutionsTaskId === job.id) {
-                      await executionsQuery.loadFirstPage("refreshing");
-                    }
                     toast.success(
                       "Job updated",
                       "Marked running task as failed.",


### PR DESCRIPTION
## 变更概述
收敛 Jobs 页缓存拓扑与失效策略，减少 mutation 后的重复请求路径，统一按资源粒度刷新。

## 模块变更
### `frontend/lib/queryKeys.ts`
- 新增 `queryKeys.schedules`：
  - `listRoot/list`
  - `executionsRoot/executions`

### `frontend/hooks/useScheduledJobsQuery.ts`
- 调整 jobs 列表查询 key 到 `queryKeys.schedules.list()`

### `frontend/hooks/useScheduledJobExecutionsQuery.ts`
- 调整执行历史查询 key 到 `queryKeys.schedules.executions(taskId)`

### `frontend/hooks/useScheduledJobs.ts`
- mutation 成功后按资源粒度失效：
  - `queryKeys.schedules.listRoot()`
  - `queryKeys.schedules.executionsRoot(taskId)`

### `frontend/screens/ScheduledJobsScreen.tsx`
- 去除 mutation 后手动双刷新逻辑
- 由 query 失效驱动数据刷新
- jobs 查询改为启用模式，减少手动 load 路径

### `frontend/screens/ScheduledJobFormScreen.tsx`
- 保存成功后失效 key 对齐到 `queryKeys.schedules.listRoot()`

### `frontend/hooks/__tests__/useScheduledJobs.test.ts`
- 增加对 `invalidateQueries` 调用的断言覆盖

## 关联 Issue
- Closes #227

## 回归验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/useScheduledJobsQuery.ts hooks/useScheduledJobExecutionsQuery.ts hooks/useScheduledJobs.ts lib/queryKeys.ts screens/ScheduledJobsScreen.tsx screens/ScheduledJobFormScreen.tsx hooks/__tests__/useScheduledJobsQuery.test.tsx hooks/__tests__/useScheduledJobExecutionsQuery.test.tsx hooks/__tests__/useScheduledJobs.test.ts screens/__tests__/ScheduledJobsScreen.test.tsx screens/__tests__/ScheduledJobFormScreen.test.tsx --maxWorkers=25%`
