### PR TITLE
perf(backend): add composite timeline indexes for core schedule and session tables (#232)

### DIFF
--- a/backend/alembic/versions/20260224_1900_r202602241900_add_core_timestamp_indexes.py
+++ b/backend/alembic/versions/20260224_1900_r202602241900_add_core_timestamp_indexes.py
@@ -1,0 +1,63 @@
+"""add core timestamp composite indexes
+
+Revision ID: r202602241900
+Revises: 9c7d1e2f3a4b
+Create Date: 2026-02-24 19:00:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from app.db.models.base import SCHEMA_NAME
+
+
+# revision identifiers, used by Alembic.
+revision: str = "r202602241900"
+down_revision: Union[str, None] = "9c7d1e2f3a4b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_agent_messages_conversation_id_created_at",
+        "agent_messages",
+        ["conversation_id", "created_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_conversation_threads_user_id_updated_at",
+        "conversation_threads",
+        ["user_id", "updated_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_a2a_schedule_tasks_user_id_created_at",
+        "a2a_schedule_tasks",
+        ["user_id", "created_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_a2a_schedule_tasks_user_id_created_at",
+        table_name="a2a_schedule_tasks",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_conversation_threads_user_id_updated_at",
+        table_name="conversation_threads",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_agent_messages_conversation_id_created_at",
+        table_name="agent_messages",
+        schema=SCHEMA_NAME,
+    )

--- a/backend/app/db/models/a2a_schedule_task.py
+++ b/backend/app/db/models/a2a_schedule_task.py
@@ -36,6 +36,11 @@ class A2AScheduleTask(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
             "enabled",
             "next_run_at",
         ),
+        Index(
+            "ix_a2a_schedule_tasks_user_id_created_at",
+            "user_id",
+            "created_at",
+        ),
         {"schema": SCHEMA_NAME},
     )
 

--- a/backend/app/db/models/agent_message.py
+++ b/backend/app/db/models/agent_message.py
@@ -13,6 +13,11 @@ class AgentMessage(Base, TimestampMixin, UserOwnedMixin):
     __tablename__ = "agent_messages"
     __table_args__ = (
         Index(
+            "ix_agent_messages_conversation_id_created_at",
+            "conversation_id",
+            "created_at",
+        ),
+        Index(
             "uq_agent_messages_conversation_sender_invoke_idempotency_key",
             "conversation_id",
             "sender",

--- a/backend/app/db/models/conversation_thread.py
+++ b/backend/app/db/models/conversation_thread.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     String,
     Text,
     UniqueConstraint,
@@ -25,6 +26,11 @@ class ConversationThread(Base, TimestampMixin, UserOwnedMixin):
 
     __tablename__ = "conversation_threads"
     __table_args__ = (
+        Index(
+            "ix_conversation_threads_user_id_updated_at",
+            "user_id",
+            "updated_at",
+        ),
         UniqueConstraint(
             "user_id",
             "external_provider",


### PR DESCRIPTION
## 变更概述
为高频分页/排序路径补充联合索引，降低大数据量下的排序与扫描成本。

## 模块变更
### `backend/app/db/models/agent_message.py`
- 新增索引：`ix_agent_messages_conversation_id_created_at (conversation_id, created_at)`

### `backend/app/db/models/conversation_thread.py`
- 新增索引：`ix_conversation_threads_user_id_updated_at (user_id, updated_at)`

### `backend/app/db/models/a2a_schedule_task.py`
- 新增索引：`ix_a2a_schedule_tasks_user_id_created_at (user_id, created_at)`

### `backend/alembic/versions/20260224_1900_r202602241900_add_core_timestamp_indexes.py`
- 新增迁移，创建上述 3 个联合索引（含 downgrade）

说明：issue 文案中的 `thread_id` 与当前模型字段不一致，现模型对应字段为 `conversation_id`，本 PR 按真实字段落地。

## 关联 Issue
- Closes #232
- Related #230

## 回归验证
- `cd backend && uv run pre-commit run --files app/db/models/agent_message.py app/db/models/conversation_thread.py app/db/models/a2a_schedule_task.py alembic/versions/20260224_1900_r202602241900_add_core_timestamp_indexes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_conversation_thread_model.py tests/test_session_hub_service.py tests/test_a2a_schedule_routes.py`
- `cd backend && uv run alembic upgrade head`（本地数据库迁移历史存在旧分支残留：`Can't locate revision identified by '6814c222efe9'`）


> 注：与 #230 同期均包含 Alembic 迁移，最终合并前需确认迁移头（heads）收敛策略。
