### PR TITLE
fix(frontend): align message folding with full message content (#298)

### DIFF
--- a/frontend/components/chat/ChatMessageItem.tsx
+++ b/frontend/components/chat/ChatMessageItem.tsx
@@ -172,154 +172,149 @@ export function ChatMessageItem({
           }`}
         >
           {hasBlocks ? (
-            renderableBlocks.map((block, blockIndex) => {
-              const blockText = block.content;
-              if (blockText.length === 0) return null;
-              const blockId = block.id || `${message.id}:${blockIndex}`;
-              if (block.type === "reasoning") {
-                const expanded = expandedReasoningByBlockId[blockId];
-                return (
-                  <View
-                    key={blockId}
-                    className={`${
-                      blockIndex > 0 ? "mt-3" : ""
-                    } rounded-xl border border-slate-700/70 bg-slate-900/70 px-3 py-2`}
-                  >
-                    <Pressable
-                      onPress={() => toggleReasoning(blockId)}
-                      accessibilityRole="button"
-                      accessibilityLabel={
-                        expanded
-                          ? "Hide reasoning details"
-                          : "Show reasoning details"
-                      }
-                    >
-                      <Text className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
-                        {expanded ? "Hide Reasoning" : "Show Reasoning"}
-                      </Text>
-                    </Pressable>
-                    {expanded ? (
-                      <View>
-                        <Text
-                          selectable
-                          className="mt-1 break-all text-xs text-slate-300"
-                        >
-                          {blockText}
-                        </Text>
-                        {renderBottomCollapseAction(
-                          `chat-message-${blockId}-collapse-bottom`,
-                          () => toggleReasoning(blockId),
-                        )}
-                      </View>
-                    ) : null}
-                  </View>
-                );
-              }
-              if (block.type === "tool_call") {
-                const expanded = expandedToolCallByBlockId[blockId];
-                return (
-                  <View
-                    key={blockId}
-                    className={`${
-                      blockIndex > 0 ? "mt-3" : ""
-                    } rounded-xl border border-slate-700/70 bg-slate-900/70 px-3 py-2`}
-                  >
-                    <Pressable
-                      onPress={() => toggleToolCall(blockId)}
-                      accessibilityRole="button"
-                      accessibilityLabel={
-                        expanded
-                          ? "Hide tool call details"
-                          : "Show tool call details"
-                      }
-                    >
-                      <Text className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
-                        {expanded ? "Hide Tool Call" : "Show Tool Call"}
-                      </Text>
-                    </Pressable>
-                    {expanded ? (
-                      <View>
-                        <Text
-                          selectable
-                          className="mt-1 break-all text-xs text-slate-300"
-                        >
-                          {blockText}
-                        </Text>
-                        {renderBottomCollapseAction(
-                          `chat-message-${blockId}-collapse-bottom`,
-                          () => toggleToolCall(blockId),
-                        )}
-                      </View>
-                    ) : null}
-                  </View>
-                );
-              }
-              if (block.type === "text") {
-                const blockExpanded = expandedTextByBlockId[blockId] ?? false;
-                const shouldCollapse = shouldCollapseByLength(blockText);
-                const topToggleAccessibilityLabel = blockExpanded
-                  ? "Collapse full text"
-                  : "Expand full text";
-                const topToggleLabel = blockExpanded
-                  ? "Show less"
-                  : "Read more";
-
-                return (
-                  <View key={blockId} className="rounded-xl">
-                    <Text
-                      selectable
+            <>
+              {renderableBlocks.map((block, blockIndex) => {
+                const blockText = block.content;
+                if (blockText.length === 0) return null;
+                const blockId = block.id || `${message.id}:${blockIndex}`;
+                if (block.type === "reasoning") {
+                  const expanded = expandedReasoningByBlockId[blockId];
+                  return (
+                    <View
+                      key={blockId}
                       className={`${
                         blockIndex > 0 ? "mt-3" : ""
-                      } break-all text-sm text-white`}
-                      numberOfLines={
-                        shouldCollapse && !blockExpanded
-                          ? COLLAPSED_TEXT_LINES
-                          : undefined
-                      }
+                      } rounded-xl border border-slate-700/70 bg-slate-900/70 px-3 py-2`}
+                    >
+                      <Pressable
+                        onPress={() => toggleReasoning(blockId)}
+                        accessibilityRole="button"
+                        accessibilityLabel={
+                          expanded
+                            ? "Hide reasoning details"
+                            : "Show reasoning details"
+                        }
+                      >
+                        <Text className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                          {expanded ? "Hide Reasoning" : "Show Reasoning"}
+                        </Text>
+                      </Pressable>
+                      {expanded ? (
+                        <View>
+                          <Text
+                            selectable
+                            className="mt-1 break-all text-xs text-slate-300"
+                          >
+                            {blockText}
+                          </Text>
+                          {renderBottomCollapseAction(
+                            `chat-message-${blockId}-collapse-bottom`,
+                            () => toggleReasoning(blockId),
+                          )}
+                        </View>
+                      ) : null}
+                    </View>
+                  );
+                }
+                if (block.type === "tool_call") {
+                  const expanded = expandedToolCallByBlockId[blockId];
+                  return (
+                    <View
+                      key={blockId}
+                      className={`${
+                        blockIndex > 0 ? "mt-3" : ""
+                      } rounded-xl border border-slate-700/70 bg-slate-900/70 px-3 py-2`}
+                    >
+                      <Pressable
+                        onPress={() => toggleToolCall(blockId)}
+                        accessibilityRole="button"
+                        accessibilityLabel={
+                          expanded
+                            ? "Hide tool call details"
+                            : "Show tool call details"
+                        }
+                      >
+                        <Text className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                          {expanded ? "Hide Tool Call" : "Show Tool Call"}
+                        </Text>
+                      </Pressable>
+                      {expanded ? (
+                        <View>
+                          <Text
+                            selectable
+                            className="mt-1 break-all text-xs text-slate-300"
+                          >
+                            {blockText}
+                          </Text>
+                          {renderBottomCollapseAction(
+                            `chat-message-${blockId}-collapse-bottom`,
+                            () => toggleToolCall(blockId),
+                          )}
+                        </View>
+                      ) : null}
+                    </View>
+                  );
+                }
+                if (block.type === "text") {
+                  return (
+                    <View key={blockId} className="rounded-xl">
+                      <Text
+                        selectable
+                        className={`${
+                          blockIndex > 0 ? "mt-3" : ""
+                        } break-all text-sm text-white`}
+                        numberOfLines={
+                          plainShouldCollapse && !plainTextExpanded
+                            ? COLLAPSED_TEXT_LINES
+                            : undefined
+                        }
+                      >
+                        {blockText}
+                      </Text>
+                    </View>
+                  );
+                }
+                return (
+                  <View
+                    key={blockId}
+                    className={`${
+                      blockIndex > 0 ? "mt-3" : ""
+                    } rounded-xl border border-slate-700/70 bg-slate-900/70 px-3 py-2`}
+                  >
+                    <Text className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                      {block.type}
+                    </Text>
+                    <Text
+                      selectable
+                      className="mt-1 break-all text-xs text-slate-300"
                     >
                       {blockText}
                     </Text>
-                    {shouldCollapse ? (
-                      <Pressable
-                        className="mt-2 rounded-md px-2 py-1"
-                        accessibilityRole="button"
-                        accessibilityLabel={topToggleAccessibilityLabel}
-                        testID={`chat-message-${blockId}-expand`}
-                        onPress={() => toggleTextExpansion(blockId)}
-                      >
-                        <Text className="text-xs font-semibold text-slate-300">
-                          {topToggleLabel}
-                        </Text>
-                      </Pressable>
-                    ) : null}
-                    {shouldCollapse && blockExpanded
-                      ? renderBottomCollapseAction(
-                          `chat-message-${blockId}-collapse-bottom`,
-                          () => toggleTextExpansion(blockId),
-                        )
-                      : null}
                   </View>
                 );
-              }
-              return (
-                <View
-                  key={blockId}
-                  className={`${
-                    blockIndex > 0 ? "mt-3" : ""
-                  } rounded-xl border border-slate-700/70 bg-slate-900/70 px-3 py-2`}
-                >
-                  <Text className="text-[10px] font-medium uppercase tracking-wide text-slate-400">
-                    {block.type}
-                  </Text>
-                  <Text
-                    selectable
-                    className="mt-1 break-all text-xs text-slate-300"
+              })}
+              {plainShouldCollapse ? (
+                <View className="mt-2">
+                  <Pressable
+                    className="rounded-md px-2 py-1"
+                    accessibilityRole="button"
+                    accessibilityLabel={plainTopToggleAccessibilityLabel}
+                    testID={`chat-message-${message.id}-expand`}
+                    onPress={() => toggleTextExpansion(message.id)}
                   >
-                    {blockText}
-                  </Text>
+                    <Text className="text-xs font-semibold text-slate-300">
+                      {plainTopToggleLabel}
+                    </Text>
+                  </Pressable>
+                  {plainTextExpanded
+                    ? renderBottomCollapseAction(
+                        `chat-message-${message.id}-collapse-bottom`,
+                        () => toggleTextExpansion(message.id),
+                      )
+                    : null}
                 </View>
-              );
-            })
+              ) : null}
+            </>
           ) : (
             <View className="rounded-xl">
               <Text

--- a/frontend/components/chat/__tests__/ChatMessageItem.test.tsx
+++ b/frontend/components/chat/__tests__/ChatMessageItem.test.tsx
@@ -121,23 +121,21 @@ describe("ChatMessageItem collapsible blocks", () => {
       />,
     );
 
-    fireEvent.press(
-      screen.getByTestId("chat-message-plain-message:text-expand"),
-    );
+    fireEvent.press(screen.getByTestId("chat-message-plain-message-expand"));
     expect(
-      screen.getByTestId("chat-message-plain-message:text-expand").props
+      screen.getByTestId("chat-message-plain-message-expand").props
         .accessibilityLabel,
     ).toBe("Collapse full text");
     expect(
-      screen.getByTestId("chat-message-plain-message:text-collapse-bottom"),
+      screen.getByTestId("chat-message-plain-message-collapse-bottom"),
     ).toBeTruthy();
 
     fireEvent.press(
-      screen.getByTestId("chat-message-plain-message:text-collapse-bottom"),
+      screen.getByTestId("chat-message-plain-message-collapse-bottom"),
     );
     expect(onLayoutChangeStart).toHaveBeenCalledTimes(2);
     expect(
-      screen.getByTestId("chat-message-plain-message:text-expand"),
+      screen.getByTestId("chat-message-plain-message-expand"),
     ).toBeTruthy();
   });
 });

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -478,7 +478,7 @@ describe("ChatScreen interrupt handling", () => {
     const expandButton = root.findAll((node) => {
       return (
         node.type === Object({}) ||
-        node.props?.testID === "chat-message-message-1:text-expand"
+        node.props?.testID === "chat-message-message-1-expand"
       );
     })[0];
 
@@ -490,12 +490,12 @@ describe("ChatScreen interrupt handling", () => {
     });
 
     const collapseButton = root.findByProps({
-      testID: "chat-message-message-1:text-expand",
+      testID: "chat-message-message-1-expand",
       accessibilityLabel: "Collapse full text",
     });
     expect(collapseButton).toBeDefined();
     const bottomCollapseButton = root.findByProps({
-      testID: "chat-message-message-1:text-collapse-bottom",
+      testID: "chat-message-message-1-collapse-bottom",
       accessibilityLabel: "Collapse full text",
     });
     expect(bottomCollapseButton).toBeDefined();
@@ -541,7 +541,7 @@ describe("ChatScreen interrupt handling", () => {
 
       act(() => {
         root
-          .findByProps({ testID: "chat-message-message-anchor:text-expand" })
+          .findByProps({ testID: "chat-message-message-anchor-expand" })
           .props.onPress();
       });
 


### PR DESCRIPTION
## 关联 Issue
- Closes #298

## 关联 Commits
- 6a150bd `fix(frontend): align message folding logic with full content field (#298)`

## 变更说明（按模块）
### Frontend / ChatMessage Rendering
- 将“展开/收起”入口从 block 粒度改为 message 粒度，基于完整消息内容字段统一判定。
- 对 `reasoning`、`tool_call`、`text` 等 block 渲染分支进行重排，统一交互入口与测试标识。

### Frontend / Tests
- 更新 `ChatMessageItem` 与 `ChatScreen.interrupt` 相关测试用例中的 `testID` 与交互断言。

## 验证记录
- 已执行并通过：`npm run lint`、`npm run check-types`
- 已执行相关测试：`ChatMessageItem` 相关测试
