### PR TITLE
feat(frontend): add clear action to chat composer input (#309)

### DIFF
--- a/frontend/components/chat/ChatComposer.tsx
+++ b/frontend/components/chat/ChatComposer.tsx
@@ -83,6 +83,19 @@ export function ChatComposer({
           blurOnSubmit={false}
           returnKeyType="default"
         />
+        {input.length > 0 && (
+          <Pressable
+            className="h-9 w-6 items-center justify-center"
+            onPress={() => {
+              onInputChange("");
+              inputRef.current?.focus();
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Clear input"
+          >
+            <Ionicons name="close-circle" size={18} color="#94a3b8" />
+          </Pressable>
+        )}
         <Pressable
           className={`h-9 w-9 items-center justify-center rounded-xl ${
             !input.trim() || Boolean(pendingInterrupt)

--- a/frontend/components/chat/__tests__/ChatComposer.test.tsx
+++ b/frontend/components/chat/__tests__/ChatComposer.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render } from "@testing-library/react-native";
+import React from "react";
+import { ChatComposer } from "../ChatComposer";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+describe("ChatComposer clear button", () => {
+  const mockProps = {
+    pendingInterrupt: null,
+    showShortcutManager: false,
+    onOpenShortcutManager: jest.fn(),
+    inputRef: { current: { focus: jest.fn() } } as any,
+    input: "",
+    onInputChange: jest.fn(),
+    onContentSizeChange: jest.fn(),
+    inputHeight: 40,
+    maxInputHeight: 200,
+    onSubmit: jest.fn(),
+    onKeyPress: jest.fn(),
+  };
+
+  it("does not show clear button when input is empty", () => {
+    const { queryByLabelText } = render(<ChatComposer {...mockProps} />);
+    expect(queryByLabelText("Clear input")).toBeNull();
+  });
+
+  it("shows clear button when input is not empty", () => {
+    const { getByLabelText } = render(
+      <ChatComposer {...mockProps} input="hello" />,
+    );
+    expect(getByLabelText("Clear input")).toBeTruthy();
+  });
+
+  it("calls onInputChange with empty string and focuses input when cleared", () => {
+    const onInputChange = jest.fn();
+    const focus = jest.fn();
+    const inputRef = { current: { focus } };
+
+    const { getByLabelText } = render(
+      <ChatComposer
+        {...mockProps}
+        input="hello"
+        onInputChange={onInputChange}
+        inputRef={inputRef as any}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Clear input"));
+
+    expect(onInputChange).toHaveBeenCalledWith("");
+    expect(focus).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 关联 Issue
- Closes #309

## 关联 Commits
- 6bc2301 `feat(frontend): add clear button to chat input (#309)`

## 变更说明（按模块）
### Frontend / ChatComposer
- 在输入框非空时显示清空按钮。
- 点击后清空输入并保持焦点。

### Frontend / Tests
- 新增 `ChatComposer` 清空按钮测试，覆盖显示条件与点击行为。

## 验证记录
- 已执行相关测试：`npm test -- --findRelatedTests components/chat/ChatComposer.tsx`
- 已执行并通过：`npm run lint`、`npm run check-types`
