### PR TITLE
feat(chat): add animated scroll-to-bottom floating action button (#308)

### DIFF
--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -29,6 +29,7 @@ import { continueSession } from "@/lib/api/sessions";
 import { isSameMessageList } from "@/lib/chat-utils";
 import {
   getAnchoredOffsetAfterContentResize,
+  shouldShowScrollToBottom,
   shouldStickToBottom,
 } from "@/lib/chatScroll";
 import { blurActiveElement } from "@/lib/focus";
@@ -87,6 +88,7 @@ export function useChatScreenController({
   const { syncShortcuts } = useShortcutStore();
 
   const [input, setInput] = useState("");
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const suppressAutoScrollRef = useRef(false);
   const shouldStickToBottomRef = useRef(true);
   const forceScrollToBottomRef = useRef(false);
@@ -443,6 +445,11 @@ export function useChatScreenController({
         contentHeight,
       });
       scrollOffsetRef.current = offsetY;
+
+      setShowScrollToBottom(
+        shouldShowScrollToBottom({ offsetY, viewportHeight, contentHeight }),
+      );
+
       if (
         offsetY <= HISTORY_AUTOLOAD_THRESHOLD &&
         typeof historyNextPage === "number" &&
@@ -780,6 +787,8 @@ export function useChatScreenController({
     questionAnswers,
     showDetails,
     toggleDetails,
+    showScrollToBottom,
+    scrollToBottom,
     showShortcutManager,
     showSessionPicker,
     openShortcutManager,

--- a/frontend/lib/__tests__/chatScroll.test.ts
+++ b/frontend/lib/__tests__/chatScroll.test.ts
@@ -2,6 +2,7 @@ import {
   CHAT_LIST_BOTTOM_STICK_THRESHOLD,
   getAnchoredOffsetAfterContentResize,
   getDistanceToBottom,
+  shouldShowScrollToBottom,
   shouldStickToBottom,
 } from "@/lib/chatScroll";
 
@@ -54,6 +55,51 @@ describe("chatScroll", () => {
         CHAT_LIST_BOTTOM_STICK_THRESHOLD + 30,
       ),
     ).toBe(true);
+  });
+
+  describe("shouldShowScrollToBottom", () => {
+    it("returns false when content is shorter than viewport", () => {
+      expect(
+        shouldShowScrollToBottom({
+          offsetY: 0,
+          viewportHeight: 600,
+          contentHeight: 400,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns true when distance to bottom exceeds one screen height", () => {
+      expect(
+        shouldShowScrollToBottom({
+          offsetY: 100,
+          viewportHeight: 600,
+          contentHeight: 2000,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when distance to bottom is within one screen height", () => {
+      expect(
+        shouldShowScrollToBottom({
+          offsetY: 1000,
+          viewportHeight: 600,
+          contentHeight: 2000,
+        }),
+      ).toBe(false);
+    });
+
+    it("supports custom threshold", () => {
+      expect(
+        shouldShowScrollToBottom(
+          {
+            offsetY: 1000,
+            viewportHeight: 600,
+            contentHeight: 2000,
+          },
+          200,
+        ),
+      ).toBe(true);
+    });
   });
 
   it("computes anchored offset when content grows", () => {

--- a/frontend/lib/chatScroll.ts
+++ b/frontend/lib/chatScroll.ts
@@ -22,6 +22,16 @@ export const shouldStickToBottom = (
   threshold = CHAT_LIST_BOTTOM_STICK_THRESHOLD,
 ): boolean => getDistanceToBottom(metrics) <= threshold;
 
+export const shouldShowScrollToBottom = (
+  metrics: ChatScrollMetrics,
+  threshold?: number,
+): boolean => {
+  const { viewportHeight, contentHeight } = metrics;
+  if (contentHeight <= viewportHeight) return false;
+  const actualThreshold = threshold ?? viewportHeight;
+  return getDistanceToBottom(metrics) > actualThreshold;
+};
+
 export const getAnchoredOffsetAfterContentResize = (
   anchor: ContentSizeAnchor,
   nextContentHeight: number,

--- a/frontend/screens/ChatScreen.tsx
+++ b/frontend/screens/ChatScreen.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import { KeyboardAvoidingView, Platform, Text, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  withTiming,
+} from "react-native-reanimated";
 
 import { ChatComposer } from "@/components/chat/ChatComposer";
 import { ChatHeaderPanel } from "@/components/chat/ChatHeaderPanel";
@@ -7,6 +11,7 @@ import { ChatTimelinePanel } from "@/components/chat/ChatTimelinePanel";
 import { SessionPickerModal } from "@/components/chat/SessionPickerModal";
 import { ShortcutManagerModal } from "@/components/chat/ShortcutManagerModal";
 import { FullscreenLoader } from "@/components/ui/FullscreenLoader";
+import { IconButton } from "@/components/ui/IconButton";
 import { useChatScreenController } from "@/hooks/useChatScreenController";
 
 export function ChatScreen({
@@ -20,6 +25,19 @@ export function ChatScreen({
     routeAgentId,
     conversationId,
   });
+
+  const animatedButtonStyle = useAnimatedStyle(() => ({
+    opacity: withTiming(controller.showScrollToBottom ? 1 : 0, {
+      duration: 200,
+    }),
+    transform: [
+      {
+        scale: withTiming(controller.showScrollToBottom ? 1 : 0.8, {
+          duration: 200,
+        }),
+      },
+    ],
+  }));
 
   if (!controller.agent) {
     if (!controller.hasFetchedAgents) {
@@ -78,6 +96,21 @@ export function ChatScreen({
         onQuestionReply={controller.handleQuestionReply}
         onQuestionReject={controller.handleQuestionReject}
       />
+
+      <Animated.View
+        style={animatedButtonStyle}
+        className="absolute bottom-24 right-4 z-50"
+        pointerEvents={controller.showScrollToBottom ? "auto" : "none"}
+      >
+        <IconButton
+          icon="chevron-down"
+          variant="secondary"
+          size="sm"
+          onPress={() => controller.scrollToBottom(true)}
+          accessibilityLabel="Scroll to bottom"
+          className="bg-slate-800/40 border border-white/10 backdrop-blur-md"
+        />
+      </Animated.View>
 
       <ShortcutManagerModal
         visible={controller.showShortcutManager}


### PR DESCRIPTION
## 关联 Issue
- Closes #308

## 关联 Commits
- 003fd1f `feat(chat): add smooth scroll-to-bottom floating button (#308)`

## 变更说明（按模块）
### Frontend / Scroll Logic
- 新增 `shouldShowScrollToBottom` 判定函数。
- 在 `useChatScreenController` 中增加 `showScrollToBottom` 状态并在滚动时更新。

### Frontend / Chat UI
- `ChatScreen` 新增悬浮“回到底部”按钮，支持淡入/缩放动画。

### Frontend / Tests
- 补充 `chatScroll.test.ts`，覆盖按钮显示阈值相关逻辑。

## 验证记录
- 已执行并通过：`npm run lint`、`npm run check-types`
- 已执行相关测试：`npm test -- lib/__tests__/chatScroll.test.ts`
