### PR TITLE
perf(frontend): reduce ChatComposer render pressure for large input (#319)

### DIFF
--- a/frontend/components/chat/ChatComposer.tsx
+++ b/frontend/components/chat/ChatComposer.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import React from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import {
   NativeSyntheticEvent,
   Platform,
@@ -12,92 +12,166 @@ import {
 
 import { type RuntimeInterrupt } from "@/lib/api/chat-utils";
 
-export function ChatComposer({
-  pendingInterrupt,
-  showShortcutManager,
-  onOpenShortcutManager,
-  inputRef,
-  input,
-  onInputChange,
-  onContentSizeChange,
-  inputHeight,
-  maxInputHeight,
-  onSubmit,
-  onKeyPress,
-}: {
-  pendingInterrupt: RuntimeInterrupt | null;
-  showShortcutManager: boolean;
-  onOpenShortcutManager: () => void;
-  inputRef: React.RefObject<TextInput | null>;
-  input: string;
-  onInputChange: (value: string) => void;
-  onContentSizeChange: (height: number) => void;
-  inputHeight: number;
-  maxInputHeight: number;
-  onSubmit: () => void;
-  onKeyPress: (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => void;
-}) {
-  return (
-    <View className="relative border-t border-slate-800 px-6 py-4">
-      {pendingInterrupt ? (
-        <View className="mb-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-          <Text className="text-xs text-amber-200">
-            Agent is waiting for authorization/input. Resolve the action card
-            first.
-          </Text>
-        </View>
-      ) : null}
+const MAX_INPUT_LENGTH = 100000;
 
-      <View className="flex-row items-end gap-2 rounded-3xl border border-slate-800 bg-slate-900/50 p-2">
-        <Pressable
-          className={`h-9 w-9 items-center justify-center rounded-xl ${
-            showShortcutManager ? "bg-primary" : "bg-slate-800"
-          }`}
-          onPress={onOpenShortcutManager}
-          accessibilityRole="button"
-          accessibilityLabel="Open shortcut manager"
-        >
-          <Ionicons
-            name={showShortcutManager ? "flash" : "flash-outline"}
-            size={18}
-            color={showShortcutManager ? "#ffffff" : "#94a3b8"}
-          />
-        </Pressable>
-        <TextInput
-          ref={inputRef}
-          className="flex-1 px-3 py-2 text-white"
-          placeholder="Type your message"
-          placeholderTextColor="#6b7280"
-          multiline
-          value={input}
-          onChangeText={onInputChange}
-          onContentSizeChange={(event) =>
-            onContentSizeChange(event.nativeEvent.contentSize.height)
-          }
-          scrollEnabled={inputHeight >= maxInputHeight}
-          textAlignVertical="top"
-          style={{ height: inputHeight, fontSize: 16 }}
-          submitBehavior={Platform.OS === "web" ? "submit" : undefined}
-          onSubmitEditing={Platform.OS === "web" ? undefined : onSubmit}
-          onKeyPress={onKeyPress}
-          blurOnSubmit={false}
-          returnKeyType="default"
-        />
-        <Pressable
-          className={`h-9 w-9 items-center justify-center rounded-xl ${
-            !input.trim() || Boolean(pendingInterrupt)
-              ? "bg-slate-800 opacity-50"
-              : "bg-primary"
-          }`}
-          testID="chat-send-button"
-          onPress={onSubmit}
-          disabled={!input.trim() || Boolean(pendingInterrupt)}
-          accessibilityRole="button"
-          accessibilityLabel="Send message"
-        >
-          <Ionicons name="send" size={16} color="#ffffff" />
-        </Pressable>
+const ShortcutButton = memo(
+  ({ active, onPress }: { active: boolean; onPress: () => void }) => (
+    <Pressable
+      className={`h-9 w-9 items-center justify-center rounded-xl ${
+        active ? "bg-primary" : "bg-slate-800"
+      }`}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel="Open shortcut manager"
+    >
+      <Ionicons
+        name={active ? "flash" : "flash-outline"}
+        size={18}
+        color={active ? "#ffffff" : "#94a3b8"}
+      />
+    </Pressable>
+  ),
+);
+
+const SendButton = memo(
+  ({ disabled, onPress }: { disabled: boolean; onPress: () => void }) => (
+    <Pressable
+      className={`h-9 w-9 items-center justify-center rounded-xl ${
+        disabled ? "bg-slate-800 opacity-50" : "bg-primary"
+      }`}
+      testID="chat-send-button"
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel="Send message"
+    >
+      <Ionicons name="send" size={16} color="#ffffff" />
+    </Pressable>
+  ),
+);
+
+const InterruptWarning = memo(
+  ({ pendingInterrupt }: { pendingInterrupt: RuntimeInterrupt | null }) => {
+    if (!pendingInterrupt) return null;
+    return (
+      <View className="mb-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+        <Text className="text-xs text-amber-200">
+          Agent is waiting for authorization/input. Resolve the action card
+          first.
+        </Text>
       </View>
-    </View>
-  );
-}
+    );
+  },
+);
+
+export const ChatComposer = memo(
+  ({
+    pendingInterrupt,
+    showShortcutManager,
+    onOpenShortcutManager,
+    inputRef,
+    input,
+    onInputChange,
+    onContentSizeChange,
+    inputHeight,
+    maxInputHeight,
+    onSubmit,
+    onKeyPress,
+  }: {
+    pendingInterrupt: RuntimeInterrupt | null;
+    showShortcutManager: boolean;
+    onOpenShortcutManager: () => void;
+    inputRef: React.RefObject<TextInput | null>;
+    input: string;
+    onInputChange: (value: string) => void;
+    onContentSizeChange: (height: number) => void;
+    inputHeight: number;
+    maxInputHeight: number;
+    onSubmit: (value?: string) => void;
+    onKeyPress: (
+      e: NativeSyntheticEvent<TextInputKeyPressEventData>,
+      value?: string,
+    ) => void;
+  }) => {
+    const [localValue, setLocalValue] = useState(input);
+
+    useEffect(() => {
+      setLocalValue(input);
+    }, [input]);
+
+    const handleInputChangeInternal = useCallback(
+      (value: string) => {
+        if (value.length > MAX_INPUT_LENGTH) return;
+        setLocalValue(value);
+        // Only sync to parent if emptiness changes to keep send button up to date
+        // or if it's a small change. For large text, we rely on contentSizeChange or submit to sync.
+        const wasEmpty = !input.trim();
+        const nowEmpty = !value.trim();
+        if (wasEmpty !== nowEmpty || value === "") {
+          onInputChange(value);
+        }
+      },
+      [input, onInputChange],
+    );
+
+    const handleContentSizeChangeInternal = useCallback(
+      (height: number) => {
+        onInputChange(localValue);
+        onContentSizeChange(height);
+      },
+      [localValue, onContentSizeChange, onInputChange],
+    );
+
+    const handleSubmitInternal = useCallback(() => {
+      onSubmit(localValue);
+    }, [localValue, onSubmit]);
+
+    const handleKeyPressInternal = useCallback(
+      (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+        onKeyPress(e, localValue);
+      },
+      [localValue, onKeyPress],
+    );
+
+    return (
+      <View className="relative border-t border-slate-800 px-6 py-4">
+        <InterruptWarning pendingInterrupt={pendingInterrupt} />
+
+        <View className="flex-row items-end gap-2 rounded-3xl border border-slate-800 bg-slate-900/50 p-2">
+          <ShortcutButton
+            active={showShortcutManager}
+            onPress={onOpenShortcutManager}
+          />
+          <TextInput
+            ref={inputRef}
+            className="flex-1 px-3 py-2 text-white"
+            placeholder="Type your message"
+            placeholderTextColor="#6b7280"
+            multiline
+            value={localValue}
+            onChangeText={handleInputChangeInternal}
+            onContentSizeChange={(event) =>
+              handleContentSizeChangeInternal(
+                event.nativeEvent.contentSize.height,
+              )
+            }
+            scrollEnabled={inputHeight >= maxInputHeight}
+            textAlignVertical="top"
+            style={{ height: inputHeight, fontSize: 16 }}
+            submitBehavior={Platform.OS === "web" ? "submit" : undefined}
+            onSubmitEditing={
+              Platform.OS === "web" ? undefined : handleSubmitInternal
+            }
+            onKeyPress={handleKeyPressInternal}
+            blurOnSubmit={false}
+            returnKeyType="default"
+          />
+          <SendButton
+            disabled={!localValue.trim() || Boolean(pendingInterrupt)}
+            onPress={handleSubmitInternal}
+          />
+        </View>
+      </View>
+    );
+  },
+);

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -469,35 +469,41 @@ export function useChatScreenController({
     }
   }, [activeAgentId, agent, validateAgentMutation]);
 
-  const handleSend = useCallback(() => {
-    if (!activeAgentId || !conversationId || !agent) {
-      return;
-    }
-    if (pendingInterrupt) {
-      toast.info(
-        "Action required",
-        "Please resolve the interactive action card before sending a new message.",
-      );
-      return;
-    }
-    if (!input.trim()) {
-      return;
-    }
-    forceScrollToBottomRef.current = true;
-    shouldStickToBottomRef.current = true;
-    sendMessage(conversationId, activeAgentId, input, agent.source);
-    setInput("");
-    setInputHeight(minInputHeight);
-    scheduleStickToBottom(true);
-  }, [
-    activeAgentId,
-    agent,
-    conversationId,
-    input,
-    pendingInterrupt,
-    scheduleStickToBottom,
-    sendMessage,
-  ]);
+  const handleSend = useCallback(
+    (overrideValue?: string) => {
+      const finalInput =
+        typeof overrideValue === "string" ? overrideValue : input;
+      if (!activeAgentId || !conversationId || !agent) {
+        return;
+      }
+      if (pendingInterrupt) {
+        toast.info(
+          "Action required",
+          "Please resolve the interactive action card before sending a new message.",
+        );
+        return;
+      }
+      if (!finalInput.trim()) {
+        return;
+      }
+      forceScrollToBottomRef.current = true;
+      shouldStickToBottomRef.current = true;
+      sendMessage(conversationId, activeAgentId, finalInput, agent.source);
+      setInput("");
+      setInputHeight(minInputHeight);
+      scheduleStickToBottom(true);
+    },
+    [
+      activeAgentId,
+      agent,
+      conversationId,
+      input,
+      pendingInterrupt,
+      scheduleStickToBottom,
+      sendMessage,
+      minInputHeight,
+    ],
+  );
 
   const runInterruptAction = useCallback(
     async (
@@ -694,7 +700,10 @@ export function useChatScreenController({
   );
 
   const handleKeyPress = useCallback(
-    (e: NativeSyntheticEvent<TextInputKeyPressEventData>) => {
+    (
+      e: NativeSyntheticEvent<TextInputKeyPressEventData>,
+      currentValue?: string,
+    ) => {
       const webEvent = e as WebTextInputKeyPressEvent;
       if (
         Platform.OS === "web" &&
@@ -703,7 +712,7 @@ export function useChatScreenController({
         !webEvent.nativeEvent.isComposing
       ) {
         webEvent.preventDefault?.();
-        handleSend();
+        handleSend(currentValue);
       }
     },
     [handleSend],


### PR DESCRIPTION
## 关联 Issue
- Related #319

## 关联 Commits
- d5c6bdf `perf(frontend): optimize large text handling in ChatComposer (#319)`

## 变更说明（按模块）
### Frontend / ChatComposer
- 引入 `localValue`，降低高频输入下父级状态同步频率。
- 拆分并 `memo` 化按钮与中断提示子组件，减少不必要重渲染。
- 增加 `MAX_INPUT_LENGTH = 100000` 输入上限。

### Frontend / Chat Controller
- `handleSend`、`handleKeyPress` 支持接收实时输入值，确保提交时使用最新文本。

## 验证记录
- 已执行并通过：`npm run lint`、`npm run check-types`
- 已执行相关测试：`ChatScreen.interrupt.test.tsx`
