### PR TITLE
feat(frontend): introduce reusable CopyButton and apply to scheduled cards (#307)

### DIFF
--- a/frontend/components/chat/ChatMessageItem.tsx
+++ b/frontend/components/chat/ChatMessageItem.tsx
@@ -1,9 +1,11 @@
 import { Ionicons } from "@expo/vector-icons";
 import * as Clipboard from "expo-clipboard";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Platform, Pressable, Text, View } from "react-native";
 
-import { type ChatMessage, type MessageBlock } from "@/lib/api/chat-utils";
+import { CopyButton } from "../ui/CopyButton";
+
+import { ChatMessage, MessageBlock } from "@/lib/api/chat-utils";
 import { COLLAPSED_TEXT_LINES, shouldCollapseByLength } from "@/lib/chat-utils";
 import { toast } from "@/lib/toast";
 
@@ -89,6 +91,19 @@ export function ChatMessageItem({
     [],
   );
 
+  const textToCopy = useMemo(() => {
+    let text = message.content;
+    if (message.role === "agent" && message.blocks?.length) {
+      const blockContent = message.blocks
+        .map((b) => `[${b.type}]\n${b.content}`)
+        .join("\n\n");
+      if (blockContent) {
+        text = `${blockContent}\n\n${text}`;
+      }
+    }
+    return text.trim();
+  }, [message]);
+
   const handleCopyPayload = useCallback(async (text: string) => {
     if (Platform.OS === "web" && typeof navigator !== "undefined") {
       if (navigator.clipboard?.writeText) {
@@ -105,21 +120,12 @@ export function ChatMessageItem({
 
   const handleCopyMessage = useCallback(async () => {
     try {
-      let textToCopy = message.content;
-      if (message.role === "agent" && message.blocks?.length) {
-        const blockContent = message.blocks
-          .map((b) => `[${b.type}]\n${b.content}`)
-          .join("\n\n");
-        if (blockContent) {
-          textToCopy = `${blockContent}\n\n${textToCopy}`;
-        }
-      }
-      await handleCopyPayload(textToCopy.trim());
+      await handleCopyPayload(textToCopy);
       toast.success("Copied", "Message copied to clipboard.");
     } catch {
       toast.error("Copy failed", "Could not copy message.");
     }
-  }, [handleCopyPayload, message]);
+  }, [handleCopyPayload, textToCopy]);
 
   const renderableBlocks = deriveRenderableBlocks(message);
   const hasBlocks = message.role === "agent" && renderableBlocks.length > 0;
@@ -358,18 +364,17 @@ export function ChatMessageItem({
             <Text className="mt-1 text-[10px] text-muted">Streaming...</Text>
           ) : null}
         </Pressable>
-        <Pressable
-          className={`absolute bottom-2 ${userCopyButtonPositionClass} rounded-lg px-2 py-2 opacity-45`}
-          onPress={handleCopyMessage}
-          accessibilityRole="button"
+        <CopyButton
+          value={textToCopy}
+          variant="ghost"
+          size="xs"
+          className={`absolute bottom-2 ${userCopyButtonPositionClass} opacity-45`}
           accessibilityLabel="Copy message"
-        >
-          <Ionicons
-            name="copy-outline"
-            size={16}
-            color={message.role === "user" ? "#ffffff" : "#cbd5e1"}
-          />
-        </Pressable>
+          successMessage="Message copied to clipboard."
+          idleIcon="copy-outline"
+          copiedIcon="checkmark"
+          iconColor={message.role === "user" ? "#ffffff" : "#cbd5e1"}
+        />
       </View>
       {canRetry && (
         <Pressable

--- a/frontend/components/scheduled/ScheduledJobCard.tsx
+++ b/frontend/components/scheduled/ScheduledJobCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Pressable, Switch, Text, View } from "react-native";
 
 import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
 import {
   type IntervalTimePoint,
   type ScheduledJob,
@@ -195,7 +196,14 @@ export function ScheduledJobCard({
         >
           {job.prompt}
         </Text>
-        <View className="mt-1 items-end">
+        <View className="mt-1 flex-row items-center justify-end gap-1">
+          <CopyButton
+            value={job.prompt}
+            variant="ghost"
+            size="xs"
+            accessibilityLabel="Copy prompt"
+            iconColor={tone.iconColor}
+          />
           <Pressable
             className="rounded px-1 py-1 active:bg-slate-800/30"
             onPress={() => setPromptExpanded((value) => !value)}

--- a/frontend/components/ui/CopyButton.tsx
+++ b/frontend/components/ui/CopyButton.tsx
@@ -1,0 +1,68 @@
+import { Ionicons } from "@expo/vector-icons";
+import * as Clipboard from "expo-clipboard";
+import React, { useCallback, useState } from "react";
+import { Platform } from "react-native";
+
+import { IconButton } from "./IconButton";
+
+import { toast } from "@/lib/toast";
+
+type IconButtonProps = React.ComponentProps<typeof IconButton>;
+
+type CopyButtonProps = Omit<IconButtonProps, "icon" | "onPress"> & {
+  value: string;
+  idleIcon?: React.ComponentProps<typeof Ionicons>["name"];
+  copiedIcon?: React.ComponentProps<typeof Ionicons>["name"];
+  successMessage?: string;
+  iconColor?: string;
+};
+
+export function CopyButton({
+  value,
+  idleIcon = "copy-outline",
+  copiedIcon = "checkmark",
+  successMessage = "Copied to clipboard",
+  iconColor,
+  ...props
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    if (!value) return;
+
+    try {
+      if (Platform.OS === "web" && typeof navigator !== "undefined") {
+        if (navigator.clipboard?.writeText) {
+          try {
+            await navigator.clipboard.writeText(value);
+          } catch {
+            // Fall back to Expo clipboard API
+            await Clipboard.setStringAsync(value);
+          }
+        } else {
+          await Clipboard.setStringAsync(value);
+        }
+      } else {
+        await Clipboard.setStringAsync(value);
+      }
+
+      setCopied(true);
+      toast.success("Copied", successMessage);
+
+      setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch {
+      toast.error("Copy failed", "Could not copy to clipboard");
+    }
+  }, [value, successMessage]);
+
+  return (
+    <IconButton
+      {...props}
+      icon={copied ? copiedIcon : idleIcon}
+      onPress={handleCopy}
+      iconColor={iconColor}
+    />
+  );
+}

--- a/frontend/components/ui/IconButton.tsx
+++ b/frontend/components/ui/IconButton.tsx
@@ -14,11 +14,12 @@ type IconButtonVariant =
 type IconButtonSize = "xs" | "sm" | "md" | "lg";
 
 type IconButtonProps = Omit<PressableProps, "accessibilityLabel"> & {
-  icon: React.ComponentProps<typeof Ionicons>["name"];
+  icon?: React.ComponentProps<typeof Ionicons>["name"];
   accessibilityLabel: string;
   variant?: IconButtonVariant;
   size?: IconButtonSize;
   loading?: boolean;
+  iconColor?: string;
 };
 
 export function IconButton({
@@ -29,6 +30,7 @@ export function IconButton({
   disabled,
   className,
   accessibilityLabel,
+  iconColor,
   ...props
 }: IconButtonProps) {
   const variants: Record<IconButtonVariant, string> = {
@@ -72,13 +74,18 @@ export function IconButton({
       {...props}
     >
       {loading ? (
-        <ActivityIndicator size="small" color={iconColors[variant]} />
-      ) : (
-        <Ionicons
-          name={icon}
-          size={iconSizes[size]}
-          color={iconColors[variant]}
+        <ActivityIndicator
+          size="small"
+          color={iconColor || iconColors[variant]}
         />
+      ) : (
+        icon && (
+          <Ionicons
+            name={icon}
+            size={iconSizes[size]}
+            color={iconColor || iconColors[variant]}
+          />
+        )
       )}
     </Pressable>
   );

--- a/frontend/screens/admin/AdminInvitationsScreen.tsx
+++ b/frontend/screens/admin/AdminInvitationsScreen.tsx
@@ -1,20 +1,13 @@
-import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import * as Clipboard from "expo-clipboard";
 import * as Linking from "expo-linking";
 import { useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  Pressable,
-  RefreshControl,
-  ScrollView,
-  Text,
-  View,
-} from "react-native";
+import { RefreshControl, ScrollView, Text, View } from "react-native";
 
 import { ScreenContainer } from "@/components/layout/ScreenContainer";
 import { PAGE_HEADER_CONTENT_GAP } from "@/components/layout/spacing";
 import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
 import { FullscreenLoader } from "@/components/ui/FullscreenLoader";
 import { IconButton } from "@/components/ui/IconButton";
 import { Input } from "@/components/ui/Input";
@@ -154,15 +147,6 @@ export function AdminInvitationsScreen() {
     [],
   );
 
-  const handleCopyLink = useCallback(async (link: string) => {
-    try {
-      await Clipboard.setStringAsync(link);
-      toast.success("Copied", "Invitation link copied.");
-    } catch {
-      toast.error("Copy failed", "Could not copy invitation link.");
-    }
-  }, []);
-
   if (!isReady) {
     return <FullscreenLoader message="Checking permissions..." />;
   }
@@ -285,25 +269,17 @@ export function AdminInvitationsScreen() {
                     </Text>
                     <View className="mt-2 flex-row items-center gap-2">
                       {inv.status === "pending" ? (
-                        <Pressable
-                          className="flex-row items-center gap-1 rounded-lg px-2 py-2 active:bg-slate-800/40"
-                          onPress={() =>
-                            handleCopyLink(
-                              buildInvitationLink(inv.code, inv.target_email),
-                            )
-                          }
-                          accessibilityRole="button"
+                        <CopyButton
+                          value={buildInvitationLink(
+                            inv.code,
+                            inv.target_email,
+                          )}
+                          variant="ghost"
+                          size="xs"
                           accessibilityLabel="Copy invitation link"
-                        >
-                          <Ionicons
-                            name="copy-outline"
-                            size={14}
-                            color="#94a3b8"
-                          />
-                          <Text className="text-xs font-medium text-slate-300">
-                            Copy
-                          </Text>
-                        </Pressable>
+                          successMessage="Invitation link copied."
+                          iconColor="#94a3b8"
+                        />
                       ) : null}
                       <Text
                         className="flex-1 font-mono text-[11px] text-muted"


### PR DESCRIPTION
## 关联 Issue
- Closes #307

## 关联 Commits
- 889865e `feat(frontend): abstract CopyButton component and integrate into ScheduledJobCard (#307)`

## 变更说明（按模块）
### Frontend / UI
- 新增 `CopyButton` 组件，统一复制逻辑、状态切换与提示文案。
- 扩展 `IconButton`，支持 `iconColor` 自定义。

### Frontend / Chat
- `ChatMessageItem` 复用 `CopyButton`，移除页面内重复复制实现。

### Frontend / Admin
- `AdminInvitationsScreen` 复用 `CopyButton`，统一邀请链接复制行为。

### Frontend / Schedule
- `ScheduledJobCard` 增加 Prompt 一键复制入口。

## 验证记录
- 已执行并通过：`npm run lint`、`npm run check-types`
- 已执行相关测试：`ChatMessageItem`、`ScheduledJobCard`
