### PR TITLE
refactor(chat-message): split message block rendering into dedicated components (#362)

### DIFF
--- a/frontend/components/chat/ChatMessageItem.tsx
+++ b/frontend/components/chat/ChatMessageItem.tsx
@@ -128,6 +128,7 @@ export function ChatMessageItem({
                     <ReasoningBlock
                       key={blockId}
                       block={block}
+                      fallbackBlockId={blockId}
                       messageId={message.id}
                       onLayoutChangeStart={onLayoutChangeStart}
                       onLoadBlockContent={onLoadBlockContent}
@@ -139,6 +140,7 @@ export function ChatMessageItem({
                     <ToolCallBlock
                       key={blockId}
                       block={block}
+                      fallbackBlockId={blockId}
                       messageId={message.id}
                       onLayoutChangeStart={onLayoutChangeStart}
                       onLoadBlockContent={onLoadBlockContent}
@@ -150,7 +152,7 @@ export function ChatMessageItem({
                     <TextBlock
                       key={blockId}
                       block={block}
-                      messageId={message.id}
+                      fallbackBlockId={blockId}
                       isAgent={message.role === "agent"}
                       onLayoutChangeStart={onLayoutChangeStart}
                       isFirst={isFirst}
@@ -161,7 +163,7 @@ export function ChatMessageItem({
                     <GenericBlock
                       key={blockId}
                       block={block}
-                      messageId={message.id}
+                      fallbackBlockId={blockId}
                       isFirst={isFirst}
                     />
                   );
@@ -172,7 +174,7 @@ export function ChatMessageItem({
               {hasPlainContent ? (
                 <TextBlock
                   content={message.content}
-                  messageId={message.id}
+                  fallbackBlockId={message.id}
                   isAgent={message.role === "agent"}
                   onLayoutChangeStart={onLayoutChangeStart}
                   isFirst

--- a/frontend/components/chat/blocks/GenericBlock.tsx
+++ b/frontend/components/chat/blocks/GenericBlock.tsx
@@ -5,13 +5,17 @@ import { type MessageBlock } from "@/lib/api/chat-utils";
 
 interface GenericBlockProps {
   block: MessageBlock;
-  messageId: string;
+  fallbackBlockId: string;
   isFirst?: boolean;
 }
 
-export function GenericBlock({ block, messageId, isFirst }: GenericBlockProps) {
+export function GenericBlock({
+  block,
+  fallbackBlockId,
+  isFirst,
+}: GenericBlockProps) {
   const blockText = block.content;
-  const blockId = block.id || `${messageId}:generic`;
+  const blockId = block.id || fallbackBlockId;
 
   return (
     <View

--- a/frontend/components/chat/blocks/ReasoningBlock.tsx
+++ b/frontend/components/chat/blocks/ReasoningBlock.tsx
@@ -5,6 +5,7 @@ import { type MessageBlock } from "@/lib/api/chat-utils";
 
 interface ReasoningBlockProps {
   block: MessageBlock;
+  fallbackBlockId: string;
   messageId: string;
   onLayoutChangeStart?: () => void;
   onLoadBlockContent?: (messageId: string, blockId: string) => Promise<boolean>;
@@ -13,6 +14,7 @@ interface ReasoningBlockProps {
 
 export function ReasoningBlock({
   block,
+  fallbackBlockId,
   messageId,
   onLayoutChangeStart,
   onLoadBlockContent,
@@ -22,7 +24,7 @@ export function ReasoningBlock({
 
   const blockText = block.content;
   const blockHasContent = blockText.length > 0;
-  const blockId = block.id || `${messageId}:reasoning`;
+  const blockId = block.id || fallbackBlockId;
 
   const toggleReasoning = useCallback(() => {
     onLayoutChangeStart?.();

--- a/frontend/components/chat/blocks/TextBlock.tsx
+++ b/frontend/components/chat/blocks/TextBlock.tsx
@@ -7,7 +7,7 @@ import { COLLAPSED_TEXT_LINES, shouldCollapseByLength } from "@/lib/chat-utils";
 interface TextBlockProps {
   block?: MessageBlock;
   content?: string;
-  messageId: string;
+  fallbackBlockId: string;
   isAgent: boolean;
   onLayoutChangeStart?: () => void;
   isFirst?: boolean;
@@ -16,7 +16,7 @@ interface TextBlockProps {
 export function TextBlock({
   block,
   content,
-  messageId,
+  fallbackBlockId,
   isAgent,
   onLayoutChangeStart,
   isFirst,
@@ -24,7 +24,7 @@ export function TextBlock({
   const [expanded, setExpanded] = useState(false);
 
   const blockText = block?.content ?? content ?? "";
-  const blockId = block?.id ?? messageId;
+  const blockId = block?.id ?? fallbackBlockId;
 
   const toggleTextExpansion = useCallback(() => {
     onLayoutChangeStart?.();

--- a/frontend/components/chat/blocks/ToolCallBlock.tsx
+++ b/frontend/components/chat/blocks/ToolCallBlock.tsx
@@ -6,6 +6,7 @@ import { type MessageBlock } from "@/lib/api/chat-utils";
 
 interface ToolCallBlockProps {
   block: MessageBlock;
+  fallbackBlockId: string;
   messageId: string;
   onLayoutChangeStart?: () => void;
   onLoadBlockContent?: (messageId: string, blockId: string) => Promise<boolean>;
@@ -14,6 +15,7 @@ interface ToolCallBlockProps {
 
 export function ToolCallBlock({
   block,
+  fallbackBlockId,
   messageId,
   onLayoutChangeStart,
   onLoadBlockContent,
@@ -23,7 +25,7 @@ export function ToolCallBlock({
 
   const blockText = block.content;
   const blockHasContent = blockText.length > 0;
-  const blockId = block.id || `${messageId}:tool_call`;
+  const blockId = block.id || fallbackBlockId;
 
   const toggleToolCall = useCallback(() => {
     onLayoutChangeStart?.();


### PR DESCRIPTION
## 关联 Issue
- Closes #362

## 关联 Commits
- c448f71 `refactor(frontend): split ChatMessageItem into sub-blocks (#362)`
- 36ba7f3 `fix(chat-message): preserve stable fallback block ids in split block components (#362)`

## 变更说明（按模块）
### Frontend / Chat Message Rendering
- 将 `ChatMessageItem` 中 `reasoning`、`tool_call`、`text`、`generic` 渲染逻辑拆分到独立子组件目录 `components/chat/blocks/`。
- 各子组件内聚自身展开/收起交互状态，降低主组件复杂度。

### Frontend / Stability Hardening
- 新增 `fallbackBlockId` 透传机制，保证当 `block.id` 缺失时仍使用与主组件一致的稳定回退 ID（含索引语义）。
- 修复拆分后潜在的同类型 block 回退 ID 冲突风险，避免展开状态串扰或 testID 冲突。

## 代码审查结论
- 需求匹配：已完成 #362 的组件拆分目标，并保持现有交互能力。
- 设计评估：职责切分清晰，主组件可读性显著提升。
- 风险评估：本次补丁已对回退 ID 稳定性做加固，降低兼容数据场景下的行为偏差风险。

## 回归验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/chat/ChatMessageItem.tsx components/chat/blocks/GenericBlock.tsx components/chat/blocks/ReasoningBlock.tsx components/chat/blocks/TextBlock.tsx components/chat/blocks/ToolCallBlock.tsx --maxWorkers=25%`
- 结果：全部通过（`2 suites / 15 tests`）。
