### PR TITLE
perf(session-hub): push session filtering and pagination into SQL (#361)

### DIFF
--- a/backend/app/services/session_hub.py
+++ b/backend/app/services/session_hub.py
@@ -109,9 +109,7 @@ class SessionHubService:
 
         # Count total
         count_stmt = (
-            select(func.count())
-            .select_from(ConversationThread)
-            .where(and_(*filters))
+            select(func.count()).select_from(ConversationThread).where(and_(*filters))
         )
         total = (await db.execute(count_stmt)).scalar() or 0
 


### PR DESCRIPTION
## 关联 Issue
- Closes #361

## 关联 Commits
- bb1ebba `perf(session-hub): optimize session list query with SQL filtering and pagination (#361)`
- 0ea6244 `chore(backend): format session hub count query chain (#361)`

## 变更说明（按模块）
### Backend / SessionHubService
- `_list_local_sessions` 将 `source`、`agent_id` 过滤条件下推到 SQL 查询层，不再先全量拉取后在内存过滤。
- 分页改为数据库层 `limit/offset`，并在同一过滤条件下增加 `count` 查询返回总数。
- `list_sessions` 使用后端返回的 `items + total` 生成分页信息，移除 Python 切片路径。

## 代码审查结论
- 需求匹配：与 #361 目标一致，核心性能瓶颈（全量查询+内存过滤）被消除。
- 范围评估：仅改动 `session_hub.py`，改动面集中。
- 风险评估：`count + data` 双查询是常规实现；主要风险在于查询一致性和过滤条件维护，当前实现使用同一 `filters` 集合，设计合理。

## 回归验证
- `cd backend && uv run pre-commit run --files app/services/session_hub.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_session_hub_service.py tests/test_me_sessions_routes.py`
- 结果：全部通过（`22 passed`）。
