### PR TITLE
fix(chat-history): clear stale cursors on conversation re-entry (#356)

### DIFF
--- a/frontend/hooks/__tests__/useChatHistoryQuery.test.tsx
+++ b/frontend/hooks/__tests__/useChatHistoryQuery.test.tsx
@@ -201,4 +201,57 @@ describe("useChatHistoryQuery", () => {
     );
     expect(secondResult.nextPage).toBeUndefined();
   });
+
+  it("clears subsequent page cursors when conversation id changes or re-enters", async () => {
+    let fetchPage: ((page: number) => Promise<{ nextPage?: number }>) | null =
+      null;
+    mockedUsePaginatedList.mockImplementation((options: any) => {
+      fetchPage = options.fetchPage;
+      return createPaginatedResult([]);
+    });
+    mockedListSessionMessagesPage.mockResolvedValue({
+      items: [],
+      pageInfo: { hasMoreBefore: true, nextBefore: "cursor-next" },
+    });
+
+    const { rerender } = renderHook(
+      ({ conversationId }) =>
+        useSessionHistoryQuery({
+          conversationId,
+          enabled: true,
+        }),
+      {
+        initialProps: { conversationId: "conversation-reset-test" },
+      },
+    );
+
+    if (!fetchPage) throw new Error("fetchPage is unavailable");
+    const runFetchPage = fetchPage as unknown as (page: number) => Promise<{
+      nextPage?: number;
+    }>;
+
+    // Load page 1 -> next cursor stored for page 2
+    await runFetchPage(1);
+
+    // Verify page 2 would use the cursor
+    await runFetchPage(2);
+    expect(mockedListSessionMessagesPage).toHaveBeenLastCalledWith(
+      "conversation-reset-test",
+      { before: "cursor-next", limit: 8 },
+    );
+
+    // Change conversationId to clear the current ref's connection or reset it
+    rerender({ conversationId: "conversation-other" });
+    // Change back to original
+    rerender({ conversationId: "conversation-reset-test" });
+
+    mockedListSessionMessagesPage.mockClear();
+
+    // Now page 2 should NOT use the old cursor because it was cleared in useEffect
+    await runFetchPage(2);
+    expect(mockedListSessionMessagesPage).toHaveBeenLastCalledWith(
+      "conversation-reset-test",
+      { before: null, limit: 8 },
+    );
+  });
 });

--- a/frontend/hooks/useChatHistoryQuery.ts
+++ b/frontend/hooks/useChatHistoryQuery.ts
@@ -57,8 +57,15 @@ export function useSessionHistoryQuery(options: {
       cursorByPageRef.current = new Map<number, string | null>([[1, null]]);
       return;
     }
-    cursorByPageRef.current = resolveMessageCursorMap(conversationId);
-    cursorByPageRef.current.set(1, null);
+    const map = resolveMessageCursorMap(conversationId);
+    // 关键修复：重入会话时，丢弃所有后续页面的旧 cursor 缓存，强制重新获取
+    Array.from(map.keys()).forEach((key) => {
+      if (key > 1) {
+        map.delete(key);
+      }
+    });
+    map.set(1, null);
+    cursorByPageRef.current = map;
   }, [conversationId]);
 
   const fetchPage = useCallback(


### PR DESCRIPTION
## 关联 Issue
- Closes #356

## 关联 Commits
- 653752f `fix(frontend): clear subsequent page cursors when re-entering session (#356)`

## 变更说明（按模块）
### Frontend / Hooks
- 在 `useSessionHistoryQuery` 的 `conversationId` 变更路径中，清理当前会话 `page > 1` 的历史 cursor，仅保留第一页锚点。
- 重新进入同一会话时强制从最新分页游标重新计算，避免复用旧 cursor 导致重复页/漏页。

### Frontend / Tests
- 在 `useChatHistoryQuery` 单测中新增“切换会话再切回”场景，验证旧 cursor 已被清理且二次请求不会携带过期 `before`。

## 代码审查结论
- 需求匹配：完整覆盖 #356 所述重入会话 cursor 污染问题。
- 方案评估：修复点集中且副作用小，不改变接口契约。
- 风险评估：主要影响分页状态缓存；新增测试已覆盖关键回归场景，风险低。

## 回归验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/useChatHistoryQuery.ts hooks/__tests__/useChatHistoryQuery.test.tsx --maxWorkers=25%`
- 结果：全部通过（`2 suites / 13 tests`）。
