### PR TITLE
feat(scheduled-jobs): add delete flow with confirmation guard (#315)

### DIFF
--- a/frontend/components/scheduled/ScheduledJobCard.tsx
+++ b/frontend/components/scheduled/ScheduledJobCard.tsx
@@ -65,6 +65,7 @@ type ScheduledJobCardProps = {
   executionsLoadingMore?: boolean;
   onToggleEnabled: () => void | Promise<void>;
   onEdit: () => void;
+  onDelete?: () => void | Promise<void>;
   onMarkFailed?: () => void | Promise<void>;
   onToggleExecutions: () => void;
   onLoadMoreExecutions?: () => void;
@@ -81,6 +82,7 @@ export function ScheduledJobCard({
   executionsLoadingMore,
   onToggleEnabled,
   onEdit,
+  onDelete,
   onMarkFailed,
   onToggleExecutions,
   onLoadMoreExecutions,
@@ -94,6 +96,7 @@ export function ScheduledJobCard({
       : null;
   const [togglingEnabled, setTogglingEnabled] = useState(false);
   const [markingFailed, setMarkingFailed] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [promptExpanded, setPromptExpanded] = useState(false);
   const canMarkFailed = job.last_run_status === "running";
 
@@ -128,6 +131,24 @@ export function ScheduledJobCard({
       await onMarkFailed();
     } finally {
       setMarkingFailed(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!onDelete || deleting) return;
+    const confirmed = await confirmAction({
+      title: "Delete scheduled job?",
+      message: "This action cannot be undone.",
+      confirmLabel: "Delete",
+      cancelLabel: "Cancel",
+      isDestructive: true,
+    });
+    if (!confirmed) return;
+    setDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -198,6 +219,15 @@ export function ScheduledJobCard({
             variant="secondary"
             iconLeft="create-outline"
             onPress={onEdit}
+          />
+          <Button
+            label="Delete"
+            size="xs"
+            variant="secondary"
+            iconLeft="trash-outline"
+            loading={deleting}
+            disabled={!onDelete}
+            onPress={handleDelete}
           />
           <Button
             label={promptExpanded ? "Less" : "Info"}

--- a/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
+++ b/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
@@ -42,6 +42,7 @@ describe("ScheduledJobCard visuals", () => {
     executionsLoading: false,
     onToggleEnabled: jest.fn(),
     onEdit: jest.fn(),
+    onDelete: jest.fn(),
     onMarkFailed: jest.fn(),
     onToggleExecutions: jest.fn(),
   };
@@ -187,5 +188,43 @@ describe("ScheduledJobCard visuals", () => {
     );
 
     expect(getByText(/Every 15 min/)).toBeTruthy();
+  });
+});
+
+jest.mock("@/lib/confirm", () => ({
+  confirmAction: jest.fn(() => Promise.resolve(true)),
+}));
+
+describe("ScheduledJobCard interactions", () => {
+  const defaultProps = {
+    agentName: "Agent One",
+    executions: [],
+    executionsOpen: false,
+    executionsLoading: false,
+    onToggleEnabled: jest.fn(),
+    onEdit: jest.fn(),
+    onDelete: jest.fn(),
+    onMarkFailed: jest.fn(),
+    onToggleExecutions: jest.fn(),
+  };
+
+  it("calls onDelete when Delete button is pressed and confirmed", async () => {
+    const job = {
+      id: "8",
+      name: "Job",
+      enabled: true,
+      last_run_status: "success" as const,
+      next_run_at_utc: "2026-02-23T10:00:00Z",
+      schedule_timezone: "UTC",
+    };
+    const { getByText } = render(
+      <ScheduledJobCard {...defaultProps} job={job as any} />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("Delete"));
+    });
+
+    expect(defaultProps.onDelete).toHaveBeenCalled();
   });
 });

--- a/frontend/hooks/useScheduledJobs.ts
+++ b/frontend/hooks/useScheduledJobs.ts
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 import {
+  deleteScheduledJob,
   disableScheduledJob,
   enableScheduledJob,
   markScheduledJobFailed,
@@ -31,6 +32,16 @@ export function useScheduledJobs() {
     [queryClient],
   );
 
+  const removeJob = useCallback(
+    async (job: ScheduledJob) => {
+      await deleteScheduledJob(job.id);
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.schedules.listRoot(),
+      });
+    },
+    [queryClient],
+  );
+
   const markJobFailed = useCallback(
     async (job: ScheduledJob, reason?: string) => {
       await markScheduledJobFailed(job.id, { reason });
@@ -49,5 +60,6 @@ export function useScheduledJobs() {
   return {
     markJobFailed,
     toggleJobStatus,
+    removeJob,
   };
 }

--- a/frontend/lib/api/scheduledJobs.ts
+++ b/frontend/lib/api/scheduledJobs.ts
@@ -147,6 +147,11 @@ export const markScheduledJobFailed = (
     },
   );
 
+export const deleteScheduledJob = (jobId: string) =>
+  apiRequest<void>(`/me/a2a/schedules/${jobId}`, {
+    method: "DELETE",
+  });
+
 export const listScheduledJobExecutionsPage = async (
   taskId: string,
   options?: { page?: number; size?: number },

--- a/frontend/screens/ScheduledJobsScreen.tsx
+++ b/frontend/screens/ScheduledJobsScreen.tsx
@@ -22,7 +22,7 @@ import { useSessionStore } from "@/store/session";
 export function ScheduledJobsScreen() {
   const router = useRouter();
   const { data: agents = [] } = useAgentsCatalogQuery(true);
-  const { markJobFailed, toggleJobStatus } = useScheduledJobs();
+  const { markJobFailed, toggleJobStatus, removeJob } = useScheduledJobs();
   const userTimeZone = useSessionStore((state) => state.user?.timezone);
   const scheduleTimeZone = userTimeZone?.trim() || resolveUserTimeZone();
 
@@ -175,6 +175,19 @@ export function ScheduledJobsScreen() {
                 onEdit={() => {
                   blurActiveElement();
                   router.push(buildScheduledJobEditHref(job.id));
+                }}
+                onDelete={async () => {
+                  try {
+                    await removeJob(job);
+                    toast.success(
+                      "Job deleted",
+                      "The scheduled task has been removed.",
+                    );
+                  } catch (error) {
+                    const message =
+                      error instanceof Error ? error.message : "Delete failed.";
+                    toast.error("Delete failed", message);
+                  }
                 }}
                 onMarkFailed={async () => {
                   try {

--- a/frontend/screens/__tests__/ScheduledJobsScreen.test.tsx
+++ b/frontend/screens/__tests__/ScheduledJobsScreen.test.tsx
@@ -4,6 +4,7 @@ import { ScheduledJobsScreen } from "@/screens/ScheduledJobsScreen";
 
 const mockToggleJobStatus = jest.fn();
 const mockMarkJobFailed = jest.fn();
+const mockRemoveJob = jest.fn();
 const mockLoadFirstPage = jest.fn();
 const mockLoadMore = jest.fn();
 let mockJobs: any[] = [];
@@ -12,6 +13,7 @@ jest.mock("@/hooks/useScheduledJobs", () => ({
   useScheduledJobs: () => ({
     markJobFailed: mockMarkJobFailed,
     toggleJobStatus: mockToggleJobStatus,
+    removeJob: mockRemoveJob,
   }),
 }));
 


### PR DESCRIPTION
## 关联 Issue
- Closes #315

## 关联 Commits
- c738408 `feat(scheduled): add delete functionality with confirmation (#315)`

## 变更说明（按模块）
### Frontend / API
- 在 `scheduledJobs` API 层新增 `deleteScheduledJob(jobId)`，打通删除接口调用。

### Frontend / Hooks
- `useScheduledJobs` 新增 `removeJob`，封装删除动作并统一触发列表缓存失效。

### Frontend / Components
- `ScheduledJobCard` 增加删除入口。
- 删除动作引入 `confirmAction` 二次确认，防止误删。

### Frontend / Screens
- `ScheduledJobsScreen` 接入删除回调，并补充成功/失败 toast 反馈。

### Frontend / Tests
- 增加 `ScheduledJobCard` 删除交互测试。
- 更新 `ScheduledJobsScreen` 测试 mock，覆盖新 hook 能力。

## 代码审查结论
- 需求匹配：覆盖 #315 的“前端删除 + 二次确认 + 列表刷新”核心诉求。
- 实现评估：调用链清晰（API -> hook -> screen -> card），职责分层合理。
- 风险评估：删除为破坏性操作，当前已有确认弹窗与异常提示，风险可控。

## 回归验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/scheduled/ScheduledJobCard.tsx hooks/useScheduledJobs.ts lib/api/scheduledJobs.ts screens/ScheduledJobsScreen.tsx components/scheduled/__tests__/ScheduledJobCard.test.tsx screens/__tests__/ScheduledJobsScreen.test.tsx --maxWorkers=25%`
- 结果：全部通过（`8 suites / 35 tests`）。
