### PR TITLE
fix(schedule): only cleanup newly created threads on failure (#338)

### DIFF
--- a/backend/app/services/a2a_schedule_job.py
+++ b/backend/app/services/a2a_schedule_job.py
@@ -67,7 +67,9 @@ def _execution_metadata(
     }
 
 
-async def _ensure_task_session(*, db, task: A2AScheduleTask) -> ConversationThread:
+async def _ensure_task_session(
+    *, db, task: A2AScheduleTask
+) -> tuple[ConversationThread, bool]:
     now = utc_now()
 
     # Check conversation_policy
@@ -84,7 +86,7 @@ async def _ensure_task_session(*, db, task: A2AScheduleTask) -> ConversationThre
             and existing_thread.status != ConversationThread.STATUS_ARCHIVED
         ):
             existing_thread.last_active_at = now
-            return existing_thread
+            return existing_thread, False
 
     thread = ConversationThread(
         id=uuid4(),
@@ -99,7 +101,7 @@ async def _ensure_task_session(*, db, task: A2AScheduleTask) -> ConversationThre
     db.add(thread)
     await db.flush()
     task.conversation_id = thread.id
-    return thread
+    return thread, True
 
 
 async def _refresh_ops_metrics() -> None:
@@ -224,7 +226,7 @@ async def _execute_claimed_task(*, claim: ClaimedA2AScheduleTask) -> None:
             )
             if not bool(getattr(runtime.agent, "enabled", True)):
                 raise RuntimeError("Target A2A agent is disabled")
-            thread = await _ensure_task_session(
+            thread, is_new = await _ensure_task_session(
                 db=db,
                 task=task,
             )
@@ -262,9 +264,10 @@ async def _execute_claimed_task(*, claim: ClaimedA2AScheduleTask) -> None:
 
             if not success and not message_refs.get("user_message_id"):
                 execution.conversation_id = None
-                await db.delete(thread)
-                if task.conversation_id == thread.id:
-                    task.conversation_id = None
+                if is_new:
+                    await db.delete(thread)
+                    if task.conversation_id == thread.id:
+                        task.conversation_id = None
             else:
                 execution.conversation_id = (
                     message_refs.get("conversation_id")
@@ -328,9 +331,10 @@ async def _execute_claimed_task(*, claim: ClaimedA2AScheduleTask) -> None:
         except Exception as exc:  # pragma: no cover - defensive path
             if thread and execution:
                 execution.conversation_id = None
-                if task.conversation_id == thread.id:
-                    task.conversation_id = None
-                await db.delete(thread)
+                if is_new:
+                    if task.conversation_id == thread.id:
+                        task.conversation_id = None
+                    await db.delete(thread)
 
             finished_at = utc_now()
             if execution is None:

--- a/backend/tests/test_issue_338_reuse_thread_cleanup.py
+++ b/backend/tests/test_issue_338_reuse_thread_cleanup.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from uuid import uuid4
+from types import SimpleNamespace
+
+from app.db.models.a2a_schedule_task import A2AScheduleTask
+from app.db.models.conversation_thread import ConversationThread
+from app.services.a2a_schedule_job import _execute_claimed_task
+from app.utils.timezone_util import utc_now
+from tests.utils import create_user
+from app.db.models.a2a_agent import A2AAgent
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+async def _create_agent(session, *, user_id, suffix: str) -> A2AAgent:
+    agent = A2AAgent(
+        user_id=user_id,
+        name=f"Agent {suffix}",
+        card_url=f"https://example.com/{suffix}",
+        auth_type="none",
+        enabled=True,
+    )
+    session.add(agent)
+    await session.commit()
+    await session.refresh(agent)
+    return agent
+
+async def _create_schedule_task(
+    session,
+    *,
+    user_id,
+    agent_id,
+    conversation_id=None,
+    policy=A2AScheduleTask.POLICY_NEW,
+) -> A2AScheduleTask:
+    task = A2AScheduleTask(
+        user_id=user_id,
+        name="Test schedule",
+        agent_id=agent_id,
+        prompt="hello",
+        cycle_type=A2AScheduleTask.CYCLE_DAILY,
+        time_point={"time": "09:00"},
+        enabled=True,
+        next_run_at=utc_now(),
+        conversation_id=conversation_id,
+        conversation_policy=policy,
+    )
+    session.add(task)
+    await session.commit()
+    await session.refresh(task)
+    return task
+
+def _mock_runtime_builder():
+    async def _build(_db, user_id, agent_id):
+        return SimpleNamespace(
+            agent=SimpleNamespace(enabled=True),
+            resolved=SimpleNamespace(name="Schedule Agent"),
+        )
+    return SimpleNamespace(build=_build)
+
+def _build_claim(task: A2AScheduleTask):
+    from app.services.a2a_schedule_service import ClaimedA2AScheduleTask
+    return ClaimedA2AScheduleTask(
+        task_id=task.id,
+        user_id=task.user_id,
+        agent_id=task.agent_id,
+        conversation_id=task.conversation_id,
+        name=task.name,
+        prompt=task.prompt,
+        cycle_type=task.cycle_type,
+        time_point=task.time_point,
+        scheduled_for=task.next_run_at,
+        run_id=uuid4(),
+    )
+
+async def test_execute_claimed_task_retains_history_on_reuse_policy_failure(
+    async_db_session,
+    async_session_maker,
+    monkeypatch,
+) -> None:
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(async_db_session, user_id=user.id, suffix="reuse-fail")
+    
+    # Create an existing thread
+    thread = ConversationThread(
+        user_id=user.id,
+        agent_id=agent.id,
+        title="History",
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(thread)
+    await async_db_session.commit()
+    await async_db_session.refresh(thread)
+    
+    # Create task with REUSE policy and existing thread
+    task = await _create_schedule_task(
+        async_db_session,
+        user_id=user.id,
+        agent_id=agent.id,
+        conversation_id=thread.id,
+        policy=A2AScheduleTask.POLICY_REUSE,
+    )
+    task_id = task.id
+    thread_id = thread.id
+    
+    # Mock runtime and gateway to return failure
+    monkeypatch.setattr("app.services.a2a_schedule_job.a2a_runtime_builder", _mock_runtime_builder())
+    monkeypatch.setattr(
+        "app.services.a2a_schedule_job.get_a2a_service",
+        lambda: SimpleNamespace(
+            gateway=SimpleNamespace(
+                stream=lambda **kwargs: (yield {"kind": "status-update", "final": True})
+            )
+        )
+    )
+    
+    # We need to mock run_background_invoke to return failure
+    async def mock_run_background_invoke(**kwargs):
+        return {"success": False, "error": "failed intentionally"}
+    
+    monkeypatch.setattr("app.services.a2a_schedule_job.run_background_invoke", mock_run_background_invoke)
+
+    claim = _build_claim(task)
+    task.current_run_id = claim.run_id
+    await async_db_session.commit()
+
+    await _execute_claimed_task(claim=claim)
+    await async_db_session.rollback()
+
+    async with async_session_maker() as check_db:
+        # Verify thread still exists
+        existing_thread = await check_db.get(ConversationThread, thread_id)
+        assert existing_thread is not None, "Historical thread should NOT be deleted"
+        
+        # Verify task still points to the thread
+        refreshed_task = await check_db.get(A2AScheduleTask, task_id)
+        assert refreshed_task.conversation_id == thread_id, "Task should still point to historical thread"
+
+async def test_execute_claimed_task_cleans_new_thread_on_failure(
+    async_db_session,
+    async_session_maker,
+    monkeypatch,
+) -> None:
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(async_db_session, user_id=user.id, suffix="new-fail")
+    
+    # Create task with NEW policy
+    task = await _create_schedule_task(
+        async_db_session,
+        user_id=user.id,
+        agent_id=agent.id,
+        policy=A2AScheduleTask.POLICY_NEW,
+    )
+    task_id = task.id
+    
+    monkeypatch.setattr("app.services.a2a_schedule_job.a2a_runtime_builder", _mock_runtime_builder())
+    
+    async def mock_run_background_invoke(**kwargs):
+        return {"success": False, "error": "failed intentionally"}
+    
+    monkeypatch.setattr("app.services.a2a_schedule_job.run_background_invoke", mock_run_background_invoke)
+
+    claim = _build_claim(task)
+    task.current_run_id = claim.run_id
+    await async_db_session.commit()
+
+    await _execute_claimed_task(claim=claim)
+    await async_db_session.rollback()
+
+    async with async_session_maker() as check_db:
+        refreshed_task = await check_db.get(A2AScheduleTask, task_id)
+        assert refreshed_task.conversation_id is None, "Failed new task should have no conversation_id"
+        
+        # We can't easily check if the thread was deleted without knowing its ID, 
+        # but _ensure_task_session creates one and assigns it to task.conversation_id.
+        # Since refreshed_task.conversation_id is None, it was at least cleared.


### PR DESCRIPTION
## 关联 Issues
- Closes #338

## 关联 Commits
- `58d67e4` fix(schedule): only cleanup newly created threads on failure (#338)

## 变更说明（按模块）
### Backend / Scheduler Job
- 调整 `_ensure_task_session` 返回 `(thread, is_new)`，显式区分“复用历史线程”与“新建线程”。
- 调整 `_execute_claimed_task`：仅当 `is_new=True` 且执行失败时删除线程并清理 `task.conversation_id`，避免误删历史会话。

### Backend / Tests
- 新增 `test_issue_338_reuse_thread_cleanup.py`，覆盖 REUSE/NEW 两种策略在失败路径下的会话清理行为。

## 代码审查结论
- 结论：达到合并标准。
- 风险提示：当前 NEW 策略测试对“线程已删除”是间接校验（通过 `conversation_id` 变化），建议后续补充直接删除断言以增强回归可靠性。
