### PR TITLE
fix(schedule): adjust invoke and lease timeout defaults (#375)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -545,7 +545,7 @@ class Settings(BaseSettings):
         description="Number of in-process workers consuming claimed scheduled tasks.",
     )
     a2a_schedule_task_invoke_timeout: float = Field(
-        default=3600.0,
+        default=7200.0,
         alias="A2A_SCHEDULE_TASK_INVOKE_TIMEOUT",
         description="Maximum total timeout in seconds for a single scheduled A2A stream execution.",
     )
@@ -560,7 +560,7 @@ class Settings(BaseSettings):
         description="Timeout in seconds before a running scheduled task is considered stale by recovery.",
     )
     a2a_schedule_run_lease_seconds: int = Field(
-        default=2400,
+        default=5400,
         alias="A2A_SCHEDULE_RUN_LEASE_SECONDS",
         description="Lease timeout in seconds for one scheduled run before recovery finalization.",
     )


### PR DESCRIPTION
## 变更说明
- 将 `A2A_SCHEDULE_TASK_INVOKE_TIMEOUT` 默认值从 `3600s` 调整为 `7200s`（120分钟）
- 将 `A2A_SCHEDULE_RUN_LEASE_SECONDS` 默认值从 `2400s` 调整为 `5400s`（90分钟）
- 该变更用于临时止血，降低误恢复风险；完整的心跳失活检测机制将另开 Issue 跟进

## 关联 Issue
- Relates #375

## 验证证据
- `cd backend && uv run pre-commit run --files app/core/config.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_a2a_schedule_job.py tests/test_settings_security_baseline.py`
- 结果：`26 passed`
