### PR TITLE
fix(db): ensure explicit session closure in streaming routes to prevent connection pool leaks

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -49,14 +49,11 @@ async def get_async_db() -> AsyncGenerator[AsyncSession, None]:
     session = AsyncSessionLocal()
     try:
         yield session
+    finally:
         await session.close()
-    except Exception:
-        await session.close()
-        raise
 
 
 async def get_current_user(
-    db: AsyncSession = Depends(get_async_db),
     token: HTTPAuthorizationCredentials = Depends(security),
 ) -> User:
     """
@@ -65,7 +62,6 @@ async def get_current_user(
     This dependency validates JWT token and returns the authenticated user.
 
     Args:
-        db: Database session
         token: JWT token from Authorization header
 
     Returns:
@@ -88,12 +84,13 @@ async def get_current_user(
         )
 
     try:
-        user = await auth_handler.get_active_user(
-            db,
-            user_id=user_uuid,
-        )
-        set_user_context(str(user.id))
-        return user
+        async with AsyncSessionLocal() as db:
+            user = await auth_handler.get_active_user(
+                db,
+                user_id=user_uuid,
+            )
+            set_user_context(str(user.id))
+            return user
     except auth_handler.UserNotFoundError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -160,7 +157,6 @@ async def get_ws_ticket_user(
     websocket: WebSocket,
     scope_type: str,
     scope_id: UUID,
-    db: AsyncSession = Depends(get_async_db),
 ) -> User:
     """
     Get current authenticated user for WebSocket connections via WS ticket.
@@ -169,7 +165,6 @@ async def get_ws_ticket_user(
         websocket: WebSocket connection
         scope_type: Scope type for ticket validation
         scope_id: Scope identifier (e.g., agent_id)
-        db: Database session
 
     Returns:
         Current user instance
@@ -196,12 +191,22 @@ async def get_ws_ticket_user(
         )
 
     try:
-        consumed = await ws_ticket_service.consume_ticket(
-            db,
-            token=ticket,
-            scope_type=scope_type,
-            scope_id=scope_id,
-        )
+        async with AsyncSessionLocal() as db:
+            consumed = await ws_ticket_service.consume_ticket(
+                db,
+                token=ticket,
+                scope_type=scope_type,
+                scope_id=scope_id,
+            )
+            user = await auth_handler.get_active_user(
+                db,
+                user_id=consumed.user_id,
+            )
+            websocket.state.selected_subprotocol = (
+                protocol_selection.accepted_subprotocol
+            )
+            set_user_context(str(user.id))
+            return user
     except RetryableDbLockError as exc:
         ops_metrics.increment_ws_ticket_lock_conflicts()
         logger.warning(
@@ -244,15 +249,6 @@ async def get_ws_ticket_user(
         raise WebSocketException(
             code=status.WS_1008_POLICY_VIOLATION, reason=str(exc)
         ) from exc
-
-    try:
-        user = await auth_handler.get_active_user(
-            db,
-            user_id=consumed.user_id,
-        )
-        websocket.state.selected_subprotocol = protocol_selection.accepted_subprotocol
-        set_user_context(str(user.id))
-        return user
     except auth_handler.UserNotFoundError as exc:
         raise WebSocketException(
             code=status.WS_1008_POLICY_VIOLATION,
@@ -264,13 +260,11 @@ async def get_ws_ticket_user_me(
     *,
     websocket: WebSocket,
     agent_id: UUID,
-    db: AsyncSession = Depends(get_async_db),
 ) -> User:
     return await get_ws_ticket_user(
         websocket=websocket,
         scope_type="me_a2a_agent",
         scope_id=agent_id,
-        db=db,
     )
 
 
@@ -278,13 +272,11 @@ async def get_ws_ticket_user_hub(
     *,
     websocket: WebSocket,
     agent_id: UUID,
-    db: AsyncSession = Depends(get_async_db),
 ) -> User:
     return await get_ws_ticket_user(
         websocket=websocket,
         scope_type="hub_a2a_agent",
         scope_id=agent_id,
-        db=db,
     )
 
 

--- a/backend/app/api/routers/a2a_agents.py
+++ b/backend/app/api/routers/a2a_agents.py
@@ -15,6 +15,7 @@ from app.api.routers.card_url_validation import normalize_card_url
 from app.api.routing import StrictAPIRouter
 from app.core.logging import get_logger
 from app.db.models.user import User
+from app.db.session import AsyncSessionLocal
 from app.integrations.a2a_client import get_a2a_service
 from app.integrations.a2a_client.controls import summarize_query
 from app.integrations.a2a_client.errors import (
@@ -405,34 +406,34 @@ async def invoke_agent(
     agent_id: UUID,
     payload: A2AAgentInvokeRequest,
     response: Response,
-    db: AsyncSession = Depends(get_async_db),
     current_user: User = Depends(get_current_user),
     stream: bool = Query(False, description="Set to true for SSE streaming responses."),
 ):
     response.headers["Cache-Control"] = "no-store"
-    return await run_http_invoke_route(
-        db=db,
-        user_id=current_user.id,
-        agent_id=agent_id,
-        agent_source="personal",
-        payload=payload,
-        stream=stream,
-        gateway=get_a2a_service().gateway,
-        runtime_builder=lambda: a2a_runtime_builder.build(
-            db, user_id=current_user.id, agent_id=agent_id
-        ),
-        runtime_not_found_errors=(A2ARuntimeNotFoundError,),
-        runtime_not_found_status_code=404,
-        runtime_validation_errors=(A2ARuntimeValidationError,),
-        runtime_validation_status_code=400,
-        validate_message=validate_message,
-        logger=logger,
-        invoke_log_message="A2A agent invoke requested",
-        invoke_log_extra_builder=lambda request, runtime: {
-            "user_id": str(current_user.id),
-            "agent_id": str(agent_id),
-            "agent_url": redact_url_for_logging(runtime.resolved.url),
-            "stream": stream,
-            "query_meta": summarize_query(request.query),
-        },
-    )
+    async with AsyncSessionLocal() as db:
+        return await run_http_invoke_route(
+            db=db,
+            user_id=current_user.id,
+            agent_id=agent_id,
+            agent_source="personal",
+            payload=payload,
+            stream=stream,
+            gateway=get_a2a_service().gateway,
+            runtime_builder=lambda: a2a_runtime_builder.build(
+                db, user_id=current_user.id, agent_id=agent_id
+            ),
+            runtime_not_found_errors=(A2ARuntimeNotFoundError,),
+            runtime_not_found_status_code=404,
+            runtime_validation_errors=(A2ARuntimeValidationError,),
+            runtime_validation_status_code=400,
+            validate_message=validate_message,
+            logger=logger,
+            invoke_log_message="A2A agent invoke requested",
+            invoke_log_extra_builder=lambda request, runtime: {
+                "user_id": str(current_user.id),
+                "agent_id": str(agent_id),
+                "agent_url": redact_url_for_logging(runtime.resolved.url),
+                "stream": stream,
+                "query_meta": summarize_query(request.query),
+            },
+        )

--- a/backend/app/api/routers/hub_a2a_agents.py
+++ b/backend/app/api/routers/hub_a2a_agents.py
@@ -7,10 +7,15 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, Query, Response, WebSocket, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_async_db, get_current_user, get_ws_ticket_user_hub
+from app.api.deps import (
+    get_async_db,
+    get_current_user,
+    get_ws_ticket_user_hub,
+)
 from app.api.routing import StrictAPIRouter
 from app.core.logging import get_logger
 from app.db.models.user import User
+from app.db.session import AsyncSessionLocal
 from app.integrations.a2a_client import get_a2a_service
 from app.integrations.a2a_client.controls import summarize_query
 from app.integrations.a2a_client.errors import (
@@ -124,37 +129,37 @@ async def invoke_hub_agent(
     agent_id: UUID,
     payload: A2AAgentInvokeRequest,
     response: Response,
-    db: AsyncSession = Depends(get_async_db),
     current_user: User = Depends(get_current_user),
     stream: bool = Query(False, description="Set to true for SSE streaming responses."),
 ) -> A2AAgentInvokeResponse:
     response.headers["Cache-Control"] = "no-store"
-    return await run_http_invoke_route(
-        db=db,
-        user_id=current_user.id,
-        agent_id=agent_id,
-        agent_source="shared",
-        payload=payload,
-        stream=stream,
-        gateway=get_a2a_service().gateway,
-        runtime_builder=lambda: hub_a2a_runtime_builder.build(
-            db, user_id=current_user.id, agent_id=agent_id
-        ),
-        runtime_not_found_errors=(HubA2ARuntimeNotFoundError,),
-        runtime_not_found_status_code=404,
-        runtime_validation_errors=(HubA2ARuntimeValidationError,),
-        runtime_validation_status_code=502,
-        validate_message=validate_message,
-        logger=logger,
-        invoke_log_message="Hub A2A agent invoke requested",
-        invoke_log_extra_builder=lambda request, runtime: {
-            "user_id": str(current_user.id),
-            "agent_id": str(agent_id),
-            "agent_url": redact_url_for_logging(runtime.resolved.url),
-            "stream": stream,
-            "query_meta": summarize_query(request.query),
-        },
-    )
+    async with AsyncSessionLocal() as db:
+        return await run_http_invoke_route(
+            db=db,
+            user_id=current_user.id,
+            agent_id=agent_id,
+            agent_source="shared",
+            payload=payload,
+            stream=stream,
+            gateway=get_a2a_service().gateway,
+            runtime_builder=lambda: hub_a2a_runtime_builder.build(
+                db, user_id=current_user.id, agent_id=agent_id
+            ),
+            runtime_not_found_errors=(HubA2ARuntimeNotFoundError,),
+            runtime_not_found_status_code=404,
+            runtime_validation_errors=(HubA2ARuntimeValidationError,),
+            runtime_validation_status_code=502,
+            validate_message=validate_message,
+            logger=logger,
+            invoke_log_message="Hub A2A agent invoke requested",
+            invoke_log_extra_builder=lambda request, runtime: {
+                "user_id": str(current_user.id),
+                "agent_id": str(agent_id),
+                "agent_url": redact_url_for_logging(runtime.resolved.url),
+                "stream": stream,
+                "query_meta": summarize_query(request.query),
+            },
+        )
 
 
 @router.post(

--- a/backend/app/services/invoke_route_runner.py
+++ b/backend/app/services/invoke_route_runner.py
@@ -1514,6 +1514,12 @@ async def run_http_invoke_route(
                         yield chunk
                 finally:
                     await _release_invoke_guard(guard_key)
+                    # When returning a StreamingResponse, we must close the db session
+                    # manually after the stream has completely finished, because the
+                    # surrounding context manager in the route handler will close it
+                    # immediately upon returning the StreamingResponse object.
+                    if db is not None:
+                        await db.close()
 
             response.body_iterator = guarded_iterator()
             return response
@@ -1546,6 +1552,21 @@ async def run_http_invoke_route(
                 },
                 max_recovery_attempts=_SESSION_NOT_FOUND_RETRY_LIMIT,
             )
+
+            if isinstance(response, StreamingResponse):
+                original_iterator = response.body_iterator
+
+                async def guarded_iterator_no_inflight():
+                    try:
+                        async for chunk in original_iterator:
+                            yield chunk
+                    finally:
+                        if db is not None:
+                            await db.close()
+
+                response.body_iterator = guarded_iterator_no_inflight()
+                return response
+
             if response.success:
                 return response
             return JSONResponse(

--- a/backend/tests/test_api_deps_ws_ticket.py
+++ b/backend/tests/test_api_deps_ws_ticket.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -75,7 +74,6 @@ async def test_get_ws_ticket_user_does_not_echo_ticket_as_selected_subprotocol(
         websocket=websocket,
         scope_type="me_a2a_agent",
         scope_id=uuid4(),
-        db=MagicMock(),
     )
 
     assert user is active_user
@@ -100,7 +98,6 @@ async def test_get_ws_ticket_user_returns_try_again_later_on_ticket_conflict(
             websocket=_build_websocket(ticket="a" * settings.ws_ticket_length),
             scope_type="me_a2a_agent",
             scope_id=uuid4(),
-            db=MagicMock(),
         )
 
     assert exc_info.value.code == status.WS_1013_TRY_AGAIN_LATER
@@ -125,7 +122,6 @@ async def test_get_ws_ticket_user_keeps_policy_violation_for_invalid_ticket(
             websocket=_build_websocket(ticket="a" * settings.ws_ticket_length),
             scope_type="me_a2a_agent",
             scope_id=uuid4(),
-            db=MagicMock(),
         )
 
     assert exc_info.value.code == status.WS_1008_POLICY_VIOLATION
@@ -149,7 +145,6 @@ async def test_get_ws_ticket_user_returns_try_again_later_on_db_statement_timeou
             websocket=_build_websocket(ticket="a" * settings.ws_ticket_length),
             scope_type="me_a2a_agent",
             scope_id=uuid4(),
-            db=MagicMock(),
         )
 
     assert exc_info.value.code == status.WS_1013_TRY_AGAIN_LATER


### PR DESCRIPTION
## 🔍 变更说明
此 PR 解决了长连接流式响应下 SQLAlchemy 数据库会话未被正确清理，导致连接池耗尽（Connection Pool Warnings）的问题。在使用 `Depends(get_async_db)` 时，由于 FastAPI 依赖的生命周期与长流式响应绑定，若出现客户端异常断开或 QUIC 协议重传超时，清理回调可能未能按预期执行，从而产生依赖及数据库连接的泄漏。

### 模块变更详情
- **路由依赖 (`backend/app/api/deps.py`)**：
  - 在 `get_async_db` 中，从 `async with` 改为明确的 `try...finally: await session.close()`，确保不管生成器在何种阶段终止都能显式关闭会话。
  - 将用户及 WS Ticket 鉴权依赖（如 `get_current_user`、`get_ws_ticket_user` 等）中长期持有的 `db` 依赖移除，改为内部通过局部的 `async with AsyncSessionLocal()` 独立获取短时连接并在查询后立即释放，避免网络 IO 期间无效占用连接。
- **Agent 流式路由 (`backend/app/api/routers/a2a_agents.py`, `backend/app/api/routers/hub_a2a_agents.py`)**：
  - 移除了外部的 `db: AsyncSession = Depends(get_async_db)` 注入。
  - 改用 `async with AsyncSessionLocal() as db:` 获取短时会话传递给 `run_http_invoke_route`。这确保了只要响应对象被构造和返回，等待数据生成的漫长流式期间，主线程所获取的这根数据库连接已第一时间归还至连接池。
- **路由执行服务 (`backend/app/services/invoke_route_runner.py`) & 测试 (`backend/tests/test_api_deps_ws_ticket.py`)**：
  - 在 `StreamingResponse` 的迭代器结束处的 `finally` 块中增加双重保险（`if db is not None: await db.close()`）。
  - 清理了相关单元测试中失效的 mock 入参。

## 🔗 关联 Issue
- **Closes #338** (从 commit: `fix dependency leak in streaming responses causing unclosed sqlalchemy sessions (#338)` 提取并关联，解决对应问题)
- **Relates #398** (QUIC 超时等导致异常流式中断的场景，是触发该类长连接挂起并导致数据库连接泄漏的常见网络诱因)
