### PR TITLE
fix(sys): implement secure WebSocket subprotocol negotiation to prevent handshake failures

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -181,7 +181,8 @@ async def get_ws_ticket_user(
     # Extract the auth ticket from Sec-WebSocket-Protocol without treating it as
     # a negotiated application subprotocol.
     protocol_selection = _parse_ws_protocol_selection(
-        subprotocol_header=websocket.headers.get("sec-websocket-protocol")
+        subprotocol_header=websocket.headers.get("sec-websocket-protocol"),
+        allowed_subprotocols=("a2a-invoke-v1",),
     )
     ticket = protocol_selection.ticket
 

--- a/backend/tests/test_api_deps_ws_ticket.py
+++ b/backend/tests/test_api_deps_ws_ticket.py
@@ -52,7 +52,7 @@ def test_parse_ws_protocol_selection_accepts_only_allowlisted_subprotocol() -> N
 
 
 @pytest.mark.asyncio
-async def test_get_ws_ticket_user_does_not_echo_ticket_as_selected_subprotocol(
+async def test_get_ws_ticket_user_echoes_valid_subprotocol(
     monkeypatch,
 ) -> None:
     ticket = "a" * settings.ws_ticket_length
@@ -69,7 +69,7 @@ async def test_get_ws_ticket_user_does_not_echo_ticket_as_selected_subprotocol(
     monkeypatch.setattr(ws_ticket_service, "consume_ticket", _consume_ticket)
     monkeypatch.setattr(api_deps.auth_handler, "get_active_user", _get_active_user)
 
-    websocket = _build_websocket(ticket=ticket)
+    websocket = _build_websocket(ticket=f"a2a-invoke-v1, {ticket}")
     user = await get_ws_ticket_user(
         websocket=websocket,
         scope_type="me_a2a_agent",
@@ -77,7 +77,7 @@ async def test_get_ws_ticket_user_does_not_echo_ticket_as_selected_subprotocol(
     )
 
     assert user is active_user
-    assert getattr(websocket.state, "selected_subprotocol", None) is None
+    assert getattr(websocket.state, "selected_subprotocol", None) == "a2a-invoke-v1"
 
 
 @pytest.mark.asyncio

--- a/frontend/services/chatConnectionService.ts
+++ b/frontend/services/chatConnectionService.ts
@@ -268,7 +268,7 @@ class ChatConnectionService {
         let connectTimer: ReturnType<typeof setTimeout> | null = null;
         let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
-        const ws = new WebSocketCtor(wsUrl, [ticket.token]);
+        const ws = new WebSocketCtor(wsUrl, ["a2a-invoke-v1", ticket.token]);
         this.wsConnections.set(conversationId, ws);
 
         const cleanup = () => {


### PR DESCRIPTION
## 🔍 问题分析与最佳实践

在之前的 PR 中，为了避免将一次性的**鉴权凭证（WS Ticket）**当作协议明文在握手响应（HTTP 101）的 `Sec-WebSocket-Protocol` 中回传暴露，后端移除了默认的 Ticket 回显逻辑。
然而，根据 **[RFC 6455 规范](https://datatracker.ietf.org/doc/html/rfc6455#section-1.3)**：如果客户端（浏览器）请求了具体的子协议（前端 `new WebSocket(url, [ticket.token])`），服务器如果不回显合法的协议，浏览器引擎会以 `Error during WebSocket handshake` 为由，主动强制断开连接，从而引发全网的卡顿和标红报错。

为了彻底解决“既要浏览器连得上，又要不暴露鉴权数据”的死胡同，此 PR 在当前分支上实施了联合前、后端协议握手的最佳实践方案：

### 🛠️ 详细实施方案

1. **构建合法的虚拟应用子协议**
   在后端的解析逻辑中，显式声明后端支持并期望的安全协议名，命名为 `a2a-invoke-v1`。
2. **前端的双重 Header 策略**
   修改前端 WebSocket 实例化代码，从发送单一 Ticket，改为发送一个由真实协议和 Ticket 组成的数组：
   ```typescript
   // frontend/services/chatConnectionService.ts
   const ws = new WebSocketCtor(wsUrl, ["a2a-invoke-v1", ticket.token]);
   ```
   *此时浏览器的请求头为：`Sec-WebSocket-Protocol: a2a-invoke-v1, <ticket_token>`*
3. **后端的智能处理与剥离**
   修改后端 `backend/app/api/deps.py` 依赖逻辑：
   - 提取列表时，从候选中识别出真正用于 Auth 的 Ticket 供数据库消耗。
   - 识别出 `a2a-invoke-v1`，将其指定为 `protocol_selection.accepted_subprotocol`。
   - 在随后的 `websocket.accept(subprotocol="a2a-invoke-v1")` 响应中，**仅仅回显 `a2a-invoke-v1` 协议名**，不会在网络层任何地方重播、暴露敏感的 Token！

## 🧪 审查与风险评估
- **合规性**：完美迎合了严格的浏览器 RFC 标准要求。`a2a-invoke-v1` 被正常回显，浏览器通过校验，WebSocket 通信瞬间打通，红色报错消失。
- **安全性**：彻底堵住了之前 Issue #396 中发现的“鉴权票据外溢到网关日志/协商头”的漏洞。
- **关联测试**：已更新对应的 `test_api_deps_ws_ticket.py` 回归测试，确保只有显式传入的合法 Subprotocol 才能在 `selected_subprotocol` 中反映出来。所有测试运行通过。
