### PR TITLE
fix(backend): persist schedule conversation policy in CRUD flow (#403)

### DIFF
--- a/backend/app/api/routers/a2a_schedules.py
+++ b/backend/app/api/routers/a2a_schedules.py
@@ -163,6 +163,7 @@ async def create_schedule_task(
             cycle_type=payload.cycle_type,
             time_point=payload.time_point,
             enabled=payload.enabled,
+            conversation_policy=payload.conversation_policy,
         )
     )
     return _build_task_response(task, schedule_timezone=schedule_timezone)
@@ -235,6 +236,7 @@ async def patch_schedule_task(
             cycle_type=payload.cycle_type,
             time_point=payload.time_point,
             enabled=payload.enabled,
+            conversation_policy=payload.conversation_policy,
         )
     )
 

--- a/backend/app/services/a2a_schedule_service.py
+++ b/backend/app/services/a2a_schedule_service.py
@@ -135,6 +135,10 @@ class A2AScheduleService:
         A2AScheduleTask.CYCLE_INTERVAL,
         A2AScheduleTask.CYCLE_SEQUENTIAL,
     }
+    _allowed_conversation_policies = {
+        A2AScheduleTask.POLICY_NEW,
+        A2AScheduleTask.POLICY_REUSE,
+    }
 
     @staticmethod
     def _normalize_timezone_str(timezone_str: str | None) -> str:
@@ -262,6 +266,7 @@ class A2AScheduleService:
         cycle_type: str,
         time_point: Dict[str, Any],
         enabled: bool,
+        conversation_policy: str = A2AScheduleTask.POLICY_NEW,
     ) -> A2AScheduleTask:
         await self._apply_nowait_write_timeouts(db)
         await self._ensure_agent_owned(db, user_id=user_id, agent_id=agent_id)
@@ -274,6 +279,9 @@ class A2AScheduleService:
         normalized_name = self._normalize_name(name)
         normalized_prompt = self._normalize_prompt(prompt)
         normalized_cycle = self._normalize_cycle_type(cycle_type)
+        normalized_conversation_policy = self._normalize_conversation_policy(
+            conversation_policy
+        )
         timezone_value = self._normalize_timezone_str(timezone_str)
         normalized_point = self._normalize_time_point(
             cycle_type=normalized_cycle,
@@ -299,6 +307,7 @@ class A2AScheduleService:
             prompt=normalized_prompt,
             cycle_type=normalized_cycle,
             time_point=normalized_point,
+            conversation_policy=normalized_conversation_policy,
             enabled=enabled,
             next_run_at=next_run_at,
             last_run_status=A2AScheduleTask.STATUS_IDLE,
@@ -323,6 +332,7 @@ class A2AScheduleService:
         cycle_type: Optional[str] = None,
         time_point: Optional[Dict[str, Any]] = None,
         enabled: Optional[bool] = None,
+        conversation_policy: Optional[str] = None,
     ) -> A2AScheduleTask:
         await self._apply_nowait_write_timeouts(db)
         await self._lock_user_row_for_quota(db, user_id=user_id)
@@ -371,6 +381,11 @@ class A2AScheduleService:
 
         if enabled is not None:
             task.enabled = enabled
+
+        if conversation_policy is not None:
+            task.conversation_policy = self._normalize_conversation_policy(
+                conversation_policy
+            )
 
         should_recompute = False
         if task.enabled and (schedule_changed or enabled is True):
@@ -1075,6 +1090,14 @@ class A2AScheduleService:
         if normalized not in self._allowed_cycle_types:
             raise A2AScheduleValidationError(
                 "cycle_type must be one of daily, weekly, monthly, interval, sequential"
+            )
+        return normalized
+
+    def _normalize_conversation_policy(self, value: str) -> str:
+        normalized = (value or "").strip().lower()
+        if normalized not in self._allowed_conversation_policies:
+            raise A2AScheduleValidationError(
+                "conversation_policy must be one of new_each_run, reuse_single"
             )
         return normalized
 

--- a/backend/tests/test_a2a_schedule_routes.py
+++ b/backend/tests/test_a2a_schedule_routes.py
@@ -174,6 +174,52 @@ async def test_schedule_routes_crud_and_toggle(
         assert after_delete_resp.status_code == 404
 
 
+async def test_schedule_conversation_policy_persists_on_create_and_update(
+    async_db_session,
+    async_session_maker,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(async_db_session, user_id=user.id, suffix="policy")
+
+    async with create_test_client(
+        a2a_schedules.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        create_resp = await client.post(
+            "/me/a2a/schedules",
+            json={
+                "name": "Policy check",
+                "agent_id": str(agent.id),
+                "prompt": "Use policy",
+                "cycle_type": "daily",
+                "time_point": {"time": "08:30"},
+                "enabled": False,
+                "conversation_policy": "reuse_single",
+                "schedule_timezone": user.timezone or "UTC",
+            },
+        )
+        assert create_resp.status_code == 201
+        created = create_resp.json()
+        task_id = created["id"]
+        assert created["conversation_policy"] == "reuse_single"
+
+        get_created_resp = await client.get(f"/me/a2a/schedules/{task_id}")
+        assert get_created_resp.status_code == 200
+        assert get_created_resp.json()["conversation_policy"] == "reuse_single"
+
+        update_resp = await client.patch(
+            f"/me/a2a/schedules/{task_id}",
+            json={"conversation_policy": "new_each_run"},
+        )
+        assert update_resp.status_code == 200
+        assert update_resp.json()["conversation_policy"] == "new_each_run"
+
+        get_updated_resp = await client.get(f"/me/a2a/schedules/{task_id}")
+        assert get_updated_resp.status_code == 200
+        assert get_updated_resp.json()["conversation_policy"] == "new_each_run"
+
+
 async def test_schedule_create_rejects_unowned_agent(
     async_db_session,
     async_session_maker,


### PR DESCRIPTION
## 变更摘要
- 修复定时任务表单 `Session Policy` 保存后未持久化的问题，确保 `Reuse Single` / `New Each Run` 能正确保存与回显。

## 关联 Issues
- Closes #403
- 上下文参考：#338（仅背景信息，本 PR 不修改 #338 的执行清理逻辑）

## 按模块说明
### backend/app/api/routers/a2a_schedules.py
- 在创建与更新路由中补传 `payload.conversation_policy` 到 service，打通字段传递链路。

### backend/app/services/a2a_schedule_service.py
- `create_task` 新增 `conversation_policy` 参数并落库。
- `update_task` 新增 `conversation_policy` 可选更新。
- 新增 `_normalize_conversation_policy`，统一校验合法值 `new_each_run` / `reuse_single`，避免 service 直接调用时写入非法策略值。

### backend/tests/test_a2a_schedule_routes.py
- 新增回归测试：创建任务时设置 `reuse_single` 并校验 GET 回读。
- 更新任务为 `new_each_run` 后再次 GET 校验，确保更新持久化。

### 文档变更
- 无。本次仅后端逻辑修复与测试补充，不涉及对外接口契约变更。

## 验证证据
```bash
cd backend && uv run pre-commit run --files app/api/routers/a2a_schedules.py app/services/a2a_schedule_service.py tests/test_a2a_schedule_routes.py --config ../.pre-commit-config.yaml
# 关键结果：Passed

cd backend && uv run pytest tests/test_a2a_schedule_routes.py
# 关键结果：24 passed in 27.41s
```

## 风险与回滚
- 风险：
  - service 层新增 `conversation_policy` 显式校验后，非法值会变为明确验证错误，属于预期约束收敛。
- 回滚方案：
  - 回滚提交 `a7f96c7`。

## 检查清单
- [x] 已遵循 `AGENTS.md` 与仓库约定
- [x] 未引入 secrets
- [x] 无需新增文档（无接口契约变更）
