### PR TITLE
fix(frontend): remove inline-code box style in markdown renderer (#405)

### DIFF
--- a/frontend/components/chat/MarkdownRender.tsx
+++ b/frontend/components/chat/MarkdownRender.tsx
@@ -63,11 +63,9 @@ export function MarkdownRender({ content, isAgent }: MarkdownRenderProps) {
         fontSize: 16,
       },
       code_inline: {
-        backgroundColor: "rgba(0, 0, 0, 0.3)",
-        borderRadius: 4,
-        paddingHorizontal: 4,
         fontFamily: Platform.OS === "ios" ? "Courier" : "monospace",
-        color: "#F87171", // red-400 for visibility
+        color: "#F87171", // keep clear inline-code emphasis without a box
+        fontWeight: "600",
       },
       code_block: {
         backgroundColor: "rgba(0, 0, 0, 0.5)",


### PR DESCRIPTION
## 变更摘要
- 调整聊天 Markdown 渲染中的行内代码样式：移除方框视觉（背景/圆角/内边距），保留等宽字体与强调色，提升代码密集文本的连续阅读体验。

## 关联 Issues
- Closes #405

## 按模块说明
### frontend/components/chat/MarkdownRender.tsx
- `code_inline` 样式移除：`backgroundColor`、`borderRadius`、`paddingHorizontal`。
- `code_inline` 样式保留并增强：继续使用等宽字体，保留强调色，并新增 `fontWeight: "600"`，确保不出现“方框”但仍可一眼识别行内代码。
- 未改动 `code_block` / `fence` 代码块样式与复制逻辑。

### 文档变更
- 无文档文件变更。本次仅前端样式细节优化，不涉及接口契约或功能流程调整。

## 验证证据
```bash
cd frontend && npm run lint
# 结果：通过

cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types
# 结果：通过

cd frontend && npm test -- --findRelatedTests components/chat/MarkdownRender.tsx --maxWorkers=25% --coverage=false
# 结果：2 passed suites, 12 passed tests
```

## 风险与回滚
- 风险：
  - 仅为行内代码视觉样式变更，功能风险低；可能存在不同设备字体粗细呈现差异。
- 回滚方案：
  - 回滚提交 `d528371`。

## 检查清单
- [x] 已遵循 `AGENTS.md` 与仓库约定
- [x] 未引入 secrets
- [x] 无需新增文档（无契约变更）
