### PR TITLE
refactor(frontend): split apiRequest flow helpers without over-modularizing (#415)

### DIFF
--- a/frontend/lib/api/__tests__/client.test.ts
+++ b/frontend/lib/api/__tests__/client.test.ts
@@ -154,6 +154,60 @@ describe("api client auth refresh flow", () => {
     expect(useSessionStore.getState().token).toBe("old-token");
   });
 
+  it("does not trigger refresh flow for auth endpoints", async () => {
+    const { client, useSessionStore, resetAuthBoundState } = loadModules();
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse(401, { detail: "login_failed" }),
+    );
+
+    useSessionStore.setState({
+      token: "old-token",
+      authStatus: "authenticated",
+    });
+
+    await expect(
+      client.apiRequest<
+        { ok: boolean },
+        { username: string; password: string }
+      >("/auth/login", {
+        method: "POST",
+        body: { username: "u", password: "p" },
+      }),
+    ).rejects.toMatchObject({
+      status: 401,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(resetAuthBoundState).not.toHaveBeenCalled();
+  });
+
+  it("skips refresh flow when Authorization header is explicitly provided", async () => {
+    const { client, useSessionStore, resetAuthBoundState } = loadModules();
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse(401, { detail: "expired" }),
+    );
+
+    useSessionStore.setState({
+      token: "store-token",
+      authStatus: "authenticated",
+    });
+
+    await expect(
+      client.apiRequest<{ ok: boolean }>("/me/echo", {
+        headers: {
+          Authorization: "Bearer override-token",
+        },
+      }),
+    ).rejects.toMatchObject({
+      status: 401,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(resetAuthBoundState).not.toHaveBeenCalled();
+  });
+
   it("uses detail.message when backend error payload is an object", async () => {
     const { client, useSessionStore } = loadModules();
     const fetchMock = global.fetch as jest.Mock;

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -64,6 +64,8 @@ type ApiRequestOptions<Body> = {
   query?: Record<string, string | number | undefined | null>;
 };
 
+type JsonRecord = Record<string, unknown>;
+
 const buildUrl = (
   path: string,
   query?: ApiRequestOptions<unknown>["query"],
@@ -369,129 +371,181 @@ export const handleAuthExpiredOnce = (options?: {
   }
 };
 
-export async function apiRequest<Response, Body = unknown>(
+const shouldAttemptAuthRefresh = (
   path: string,
-  options: ApiRequestOptions<Body> = {},
-): Promise<Response> {
-  const { method = "GET", body, headers = {}, tokenOverride, query } = options;
-  const sessionSnapshot = useSessionStore.getState();
-  let token = tokenOverride ?? sessionSnapshot.token;
-  const requestAuthVersion = sessionSnapshot.authVersion;
-  const url = buildUrl(path, query);
-  const shouldAttemptRefresh =
-    !tokenOverride && !("Authorization" in headers) && !isAuthPath(path);
+  tokenOverride: string | undefined,
+  headers: Record<string, string>,
+): boolean =>
+  !tokenOverride && !("Authorization" in headers) && !isAuthPath(path);
 
-  const execute = async (accessToken: string | null) => {
-    return await fetch(url, {
-      method,
-      credentials: "include",
-      headers: {
-        "Content-Type": "application/json",
-        ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
-        ...headers,
-      },
-      body: body ? JSON.stringify(body) : undefined,
-    });
+const executeJsonRequest = async (
+  url: string,
+  method: HttpMethod,
+  body: unknown,
+  headers: Record<string, string>,
+  accessToken: string | null,
+): Promise<Response> => {
+  return await fetch(url, {
+    method,
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+};
+
+const parseApiErrorDetails = async (
+  response: Response,
+): Promise<{
+  message: string;
+  errorCode: string | null;
+  upstreamError: JsonRecord | null;
+}> => {
+  let details: ApiErrorResponse | undefined;
+  try {
+    details = await response.json();
+  } catch {
+    // Ignore invalid JSON
+  }
+
+  const errorBody = details?.detail || details?.message || details?.error;
+  const detailsRecord =
+    details && typeof details === "object" && !Array.isArray(details)
+      ? (details as JsonRecord)
+      : undefined;
+  const detailRecord =
+    details?.detail &&
+    typeof details.detail === "object" &&
+    !Array.isArray(details.detail)
+      ? (details.detail as JsonRecord)
+      : undefined;
+  const errorCode =
+    typeof detailsRecord?.error_code === "string"
+      ? detailsRecord.error_code
+      : typeof detailRecord?.error_code === "string"
+        ? detailRecord.error_code
+        : null;
+  const upstreamError =
+    detailRecord?.upstream_error &&
+    typeof detailRecord.upstream_error === "object" &&
+    !Array.isArray(detailRecord.upstream_error)
+      ? (detailRecord.upstream_error as JsonRecord)
+      : detailsRecord?.upstream_error &&
+          typeof detailsRecord.upstream_error === "object" &&
+          !Array.isArray(detailsRecord.upstream_error)
+        ? (detailsRecord.upstream_error as JsonRecord)
+        : null;
+  let message: string;
+
+  if (typeof errorBody === "string") {
+    message = errorBody;
+  } else if (Array.isArray(errorBody)) {
+    message = errorBody
+      .map((err) => {
+        const msg = err.msg || err.message || "Unknown error";
+        const loc = err.loc?.join(".") ?? "";
+        return loc ? `${loc}: ${msg}` : msg;
+      })
+      .join("; ");
+  } else if (errorBody && typeof errorBody === "object") {
+    const messageField =
+      "message" in errorBody &&
+      typeof (errorBody as { message?: unknown }).message === "string"
+        ? (errorBody as { message: string }).message.trim()
+        : "";
+    message = messageField || JSON.stringify(errorBody);
+  } else {
+    message = `Request failed (${response.status})`;
+  }
+
+  if (errorCode) {
+    message = `${message} [${errorCode}]`;
+  }
+
+  return {
+    message,
+    errorCode,
+    upstreamError,
   };
+};
 
-  if (shouldAttemptRefresh) {
+const executeRequestWithAuthRecovery = async (
+  path: string,
+  url: string,
+  method: HttpMethod,
+  body: unknown,
+  headers: Record<string, string>,
+  tokenOverride: string | undefined,
+): Promise<Response> => {
+  const sessionSnapshot = useSessionStore.getState();
+  const requestAuthVersion = sessionSnapshot.authVersion;
+  let token = tokenOverride ?? sessionSnapshot.token;
+  const canAutoRefresh = shouldAttemptAuthRefresh(path, tokenOverride, headers);
+
+  if (canAutoRefresh) {
     token = await ensureFreshAccessToken({
       expectedAuthVersion: requestAuthVersion,
     });
   }
 
-  let response = await execute(token);
-
-  if (isUnauthorizedStatusCode(response.status) && shouldAttemptRefresh) {
-    const refreshed = await refreshAccessToken({
-      force: true,
-      expectedAuthVersion: requestAuthVersion,
-    });
-    if (refreshed) {
-      applyRefreshedToken(refreshed, {
-        expectedAuthVersion: requestAuthVersion,
-      });
-      response = await execute(refreshed.accessToken);
-
-      if (isUnauthorizedStatusCode(response.status)) {
-        handleAuthExpiredOnce({
-          expectedAuthVersion: requestAuthVersion,
-        });
-        throw new AuthExpiredError();
-      }
-    } else {
-      handleAuthExpiredOnce({
-        expectedAuthVersion: requestAuthVersion,
-      });
-      throw new AuthExpiredError();
-    }
+  let response = await executeJsonRequest(url, method, body, headers, token);
+  if (!isUnauthorizedStatusCode(response.status) || !canAutoRefresh) {
+    return response;
   }
 
+  const refreshed = await refreshAccessToken({
+    force: true,
+    expectedAuthVersion: requestAuthVersion,
+  });
+  if (!refreshed) {
+    handleAuthExpiredOnce({
+      expectedAuthVersion: requestAuthVersion,
+    });
+    throw new AuthExpiredError();
+  }
+
+  applyRefreshedToken(refreshed, {
+    expectedAuthVersion: requestAuthVersion,
+  });
+  response = await executeJsonRequest(
+    url,
+    method,
+    body,
+    headers,
+    refreshed.accessToken,
+  );
+  if (isUnauthorizedStatusCode(response.status)) {
+    handleAuthExpiredOnce({
+      expectedAuthVersion: requestAuthVersion,
+    });
+    throw new AuthExpiredError();
+  }
+  return response;
+};
+
+export async function apiRequest<Response, Body = unknown>(
+  path: string,
+  options: ApiRequestOptions<Body> = {},
+): Promise<Response> {
+  const { method = "GET", body, headers = {}, tokenOverride, query } = options;
+  const url = buildUrl(path, query);
+  const response = await executeRequestWithAuthRecovery(
+    path,
+    url,
+    method,
+    body,
+    headers,
+    tokenOverride,
+  );
+
   if (!response.ok) {
-    let details: ApiErrorResponse | undefined;
-    try {
-      details = await response.json();
-    } catch {
-      // Ignore invalid JSON
-    }
-
-    const errorBody = details?.detail || details?.message || details?.error;
-    const detailsRecord =
-      details && typeof details === "object" && !Array.isArray(details)
-        ? (details as Record<string, unknown>)
-        : undefined;
-    const detailRecord =
-      details?.detail &&
-      typeof details.detail === "object" &&
-      !Array.isArray(details.detail)
-        ? (details.detail as Record<string, unknown>)
-        : undefined;
-    const errorCode =
-      typeof detailsRecord?.error_code === "string"
-        ? detailsRecord.error_code
-        : typeof detailRecord?.error_code === "string"
-          ? detailRecord.error_code
-          : null;
-    const upstreamError =
-      detailRecord?.upstream_error &&
-      typeof detailRecord.upstream_error === "object" &&
-      !Array.isArray(detailRecord.upstream_error)
-        ? (detailRecord.upstream_error as Record<string, unknown>)
-        : detailsRecord?.upstream_error &&
-            typeof detailsRecord.upstream_error === "object" &&
-            !Array.isArray(detailsRecord.upstream_error)
-          ? (detailsRecord.upstream_error as Record<string, unknown>)
-          : null;
-    let errorMessage: string;
-
-    if (typeof errorBody === "string") {
-      errorMessage = errorBody;
-    } else if (Array.isArray(errorBody)) {
-      errorMessage = errorBody
-        .map((err) => {
-          const msg = err.msg || err.message || "Unknown error";
-          const loc = err.loc?.join(".") ?? "";
-          return loc ? `${loc}: ${msg}` : msg;
-        })
-        .join("; ");
-    } else if (errorBody && typeof errorBody === "object") {
-      const messageField =
-        "message" in errorBody &&
-        typeof (errorBody as { message?: unknown }).message === "string"
-          ? (errorBody as { message: string }).message.trim()
-          : "";
-      errorMessage = messageField || JSON.stringify(errorBody);
-    } else {
-      errorMessage = `Request failed (${response.status})`;
-    }
-
-    if (errorCode) {
-      errorMessage = `${errorMessage} [${errorCode}]`;
-    }
-
-    throw new ApiRequestError(errorMessage, response.status, {
-      errorCode,
-      upstreamError,
+    const parsed = await parseApiErrorDetails(response);
+    throw new ApiRequestError(parsed.message, response.status, {
+      errorCode: parsed.errorCode,
+      upstreamError: parsed.upstreamError,
     });
   }
 


### PR DESCRIPTION
## 关联 Issues
- Closes #415

## 问题审查结论
- Issue 所述问题成立：`apiRequest` 存在多职责聚合，影响可维护性与可测试性。
- 方案取舍：未采用重型“拦截器体系/多模块大拆分”，避免超出当前项目复杂度；改为同文件内中等粒度职责拆分，降低心智负担并保持行为稳定。

## 模块变更
### 1) `frontend/lib/api/client.ts`
- 提取 `shouldAttemptAuthRefresh`：统一判定何时可进入自动 refresh 流程。
- 提取 `executeJsonRequest`：统一请求发送逻辑，减少重复。
- 提取 `parseApiErrorDetails`：集中错误体解析、`errorCode/upstreamError` 组装。
- 提取 `executeRequestWithAuthRecovery`：封装 401 -> force refresh -> retry 的恢复链路。
- 收敛 `apiRequest` 为编排层，保留原有外部行为与异常语义。

### 2) `frontend/lib/api/__tests__/client.test.ts`
- 新增“auth endpoint 不触发 refresh 流程”用例。
- 新增“显式 `Authorization` header 时跳过 refresh 流程”用例。
- 以边界测试确保拆分后行为不回归。

## 风险与评估
- 合理性：本次改动控制在函数内聚层级，不引入额外框架/拦截器抽象，符合“不过度拆解”目标。
- 稳健性：核心认证恢复语义不变，新增边界测试补强约束。
- 已知权衡：仍保留在单文件中，后续若认证策略继续扩展，再考虑进一步模块化。

## 验证记录
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/api/client.ts lib/api/__tests__/client.test.ts --maxWorkers=25%`
- 结果：全部通过（related tests: 23 suites / 98 tests）
