### PR TITLE
refactor(stream): enforce strict artifact-update contract and drop observability (#335)

### DIFF
--- a/backend/app/services/a2a_invoke_service.py
+++ b/backend/app/services/a2a_invoke_service.py
@@ -859,17 +859,11 @@ class A2AInvokeService:
         if not artifact:
             return None, "missing_artifact"
 
-        artifact_metadata = as_dict(artifact.get("metadata"))
-        opencode_metadata = as_dict(artifact_metadata.get("opencode"))
         block_type = cls._StreamTextAccumulator._extract_artifact_type(
             payload, artifact
         )
         if block_type is None:
             return None, "missing_or_invalid_block_type"
-        if cls._pick_non_empty_str(opencode_metadata, ("message_id",)) is None:
-            return None, "missing_message_id"
-        if cls._pick_non_empty_str(opencode_metadata, ("event_id",)) is None:
-            return None, "missing_event_id"
         if (
             cls._StreamTextAccumulator._extract_text_from_parts(artifact.get("parts"))
             == ""

--- a/backend/tests/test_a2a_invoke_service.py
+++ b/backend/tests/test_a2a_invoke_service.py
@@ -578,6 +578,53 @@ async def test_sse_warns_non_contract_artifact_update_once_per_reason(caplog):
 
 
 @pytest.mark.asyncio
+async def test_sse_warns_missing_text_parts_when_identity_ids_absent(caplog):
+    completed: list[str] = []
+
+    async def _on_complete(text: str):
+        completed.append(text)
+
+    caplog.set_level(logging.WARNING)
+    response = a2a_invoke_service.stream_sse(
+        gateway=_GatewayWithEvents(
+            [
+                {
+                    "kind": "artifact-update",
+                    "artifact": {
+                        "metadata": {
+                            "opencode": {
+                                "block_type": "text",
+                            }
+                        },
+                        "content": "legacy",
+                    },
+                }
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+        on_complete=_on_complete,
+    )
+    async for _ in response.body_iterator:
+        pass
+
+    assert completed == [""]
+    warning_records = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING"
+        and record.message == "Dropped non-contract artifact-update event"
+    ]
+    assert len(warning_records) == 1
+    assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
+
+
+@pytest.mark.asyncio
 async def test_sse_cache_replays_mutated_event_payload_from_on_event():
     from app.services.stream_cache.memory_cache import global_stream_cache
 


### PR DESCRIPTION
## 变更目标
围绕 #335，对 A2A 流式事件处理做“严格契约收敛 + 可观测性补强 + 热路径轻量优化”，降低历史兜底分支带来的语义漂移与运行期开销。

## 模块变更
### 1) Backend / Stream Contract（`backend/app/services/a2a_invoke_service.py`）
- 将 `_StreamTextAccumulator.consume` 统一为单一入口：仅消费 `extract_stream_chunk_from_serialized_event` 的解析结果。
- 移除累积器内部 legacy fallback（`artifact.append`、`last_chunk`、`delta/content/text`）。
- 收紧 stream identity 提取：
  - `seq` 仅认顶层 `seq`；
  - `task_id` 仅认顶层 `task_id` 或顶层 `task.id/task.task_id`。
- SSE / WS 的序号推进逻辑改为使用上述严格 `seq` 提取函数，避免宽扫描路径。

### 2) Backend / Observability（`backend/app/services/a2a_invoke_service.py`）
- 对“通过校验但不满足严格 chunk 契约”的 `artifact-update` 增加 warning。
- 增加 `drop_reason` 分类字段，并在**单次流会话内按原因去重**，避免日志刷屏。
- 覆盖 `stream_sse`、`stream_ws`、`consume_stream` 三条流式路径。

### 3) Backend / Performance（`backend/app/services/a2a_invoke_service.py`）
- 将 `artifact-update` 的严格解析与 `drop_reason` 判断合并为单次分析。
- 在流循环中复用同一份 `stream_block`：
  - 告警判定与文本累积共用结果；
  - 避免同一事件重复调用 chunk 解析函数。

### 4) Backend / Tests（`backend/tests/test_a2a_invoke_service.py`）
- 对齐严格契约测试样例（`opencode.message_id/event_id`）。
- 新增/更新回归：
  - legacy `artifact-update`（无 `parts`）不再参与最终文本聚合；
  - `seq` 仅从顶层字段读取；
  - 忽略 `status.task.id` 的 nested fallback；
  - 同一 `drop_reason` 仅 warning 一次（SSE / WS / consume 三路径）。

## 关联 Issue
- Closes #335


## 验证证据
### Backend scoped checks
1. `cd backend && uv run pytest tests/test_a2a_invoke_service.py tests/test_invoke_route_runner.py`
- 80 passed
2. `cd backend && uv run pre-commit run --files app/services/a2a_invoke_service.py tests/test_a2a_invoke_service.py --config ../.pre-commit-config.yaml`
- passed

## 风险与边界
- 收紧后将不再接受部分 legacy 非契约路径（如 nested `seq`、nested `status.task` fallback）。
- 新增 warning 逻辑会引入轻微运行期开销（仅事件级别）；本 PR 已通过“单次解析复用”降低该成本。

