### PR TITLE
fix(a2a-client): validate negotiated transport URL only (#427)

### DIFF
--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -460,11 +460,16 @@ class A2AClient:
 
         # Validate only the negotiated transport target so non-selected interface URLs
         # (for unsupported protocols like GRPC) do not block HTTP-capable agents.
+        selected_transport_label = (
+            selected_transport.value
+            if isinstance(selected_transport, TransportProtocol)
+            else str(selected_transport)
+        )
         try:
             validate_outbound_http_url(
                 selected_url,
                 allowed_hosts=a2a_proxy_service.get_effective_allowed_hosts_sync(),
-                purpose=f"Agent interface URL ({selected_transport})",
+                purpose=f"Agent interface URL ({selected_transport_label})",
             )
         except OutboundURLNotAllowedError as exc:
             raise A2AOutboundNotAllowedError(str(exc)) from exc
@@ -479,47 +484,52 @@ class A2AClient:
 
     def _resolve_negotiated_transport_target(
         self, card: AgentCard
-    ) -> tuple[str | None, str | None, list[str]]:
-        def _as_transport_label(value: TransportProtocol | str | None) -> str:
+    ) -> tuple[TransportProtocol | str | None, str | None, list[str]]:
+        def _as_display_label(value: TransportProtocol | str | None) -> str:
             if value is None:
                 return ""
             if isinstance(value, TransportProtocol):
-                return value.value.strip().upper()
-            return str(value).strip().upper()
+                return value.value
+            return str(value).strip()
 
-        supported_labels: list[str] = []
-        for value in self._supported_transports or [TransportProtocol.jsonrpc]:
-            label = _as_transport_label(value)
-            if label:
-                supported_labels.append(label)
+        client_set: list[TransportProtocol | str] = list(
+            self._supported_transports or [TransportProtocol.jsonrpc]
+        )
+        if not client_set:
+            client_set = [TransportProtocol.jsonrpc]
+
+        supported_labels: list[str] = [
+            label
+            for label in (_as_display_label(value) for value in client_set)
+            if label
+        ]
         if not supported_labels:
             supported_labels = [TransportProtocol.jsonrpc.value]
 
         preferred_transport = (
             getattr(card, "preferred_transport", None) or TransportProtocol.jsonrpc
         )
-        preferred_url = (getattr(card, "url", "") or "").strip()
+        preferred_url = getattr(card, "url", "") or ""
 
-        server_set: dict[str, str] = {}
-        preferred_label = _as_transport_label(preferred_transport)
-        if preferred_label and preferred_url:
-            server_set[preferred_label] = preferred_url
+        server_set: dict[TransportProtocol | str, str] = {}
+        if preferred_transport and preferred_url:
+            server_set[preferred_transport] = preferred_url
 
         for iface in getattr(card, "additional_interfaces", None) or []:
-            transport = _as_transport_label(getattr(iface, "transport", None))
-            interface_url = (getattr(iface, "url", "") or "").strip()
+            transport = getattr(iface, "transport", None)
+            interface_url = getattr(iface, "url", "") or ""
             if transport and interface_url:
                 server_set[transport] = interface_url
 
         if self._use_client_preference:
-            for transport in supported_labels:
+            for transport in client_set:
                 url = server_set.get(transport)
                 if url:
                     return transport, url, supported_labels
             return None, None, supported_labels
 
         for transport, url in server_set.items():
-            if transport in supported_labels:
+            if transport in client_set:
                 return transport, url, supported_labels
         return None, None, supported_labels
 

--- a/backend/tests/test_a2a_client.py
+++ b/backend/tests/test_a2a_client.py
@@ -410,3 +410,60 @@ async def test_get_agent_card_blocks_selected_interface_not_in_allowlist(
 
     with pytest.raises(A2AOutboundNotAllowedError):
         await a2a_client.get_agent_card()
+
+
+@pytest.mark.asyncio
+async def test_get_agent_card_uses_sdk_exact_transport_matching_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResolver:
+        base_url = "http://example-agent.internal:24020"
+        agent_card_path = ".well-known/agent-card.json"
+
+        def __init__(self, card_payload: SimpleNamespace) -> None:
+            self._card_payload = card_payload
+
+        async def get_agent_card(self, **_kwargs):
+            return self._card_payload
+
+    card = SimpleNamespace(
+        name="Gateway",
+        preferred_transport="JSONRPC",
+        url="http://example-agent.internal:24020/jsonrpc",
+        additional_interfaces=[],
+    )
+    validate_calls: list[str] = []
+
+    def fake_validate_outbound_http_url(
+        url: str,
+        *,
+        allowed_hosts,
+        purpose: str = "outbound HTTP request",
+    ) -> str:
+        validate_calls.append(url)
+        return url
+
+    monkeypatch.setattr(
+        client_module,
+        "validate_outbound_http_url",
+        fake_validate_outbound_http_url,
+    )
+    monkeypatch.setattr(
+        client_module.a2a_proxy_service,
+        "get_effective_allowed_hosts_sync",
+        lambda: ["example-agent.internal:24020"],
+    )
+
+    # Non-standard client transport label should not be normalized by pre-check.
+    a2a_client = A2AClient(
+        "http://example-agent.internal:24020",
+        supported_transports=[" jsonrpc "],
+    )
+    a2a_client._get_http_client = AsyncMock(return_value=Mock())
+    a2a_client._build_card_resolver = Mock(return_value=FakeResolver(card))
+
+    with pytest.raises(A2AAgentUnavailableError, match="no compatible transports"):
+        await a2a_client.get_agent_card()
+
+    # Only the card URL is validated because no compatible transport is negotiated.
+    assert validate_calls == ["http://example-agent.internal:24020"]


### PR DESCRIPTION
Closes #427
Related #9

## 变更概览
本 PR 修复 A2A Agent Card 在多接口场景下的出站 URL 校验策略，避免因未被选中的非 HTTP(S) 接口（如 `grpc://`）导致整体调用误阻断；并根据审查意见进一步收敛实现冗余。

## 模块一：Backend / A2A Client (`backend/app/integrations/a2a_client/client.py`)
### 改动内容
- 将 Agent Card 校验策略从“全量校验 `additional_interfaces`”调整为“仅校验协商后会被实际使用的 transport URL”。
- 当客户端与 Agent Card 不存在兼容 transport 时，提前抛出 `A2AAgentUnavailableError`，错误信息为 `no compatible transports` 语义。
- 根据审查意见收敛冗余代码：
  - 去除多余 helper（`_normalize_transport_label`、`_supported_transport_labels`）。
  - 将 transport 归一化与支持集整理内聚到 `_resolve_negotiated_transport_target` 单一入口。

### 设计意图
- 保持安全基线：实际被选中的 HTTP(S) 目标仍执行 allowlist 与 URL 安全校验。
- 降低误阻断：未选中的接口（例如 GRPC）不再触发当前 HTTP 校验器的一票否决。
- 降低维护风险：减少重复 helper，提升协商逻辑可读性和可维护性。

## 模块二：Backend / Tests (`backend/tests/test_a2a_client.py`)
### 新增用例
- `test_get_agent_card_ignores_non_selected_non_http_interfaces`
  - 验证存在 `grpc://` 非选中接口时，不阻断 HTTP 可用路径。
- `test_get_agent_card_raises_when_no_compatible_transport`
  - 验证仅有不兼容 transport 时，返回“无兼容 transport”错误语义。
- `test_get_agent_card_honors_client_preference_transport_order`
  - 覆盖 `use_client_preference=True` 分支，验证客户端偏好顺序可正确选中 JSONRPC 接口。

## 验证记录（低负载串行）
1. `cd backend && uv run pre-commit run --files app/integrations/a2a_client/client.py tests/test_a2a_client.py --config ../.pre-commit-config.yaml`
   - 结果：Passed
2. `cd backend && uv run pytest tests/test_a2a_client.py`
   - 结果：`12 passed in 0.54s`

## 风险与边界
- 当前实现聚焦 HTTP/JSONRPC 客户端能力；若未来启用 GRPC transport，仍需引入与协议匹配的出站安全校验策略（而非复用 HTTP 校验器）。
- 本 PR 不涉及前端、数据库或配置结构变更。
