### PR TITLE
fix(backend): rebuild a2a schedule consistency model (#395)

### DIFF
--- a/backend/alembic/versions/20260311_1215_f0d714e35080_add_pending_status_to_a2a_schedule_.py
+++ b/backend/alembic/versions/20260311_1215_f0d714e35080_add_pending_status_to_a2a_schedule_.py
@@ -5,6 +5,11 @@ Revises: r202603031200
 Create Date: 2026-03-11 12:15:02.113820
 
 """
+
+from __future__ import annotations
+
+import os
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -15,6 +20,8 @@ down_revision = 'r202603031200'
 branch_labels = None
 depends_on = None
 
+SCHEMA_NAME = os.getenv("SCHEMA_NAME", "a2a_client_hub_schema")
+
 
 def upgrade() -> None:
     # Adding pending status is just a string update (since we use VARCHAR, not strict ENUM).
@@ -23,14 +30,14 @@ def upgrade() -> None:
         "ix_a2a_schedule_executions_queue_poll",
         "a2a_schedule_executions",
         ["status", "scheduled_for"],
-        schema="a2a",
+        schema=SCHEMA_NAME,
     )
     op.create_index(
         "uq_a2a_schedule_executions_active_task",
         "a2a_schedule_executions",
         ["task_id"],
         unique=True,
-        schema="a2a",
+        schema=SCHEMA_NAME,
         postgresql_where=sa.text("status IN ('pending', 'running')"),
     )
 
@@ -39,10 +46,10 @@ def downgrade() -> None:
     op.drop_index(
         "uq_a2a_schedule_executions_active_task",
         table_name="a2a_schedule_executions",
-        schema="a2a",
+        schema=SCHEMA_NAME,
     )
     op.drop_index(
         "ix_a2a_schedule_executions_queue_poll",
         table_name="a2a_schedule_executions",
-        schema="a2a",
+        schema=SCHEMA_NAME,
     )

--- a/backend/alembic/versions/20260312_1400_4b6c6e0d8a2f_shift_schedule_running_truth_to_execution.py
+++ b/backend/alembic/versions/20260312_1400_4b6c6e0d8a2f_shift_schedule_running_truth_to_execution.py
@@ -1,0 +1,184 @@
+"""Shift schedule running truth to executions and drop task run-state columns.
+
+Revision ID: 4b6c6e0d8a2f
+Revises: f0d714e35080
+Create Date: 2026-03-12 14:00:00.000000
+"""
+
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4b6c6e0d8a2f"  # pragma: allowlist secret
+down_revision = "f0d714e35080"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+SCHEMA_NAME = os.getenv("SCHEMA_NAME", "a2a_client_hub_schema")
+
+
+def _legacy_running_projection_count() -> int:
+    bind = op.get_bind()
+    return int(
+        bind.execute(
+            sa.text(
+                f"""
+                SELECT count(*)
+                FROM {SCHEMA_NAME}.a2a_schedule_tasks
+                WHERE current_run_id IS NOT NULL
+                   OR running_started_at IS NOT NULL
+                   OR last_heartbeat_at IS NOT NULL
+                   OR last_run_status = 'running'
+                """
+            )
+        ).scalar_one()
+    )
+
+
+def upgrade() -> None:
+    if _legacy_running_projection_count() > 0:
+        raise RuntimeError(
+            "Legacy schedule task running-state columns are still populated. "
+            "Run `uv run python scripts/backfill_schedule_execution_running_truth.py "
+            "--apply` before applying revision 4b6c6e0d8a2f."
+        )
+
+    op.add_column(
+        "a2a_schedule_executions",
+        sa.Column(
+            "last_heartbeat_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Most recent heartbeat observed while execution is running",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.alter_column(
+        "a2a_schedule_executions",
+        "started_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=True,
+        schema=SCHEMA_NAME,
+    )
+    op.alter_column(
+        "a2a_schedule_executions",
+        "status",
+        existing_type=sa.String(length=32),
+        server_default=None,
+        schema=SCHEMA_NAME,
+    )
+
+    op.drop_constraint(
+        "ck_a2a_schedule_tasks_current_run_requires_running",
+        "a2a_schedule_tasks",
+        type_="check",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_constraint(
+        "ck_a2a_schedule_tasks_running_requires_fields",
+        "a2a_schedule_tasks",
+        type_="check",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_a2a_schedule_tasks_running_agent",
+        table_name="a2a_schedule_tasks",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_a2a_schedule_tasks_running_global",
+        table_name="a2a_schedule_tasks",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_column("a2a_schedule_tasks", "last_heartbeat_at", schema=SCHEMA_NAME)
+    op.drop_column("a2a_schedule_tasks", "running_started_at", schema=SCHEMA_NAME)
+    op.drop_column("a2a_schedule_tasks", "current_run_id", schema=SCHEMA_NAME)
+
+
+def downgrade() -> None:
+    op.add_column(
+        "a2a_schedule_tasks",
+        sa.Column(
+            "current_run_id",
+            sa.UUID(),
+            nullable=True,
+            comment="Identifier of the currently running execution attempt",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.add_column(
+        "a2a_schedule_tasks",
+        sa.Column(
+            "running_started_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Timestamp when the current running execution was claimed",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.add_column(
+        "a2a_schedule_tasks",
+        sa.Column(
+            "last_heartbeat_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="Most recent heartbeat timestamp for the current running execution",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_a2a_schedule_tasks_running_global",
+        "a2a_schedule_tasks",
+        ["last_run_status", "current_run_id", "deleted_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_a2a_schedule_tasks_running_agent",
+        "a2a_schedule_tasks",
+        ["agent_id", "last_run_status", "current_run_id", "deleted_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_check_constraint(
+        "ck_a2a_schedule_tasks_running_requires_fields",
+        "a2a_schedule_tasks",
+        "(last_run_status <> 'running') OR "
+        "(current_run_id IS NOT NULL AND running_started_at IS NOT NULL)",
+        schema=SCHEMA_NAME,
+    )
+    op.create_check_constraint(
+        "ck_a2a_schedule_tasks_current_run_requires_running",
+        "a2a_schedule_tasks",
+        "(current_run_id IS NULL) OR (last_run_status = 'running')",
+        schema=SCHEMA_NAME,
+    )
+
+    op.execute(
+        sa.text(
+            f"""
+            UPDATE {SCHEMA_NAME}.a2a_schedule_executions
+            SET started_at = scheduled_for
+            WHERE started_at IS NULL
+            """
+        )
+    )
+    op.alter_column(
+        "a2a_schedule_executions",
+        "status",
+        existing_type=sa.String(length=32),
+        server_default="running",
+        schema=SCHEMA_NAME,
+    )
+    op.alter_column(
+        "a2a_schedule_executions",
+        "started_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_column("a2a_schedule_executions", "last_heartbeat_at", schema=SCHEMA_NAME)

--- a/backend/app/api/routers/a2a_schedules.py
+++ b/backend/app/api/routers/a2a_schedules.py
@@ -96,6 +96,7 @@ def _build_task_response(
         conversation_id=task.conversation_id,
         conversation_policy=task.conversation_policy,
         enabled=bool(task.enabled),
+        is_running=bool(getattr(task, "is_running", False)),
         next_run_at_utc=task.next_run_at,
         next_run_at_local=a2a_schedule_service.format_local_datetime(
             task.next_run_at,

--- a/backend/app/db/models/a2a_schedule_execution.py
+++ b/backend/app/db/models/a2a_schedule_execution.py
@@ -73,8 +73,13 @@ class A2AScheduleExecution(Base, TimestampMixin, UserOwnedMixin):
     )
     started_at = Column(
         DateTime(timezone=True),
-        nullable=False,
-        comment="Execution start time",
+        nullable=True,
+        comment="Execution start time; NULL while still pending in the durable queue",
+    )
+    last_heartbeat_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Most recent heartbeat observed while execution is running",
     )
     finished_at = Column(
         DateTime(timezone=True),
@@ -84,9 +89,7 @@ class A2AScheduleExecution(Base, TimestampMixin, UserOwnedMixin):
     status = Column(
         String(32),
         nullable=False,
-        default=STATUS_RUNNING,
-        server_default=STATUS_RUNNING,
-        comment="Execution status",
+        comment="Execution lifecycle status",
     )
     error_message = Column(
         Text,

--- a/backend/app/db/models/a2a_schedule_task.py
+++ b/backend/app/db/models/a2a_schedule_task.py
@@ -37,19 +37,6 @@ class A2AScheduleTask(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
             "next_run_at",
         ),
         Index(
-            "ix_a2a_schedule_tasks_running_global",
-            "last_run_status",
-            "current_run_id",
-            "deleted_at",
-        ),
-        Index(
-            "ix_a2a_schedule_tasks_running_agent",
-            "agent_id",
-            "last_run_status",
-            "current_run_id",
-            "deleted_at",
-        ),
-        Index(
             "ix_a2a_schedule_tasks_user_id_created_at",
             "user_id",
             "created_at",
@@ -58,7 +45,6 @@ class A2AScheduleTask(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
     )
 
     STATUS_IDLE: ClassVar[str] = "idle"
-    STATUS_RUNNING: ClassVar[str] = "running"
     STATUS_SUCCESS: ClassVar[str] = "success"
     STATUS_FAILED: ClassVar[str] = "failed"
 
@@ -142,27 +128,12 @@ class A2AScheduleTask(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
         nullable=False,
         default=STATUS_IDLE,
         server_default=STATUS_IDLE,
-        comment="Status of the most recent execution",
-    )
-    current_run_id = Column(
-        UUID(as_uuid=True),
-        nullable=True,
-        comment="Identifier of the currently running execution attempt",
-    )
-    running_started_at = Column(
-        DateTime(timezone=True),
-        nullable=True,
-        comment="Timestamp when the current running execution was claimed",
+        comment="Terminal status of the most recent completed execution",
     )
     delete_requested_at = Column(
         DateTime(timezone=True),
         nullable=True,
         comment="Timestamp when user requested deletion while run is still in progress",
-    )
-    last_heartbeat_at = Column(
-        DateTime(timezone=True),
-        nullable=True,
-        comment="Most recent heartbeat timestamp for the current running execution",
     )
 
 

--- a/backend/app/schemas/a2a_schedule.py
+++ b/backend/app/schemas/a2a_schedule.py
@@ -17,7 +17,7 @@ A2AScheduleCycleType = Literal[
     "interval",
     "sequential",
 ]
-A2AScheduleRunStatus = Literal["idle", "running", "success", "failed"]
+A2AScheduleRunStatus = Literal["idle", "success", "failed"]
 A2AScheduleExecutionStatus = Literal["pending", "running", "success", "failed"]
 A2AScheduleConversationPolicy = Literal["new_each_run", "reuse_single"]
 
@@ -63,6 +63,7 @@ class A2AScheduleTaskResponse(A2AScheduleTaskBase):
     conversation_id: Optional[UUID] = None
     conversation_policy: A2AScheduleConversationPolicy
     enabled: bool
+    is_running: bool = False
     next_run_at_utc: Optional[datetime] = None
     next_run_at_local: Optional[str] = None
     last_run_at: Optional[datetime] = None
@@ -91,8 +92,9 @@ class A2AScheduleExecutionResponse(BaseModel):
     task_id: UUID
     status: A2AScheduleExecutionStatus
     scheduled_for: datetime
-    started_at: datetime
+    started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
+    last_heartbeat_at: Optional[datetime] = None
     error_message: Optional[str] = None
     response_content: Optional[str] = None
     conversation_id: Optional[UUID] = None

--- a/backend/app/services/a2a_schedule_job.py
+++ b/backend/app/services/a2a_schedule_job.py
@@ -120,14 +120,13 @@ async def _touch_schedule_run_heartbeat(*, claim: ClaimedA2AScheduleTask) -> boo
             statement_timeout_ms=_HEARTBEAT_STATEMENT_TIMEOUT_MS,
         )
         stmt = (
-            update(A2AScheduleTask)
+            update(A2AScheduleExecution)
             .where(
                 and_(
-                    A2AScheduleTask.id == claim.task_id,
-                    A2AScheduleTask.user_id == claim.user_id,
-                    A2AScheduleTask.deleted_at.is_(None),
-                    A2AScheduleTask.last_run_status == A2AScheduleTask.STATUS_RUNNING,
-                    A2AScheduleTask.current_run_id == claim.run_id,
+                    A2AScheduleExecution.task_id == claim.task_id,
+                    A2AScheduleExecution.user_id == claim.user_id,
+                    A2AScheduleExecution.run_id == claim.run_id,
+                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
                 )
             )
             .values(last_heartbeat_at=observed_at)
@@ -328,14 +327,34 @@ async def _execute_claimed_task(*, claim: ClaimedA2AScheduleTask) -> None:
             )
         )
         task = await db.scalar(stmt)
-        if task is None:
-            return
-        if task.current_run_id != claim.run_id:
+        execution = await db.scalar(
+            select(A2AScheduleExecution)
+            .where(
+                and_(
+                    A2AScheduleExecution.task_id == claim.task_id,
+                    A2AScheduleExecution.user_id == claim.user_id,
+                    A2AScheduleExecution.run_id == claim.run_id,
+                )
+            )
+            .limit(1)
+        )
+        if task is None or execution is None:
             logger.info(
-                "Skip stale schedule claim task=%s run_id=%s current_run_id=%s",
+                "Skip stale schedule claim task=%s run_id=%s because task or execution disappeared",
+                claim.task_id,
+                claim.run_id,
+                extra={
+                    "schedule_task_id": str(claim.task_id),
+                    "run_id": str(claim.run_id),
+                    "phase": "claim",
+                },
+            )
+            return
+        if execution.status != A2AScheduleExecution.STATUS_RUNNING:
+            logger.info(
+                "Skip stale schedule claim task=%s run_id=%s because execution is no longer running",
                 task.id,
                 claim.run_id,
-                task.current_run_id,
                 extra={
                     "schedule_task_id": str(task.id),
                     "run_id": str(claim.run_id),
@@ -344,53 +363,40 @@ async def _execute_claimed_task(*, claim: ClaimedA2AScheduleTask) -> None:
             )
             return
         if not task.enabled:
-            if task.last_run_status == A2AScheduleTask.STATUS_RUNNING:
-                finished_at = utc_now()
-                failure_message = "Task disabled or deleted before execution started"
-                try:
-                    finalized = await a2a_schedule_service.finalize_task_run(
-                        db,
-                        task_id=task.id,
-                        user_id=task.user_id,
-                        run_id=claim.run_id,
-                        final_status=A2AScheduleTask.STATUS_FAILED,
-                        finished_at=finished_at,
-                        conversation_id=task.conversation_id,
-                        response_content=failure_message,
-                        error_message=failure_message,
-                    )
-                except A2AScheduleConflictError:
-                    ops_metrics.increment_schedule_finalize_lock_conflicts()
-                    logger.warning(
-                        "Skip disabled-task finalize due to lock contention task=%s run_id=%s",
-                        task.id,
-                        claim.run_id,
-                        extra={
-                            "schedule_task_id": str(task.id),
-                            "run_id": str(claim.run_id),
-                            "phase": "finalize",
-                            "finalize_conflict": True,
-                        },
-                    )
-                    await rollback_safely(db)
-                    return
-                if finalized:
-                    await commit_safely(db)
-                else:
-                    await rollback_safely(db)
-            return
-
-        execution = await db.scalar(
-            select(A2AScheduleExecution)
-            .where(
-                and_(
-                    A2AScheduleExecution.task_id == task.id,
-                    A2AScheduleExecution.user_id == task.user_id,
-                    A2AScheduleExecution.run_id == claim.run_id,
+            finished_at = utc_now()
+            failure_message = "Task disabled or deleted before execution started"
+            try:
+                finalized = await a2a_schedule_service.finalize_task_run(
+                    db,
+                    task_id=task.id,
+                    user_id=task.user_id,
+                    run_id=claim.run_id,
+                    final_status=A2AScheduleTask.STATUS_FAILED,
+                    finished_at=finished_at,
+                    conversation_id=task.conversation_id,
+                    response_content=failure_message,
+                    error_message=failure_message,
                 )
-            )
-            .limit(1)
-        )
+            except A2AScheduleConflictError:
+                ops_metrics.increment_schedule_finalize_lock_conflicts()
+                logger.warning(
+                    "Skip disabled-task finalize due to lock contention task=%s run_id=%s",
+                    task.id,
+                    claim.run_id,
+                    extra={
+                        "schedule_task_id": str(task.id),
+                        "run_id": str(claim.run_id),
+                        "phase": "finalize",
+                        "finalize_conflict": True,
+                    },
+                )
+                await rollback_safely(db)
+                return
+            if finalized:
+                await commit_safely(db)
+            else:
+                await rollback_safely(db)
+            return
 
         heartbeat_stop_event = asyncio.Event()
         heartbeat_task: asyncio.Task[None] | None = None

--- a/backend/app/services/a2a_schedule_service.py
+++ b/backend/app/services/a2a_schedule_service.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Optional, TypeVar
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, func, or_, select
-from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -215,6 +214,70 @@ class A2AScheduleService:
             raise A2AScheduleNotFoundError("Schedule task not found")
         return task
 
+    async def _get_running_execution(
+        self,
+        db: AsyncSession,
+        *,
+        task_id: UUID,
+        user_id: UUID,
+        for_update: bool = False,
+    ) -> A2AScheduleExecution | None:
+        stmt = (
+            select(A2AScheduleExecution)
+            .where(
+                and_(
+                    A2AScheduleExecution.task_id == task_id,
+                    A2AScheduleExecution.user_id == user_id,
+                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
+                )
+            )
+            .order_by(A2AScheduleExecution.id.asc())
+            .limit(1)
+        )
+        if for_update:
+            stmt = stmt.with_for_update(nowait=True)
+        return await db.scalar(stmt)
+
+    async def _set_task_running_projection(
+        self,
+        db: AsyncSession,
+        *,
+        task: A2AScheduleTask,
+    ) -> A2AScheduleTask:
+        running_execution = await self._get_running_execution(
+            db,
+            task_id=task.id,
+            user_id=task.user_id,
+        )
+        setattr(task, "is_running", running_execution is not None)
+        return task
+
+    async def _set_tasks_running_projection(
+        self,
+        db: AsyncSession,
+        *,
+        tasks: list[A2AScheduleTask],
+    ) -> None:
+        if not tasks:
+            return
+
+        task_ids = [task.id for task in tasks]
+        running_task_ids = set(
+            (
+                await db.scalars(
+                    select(A2AScheduleExecution.task_id)
+                    .where(
+                        A2AScheduleExecution.task_id.in_(task_ids),
+                        A2AScheduleExecution.status
+                        == A2AScheduleExecution.STATUS_RUNNING,
+                    )
+                    .distinct()
+                )
+            ).all()
+        )
+        for task in tasks:
+            setattr(task, "is_running", task.id in running_task_ids)
+
     @_map_retryable_db_errors("Schedule task list")
     async def list_tasks(
         self,
@@ -238,6 +301,7 @@ class A2AScheduleService:
         )
         rows = await db.execute(stmt)
         items = list(rows.scalars().all())
+        await self._set_tasks_running_projection(db, tasks=items)
 
         count_stmt = select(func.count(A2AScheduleTask.id)).where(
             A2AScheduleTask.user_id == user_id,
@@ -255,7 +319,8 @@ class A2AScheduleService:
         user_id: UUID,
         task_id: UUID,
     ) -> A2AScheduleTask:
-        return await self._get_task(db, user_id=user_id, task_id=task_id)
+        task = await self._get_task(db, user_id=user_id, task_id=task_id)
+        return await self._set_task_running_projection(db, task=task)
 
     @_map_retryable_db_errors("Schedule task creation")
     async def create_task(
@@ -320,6 +385,7 @@ class A2AScheduleService:
         db.add(task)
         await commit_safely(db)
         await db.refresh(task)
+        setattr(task, "is_running", False)
         return task
 
     @_map_retryable_db_errors("Schedule task update")
@@ -344,7 +410,14 @@ class A2AScheduleService:
         task = await self._get_task_for_update(db, user_id=user_id, task_id=task_id)
         timezone_value = self._normalize_timezone_str(timezone_str)
 
-        if task.last_run_status == A2AScheduleTask.STATUS_RUNNING:
+        if (
+            await self._get_running_execution(
+                db,
+                task_id=task.id,
+                user_id=task.user_id,
+            )
+            is not None
+        ):
             raise A2AScheduleConflictError(
                 "Task is currently running and cannot be edited."
             )
@@ -409,6 +482,7 @@ class A2AScheduleService:
 
         await commit_safely(db)
         await db.refresh(task)
+        setattr(task, "is_running", False)
         return task
 
     @_map_retryable_db_errors("Schedule task toggle")
@@ -445,7 +519,7 @@ class A2AScheduleService:
 
         await commit_safely(db)
         await db.refresh(task)
-        return task
+        return await self._set_task_running_projection(db, task=task)
 
     @_map_retryable_db_errors("Schedule task deletion")
     async def delete_task(
@@ -457,10 +531,12 @@ class A2AScheduleService:
     ) -> None:
         await self._apply_nowait_write_timeouts(db)
         task = await self._get_task_for_update(db, user_id=user_id, task_id=task_id)
-        if (
-            task.last_run_status == A2AScheduleTask.STATUS_RUNNING
-            and task.current_run_id is not None
-        ):
+        running_execution = await self._get_running_execution(
+            db,
+            task_id=task.id,
+            user_id=task.user_id,
+        )
+        if running_execution is not None:
             # Keep the row alive until the current run reaches a terminal status.
             task.delete_requested_at = utc_now()
             task.enabled = False
@@ -506,53 +582,25 @@ class A2AScheduleService:
         if task is None:
             raise A2AScheduleNotFoundError("Schedule task not found")
 
-        if (
-            task.last_run_status == A2AScheduleTask.STATUS_FAILED
-            and task.current_run_id is None
-        ):
-            return task
-
-        if task.last_run_status != A2AScheduleTask.STATUS_RUNNING:
+        execution = await self._get_running_execution(
+            db,
+            task_id=task.id,
+            user_id=task.user_id,
+            for_update=True,
+        )
+        if execution is None:
+            if task.last_run_status == A2AScheduleTask.STATUS_FAILED:
+                return await self._set_task_running_projection(db, task=task)
             raise A2AScheduleValidationError(
                 "Only running tasks can be manually marked as failed"
             )
 
-        run_id = task.current_run_id or uuid4()
-        started_at = ensure_utc(task.running_started_at or now_utc)
-        exec_stmt = (
-            select(A2AScheduleExecution)
-            .where(
-                and_(
-                    A2AScheduleExecution.task_id == task.id,
-                    A2AScheduleExecution.user_id == task.user_id,
-                    A2AScheduleExecution.run_id == run_id,
-                )
-            )
-            .with_for_update(nowait=True)
-            .limit(1)
-        )
-        execution = await db.scalar(exec_stmt)
-        if execution is None:
-            execution = A2AScheduleExecution(
-                user_id=task.user_id,
-                task_id=task.id,
-                run_id=run_id,
-                scheduled_for=started_at,
-                started_at=started_at,
-                finished_at=now_utc,
-                status=A2AScheduleExecution.STATUS_FAILED,
-                error_message=manual_error_message,
-                conversation_id=task.conversation_id,
-            )
-            db.add(execution)
-        else:
-            if execution.status == A2AScheduleExecution.STATUS_RUNNING:
-                execution.status = A2AScheduleExecution.STATUS_FAILED
-            if execution.finished_at is None:
-                execution.finished_at = now_utc
-            execution.error_message = manual_error_message
-            if execution.conversation_id is None:
-                execution.conversation_id = task.conversation_id
+        if execution.finished_at is None:
+            execution.finished_at = now_utc
+        execution.status = A2AScheduleExecution.STATUS_FAILED
+        execution.error_message = manual_error_message
+        if execution.conversation_id is None:
+            execution.conversation_id = task.conversation_id
 
         threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
         self._apply_task_terminal_projection(
@@ -564,6 +612,7 @@ class A2AScheduleService:
 
         await commit_safely(db)
         await db.refresh(task)
+        setattr(task, "is_running", False)
         return task
 
     @_map_retryable_db_errors("Schedule execution list")
@@ -614,9 +663,6 @@ class A2AScheduleService:
         finished_at_utc = ensure_utc(finished_at)
         task.last_run_status = final_status
         task.last_run_at = finished_at_utc
-        task.current_run_id = None
-        task.running_started_at = None
-        task.last_heartbeat_at = None
         if conversation_id is not None:
             task.conversation_id = conversation_id
 
@@ -674,12 +720,6 @@ class A2AScheduleService:
             .limit(1)
             .scalar_subquery()
         )
-
-        # Enqueue only due tasks that dont already have a pending or running execution
-        # Wait, that might be complex if we allow multiple queue items.
-        # Since we decoupled, we should just check if current_run_id is None?
-        # No, current_run_id is gone from task conceptually, but let us keep it for backwards compatibility during migration,
-        # actually, let us just rely on an exists subquery.
 
         has_pending_subquery = (
             select(1)
@@ -743,9 +783,6 @@ class A2AScheduleService:
 
             run_id = uuid4()
             selected_task.next_run_at = next_run_at
-            # We DONT mark task as running anymore
-            selected_task.last_run_status = A2AScheduleTask.STATUS_IDLE
-            selected_task.current_run_id = None
 
             db.add(
                 A2AScheduleExecution(
@@ -753,7 +790,8 @@ class A2AScheduleService:
                     task_id=selected_task.id,
                     run_id=run_id,
                     scheduled_for=scheduled_for,
-                    started_at=now_utc,
+                    started_at=None,
+                    last_heartbeat_at=None,
                     status=A2AScheduleExecution.STATUS_PENDING,
                     conversation_id=selected_task.conversation_id,
                 )
@@ -828,9 +866,16 @@ class A2AScheduleService:
         task_stmt = (
             select(A2AScheduleTask)
             .where(A2AScheduleTask.id == execution.task_id)
+            .with_for_update(nowait=True)
             .limit(1)
         )
-        task = await db.scalar(task_stmt)
+        try:
+            task = await db.scalar(task_stmt)
+        except DBAPIError as exc:
+            if to_retryable_db_lock_error(exc) is not None:
+                await db.rollback()
+                return None
+            raise
         if task is None or task.deleted_at is not None or not task.enabled:
             execution.status = A2AScheduleExecution.STATUS_FAILED
             execution.finished_at = now_utc
@@ -842,11 +887,7 @@ class A2AScheduleService:
 
         execution.status = A2AScheduleExecution.STATUS_RUNNING
         execution.started_at = now_utc
-
-        task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-        task.current_run_id = execution.run_id
-        task.running_started_at = now_utc
-        task.last_heartbeat_at = now_utc
+        execution.last_heartbeat_at = now_utc
 
         await commit_safely(db)
 
@@ -888,13 +929,13 @@ class A2AScheduleService:
 
         stale_predicates = [
             func.coalesce(
-                A2AScheduleTask.last_heartbeat_at,
-                A2AScheduleTask.running_started_at,
+                A2AScheduleExecution.last_heartbeat_at,
+                A2AScheduleExecution.started_at,
             )
             <= cutoff
         ]
         if hard_cutoff is not None:
-            stale_predicates.append(A2AScheduleTask.running_started_at <= hard_cutoff)
+            stale_predicates.append(A2AScheduleExecution.started_at <= hard_cutoff)
 
         error_message = "Execution marked as failed by recovery: stale running task exceeded timeout"
         recovered_count = 0
@@ -904,7 +945,6 @@ class A2AScheduleService:
             stale_where = and_(
                 A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
                 A2AScheduleTask.deleted_at.is_(None),
-                A2AScheduleTask.current_run_id == A2AScheduleExecution.run_id,
                 or_(*stale_predicates),
             )
             stmt = (
@@ -914,8 +954,8 @@ class A2AScheduleService:
                 )
                 .where(stale_where)
                 .order_by(
-                    A2AScheduleTask.running_started_at.asc(),
-                    A2AScheduleTask.id.asc(),
+                    A2AScheduleExecution.started_at.asc(),
+                    A2AScheduleExecution.id.asc(),
                 )
                 .limit(1)
                 .with_for_update(of=A2AScheduleExecution, skip_locked=True)
@@ -960,7 +1000,7 @@ class A2AScheduleService:
                     continue
                 raise
 
-            if task is None or task.current_run_id != execution.run_id:
+            if task is None:
                 # Task might have been finalized or deleted by the time we locked it.
                 await commit_safely(db)
                 continue
@@ -980,76 +1020,6 @@ class A2AScheduleService:
             )
             recovered_count += 1
 
-            await commit_safely(db)
-
-        # Compatibility cleanup for legacy orphaned running tasks created before
-        # the durable execution queue was introduced.
-        has_matching_execution_subquery = (
-            select(1)
-            .where(
-                and_(
-                    A2AScheduleExecution.task_id == A2AScheduleTask.id,
-                    A2AScheduleExecution.run_id == A2AScheduleTask.current_run_id,
-                )
-            )
-            .limit(1)
-            .exists()
-        )
-        while True:
-            await self._apply_skip_locked_write_timeouts(db)
-            orphan_where = and_(
-                A2AScheduleTask.deleted_at.is_(None),
-                A2AScheduleTask.last_run_status == A2AScheduleTask.STATUS_RUNNING,
-                A2AScheduleTask.current_run_id.is_not(None),
-                A2AScheduleTask.running_started_at.is_not(None),
-                or_(*stale_predicates),
-                ~has_matching_execution_subquery,
-            )
-            orphan_stmt = (
-                select(A2AScheduleTask)
-                .where(orphan_where)
-                .order_by(
-                    A2AScheduleTask.running_started_at.asc(),
-                    A2AScheduleTask.id.asc(),
-                )
-                .limit(1)
-                .with_for_update(skip_locked=True)
-            )
-            task = await db.scalar(orphan_stmt)
-            if task is None:
-                break
-
-            run_id = task.current_run_id
-            if run_id is None:
-                await commit_safely(db)
-                continue
-
-            started_at = ensure_utc(task.running_started_at or now_utc)
-            await db.execute(
-                insert(A2AScheduleExecution)
-                .values(
-                    user_id=task.user_id,
-                    task_id=task.id,
-                    run_id=run_id,
-                    scheduled_for=started_at,
-                    started_at=started_at,
-                    finished_at=now_utc,
-                    status=A2AScheduleExecution.STATUS_FAILED,
-                    error_message=error_message,
-                    conversation_id=task.conversation_id,
-                )
-                .on_conflict_do_nothing(
-                    index_elements=["task_id", "run_id"],
-                )
-            )
-            self._apply_task_terminal_projection(
-                task,
-                final_status=A2AScheduleTask.STATUS_FAILED,
-                finished_at=now_utc,
-                failure_threshold=failure_threshold,
-                conversation_id=task.conversation_id,
-            )
-            recovered_count += 1
             await commit_safely(db)
         return recovered_count
 
@@ -1103,7 +1073,7 @@ class A2AScheduleService:
             .limit(1)
         )
         task = await db.scalar(stmt)
-        if task is None or task.current_run_id != run_id:
+        if task is None:
             return False
 
         threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)

--- a/backend/scripts/backfill_schedule_execution_running_truth.py
+++ b/backend/scripts/backfill_schedule_execution_running_truth.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Drain legacy schedule task running-state columns before execution-truth migration.
+
+This script must run against the pre-`4b6c6e0d8a2f` schema, before the migration
+that drops `current_run_id`, `running_started_at`, and `last_heartbeat_at` from
+`a2a_schedule_tasks`.
+
+It performs a one-off reconciliation:
+1. Find tasks still carrying legacy running-state projection.
+2. Reuse a matching terminal execution when one already exists.
+3. Otherwise fail the in-flight run by updating or inserting an execution row.
+4. Clear the task-side running projection so the migration can proceed safely.
+
+Default mode is dry-run. Pass `--apply` to mutate the database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.engine.url import make_url
+
+BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+BACKFILL_ERROR_MESSAGE = (
+    "Execution backfilled as failed during schedule running-truth migration drain"
+)
+RUNNING_STATUS = "running"
+SUCCESS_STATUS = "success"
+FAILED_STATUS = "failed"
+LEGACY_TASK_COLUMNS = {
+    "current_run_id",
+    "running_started_at",
+    "last_heartbeat_at",
+}
+_SETTINGS: Any | None = None
+
+
+@dataclass(frozen=True)
+class BackfillStats:
+    scanned: int = 0
+    inserted_executions: int = 0
+    failed_existing_executions: int = 0
+    reused_terminal_executions: int = 0
+    updated_tasks: int = 0
+
+    def merge(
+        self,
+        *,
+        scanned: int = 0,
+        inserted_executions: int = 0,
+        failed_existing_executions: int = 0,
+        reused_terminal_executions: int = 0,
+        updated_tasks: int = 0,
+    ) -> "BackfillStats":
+        return BackfillStats(
+            scanned=self.scanned + scanned,
+            inserted_executions=self.inserted_executions + inserted_executions,
+            failed_existing_executions=(
+                self.failed_existing_executions + failed_existing_executions
+            ),
+            reused_terminal_executions=(
+                self.reused_terminal_executions + reused_terminal_executions
+            ),
+            updated_tasks=self.updated_tasks + updated_tasks,
+        )
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _get_settings() -> Any:
+    global _SETTINGS
+    if _SETTINGS is None:
+        from app.core.config import settings as app_settings  # noqa: WPS433
+
+        _SETTINGS = app_settings
+    return _SETTINGS
+
+
+def _ensure_utc(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    raise TypeError(f"Unsupported datetime value: {value!r}")
+
+
+def _normalize_minutes(time_point: Any) -> int:
+    if not isinstance(time_point, dict):
+        return 5
+    raw = time_point.get("minutes", time_point.get("interval_minutes"))
+    if not isinstance(raw, int):
+        return 5
+    return max(5, min(1440, raw))
+
+
+def _compute_sequential_next_run_at(
+    *,
+    time_point: Any,
+    after_utc: datetime,
+) -> datetime:
+    return after_utc + timedelta(minutes=_normalize_minutes(time_point))
+
+
+def _ensure_legacy_columns_present(connection: Connection) -> bool:
+    settings = _get_settings()
+    rows = connection.execute(
+        text("""
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = :schema_name
+              AND table_name = 'a2a_schedule_tasks'
+            """),
+        {"schema_name": settings.schema_name},
+    ).scalars()
+    task_columns = set(rows)
+    return LEGACY_TASK_COLUMNS.issubset(task_columns)
+
+
+def _legacy_task_rows(
+    connection: Connection,
+    *,
+    lock_rows: bool,
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    settings = _get_settings()
+    limit_clause = "LIMIT :limit" if limit is not None else ""
+    lock_clause = "FOR UPDATE" if lock_rows else ""
+    stmt = text(f"""
+        SELECT
+            id,
+            user_id,
+            conversation_id,
+            cycle_type,
+            time_point,
+            enabled,
+            next_run_at,
+            consecutive_failures,
+            last_run_status,
+            current_run_id,
+            running_started_at,
+            last_heartbeat_at,
+            delete_requested_at,
+            deleted_at
+        FROM {settings.schema_name}.a2a_schedule_tasks
+        WHERE current_run_id IS NOT NULL
+           OR running_started_at IS NOT NULL
+           OR last_heartbeat_at IS NOT NULL
+           OR last_run_status = :running_status
+        ORDER BY updated_at ASC, id ASC
+        {limit_clause}
+        {lock_clause}
+        """)
+    params = {"running_status": RUNNING_STATUS}
+    if limit is not None:
+        params["limit"] = limit
+    result = connection.execute(stmt, params)
+    return [dict(row) for row in result.mappings().all()]
+
+
+def _matching_execution(
+    connection: Connection,
+    *,
+    task_id: UUID,
+    run_id: UUID,
+    lock_row: bool,
+) -> dict[str, Any] | None:
+    settings = _get_settings()
+    lock_clause = "FOR UPDATE" if lock_row else ""
+    result = connection.execute(
+        text(f"""
+            SELECT
+                id,
+                status,
+                scheduled_for,
+                started_at,
+                finished_at,
+                conversation_id
+            FROM {settings.schema_name}.a2a_schedule_executions
+            WHERE task_id = :task_id
+              AND run_id = :run_id
+            LIMIT 1
+            {lock_clause}
+            """),
+        {"task_id": task_id, "run_id": run_id},
+    )
+    row = result.mappings().one_or_none()
+    return dict(row) if row is not None else None
+
+
+def _task_projection_after_terminal(
+    task_row: dict[str, Any],
+    *,
+    final_status: str,
+    finished_at: datetime,
+    failure_threshold: int,
+    conversation_id: UUID | None,
+) -> dict[str, Any]:
+    enabled = bool(task_row["enabled"])
+    next_run_at = _ensure_utc(task_row["next_run_at"])
+    delete_requested_at = _ensure_utc(task_row["delete_requested_at"])
+    deleted_at = _ensure_utc(task_row["deleted_at"])
+    consecutive_failures = int(task_row["consecutive_failures"] or 0)
+
+    if deleted_at is not None:
+        enabled = False
+        next_run_at = None
+        delete_requested_at = None
+    elif final_status == SUCCESS_STATUS:
+        consecutive_failures = 0
+    elif final_status == FAILED_STATUS:
+        consecutive_failures += 1
+        if consecutive_failures >= failure_threshold:
+            enabled = False
+    else:
+        raise ValueError(f"Unsupported terminal status: {final_status}")
+
+    if delete_requested_at is not None:
+        deleted_at = finished_at
+        enabled = False
+        next_run_at = None
+        delete_requested_at = None
+    elif task_row["cycle_type"] == "sequential":
+        next_run_at = (
+            _compute_sequential_next_run_at(
+                time_point=task_row["time_point"],
+                after_utc=finished_at,
+            )
+            if enabled
+            else None
+        )
+
+    return {
+        "last_run_status": final_status,
+        "last_run_at": finished_at,
+        "consecutive_failures": consecutive_failures,
+        "enabled": enabled,
+        "next_run_at": next_run_at,
+        "delete_requested_at": delete_requested_at,
+        "deleted_at": deleted_at,
+        "conversation_id": conversation_id or task_row["conversation_id"],
+    }
+
+
+def _apply_task_projection(
+    connection: Connection,
+    *,
+    task_id: UUID,
+    projection: dict[str, Any],
+) -> None:
+    settings = _get_settings()
+    connection.execute(
+        text(f"""
+            UPDATE {settings.schema_name}.a2a_schedule_tasks
+            SET
+                last_run_status = :last_run_status,
+                last_run_at = :last_run_at,
+                consecutive_failures = :consecutive_failures,
+                enabled = :enabled,
+                next_run_at = :next_run_at,
+                delete_requested_at = :delete_requested_at,
+                deleted_at = :deleted_at,
+                conversation_id = :conversation_id,
+                current_run_id = NULL,
+                running_started_at = NULL,
+                last_heartbeat_at = NULL,
+                updated_at = now()
+            WHERE id = :task_id
+            """),
+        {"task_id": task_id, **projection},
+    )
+
+
+def _fail_existing_execution(
+    connection: Connection,
+    *,
+    execution_id: UUID,
+    started_at: datetime,
+    finished_at: datetime,
+    conversation_id: UUID | None,
+) -> None:
+    settings = _get_settings()
+    connection.execute(
+        text(f"""
+            UPDATE {settings.schema_name}.a2a_schedule_executions
+            SET
+                started_at = COALESCE(started_at, :started_at),
+                finished_at = :finished_at,
+                status = :status,
+                error_message = :error_message,
+                conversation_id = COALESCE(conversation_id, :conversation_id),
+                updated_at = now()
+            WHERE id = :execution_id
+            """),
+        {
+            "execution_id": execution_id,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "status": FAILED_STATUS,
+            "error_message": BACKFILL_ERROR_MESSAGE,
+            "conversation_id": conversation_id,
+        },
+    )
+
+
+def _insert_failed_execution(
+    connection: Connection,
+    *,
+    task_row: dict[str, Any],
+    run_id: UUID,
+    scheduled_for: datetime,
+    started_at: datetime,
+    finished_at: datetime,
+) -> None:
+    settings = _get_settings()
+    connection.execute(
+        text(f"""
+            INSERT INTO {settings.schema_name}.a2a_schedule_executions (
+                id,
+                user_id,
+                task_id,
+                run_id,
+                scheduled_for,
+                started_at,
+                finished_at,
+                status,
+                error_message,
+                response_content,
+                conversation_id,
+                user_message_id,
+                agent_message_id
+            ) VALUES (
+                :id,
+                :user_id,
+                :task_id,
+                :run_id,
+                :scheduled_for,
+                :started_at,
+                :finished_at,
+                :status,
+                :error_message,
+                NULL,
+                :conversation_id,
+                NULL,
+                NULL
+            )
+            ON CONFLICT (task_id, run_id) DO NOTHING
+            """),
+        {
+            "id": uuid4(),
+            "user_id": task_row["user_id"],
+            "task_id": task_row["id"],
+            "run_id": run_id,
+            "scheduled_for": scheduled_for,
+            "started_at": started_at,
+            "finished_at": finished_at,
+            "status": FAILED_STATUS,
+            "error_message": BACKFILL_ERROR_MESSAGE,
+            "conversation_id": task_row["conversation_id"],
+        },
+    )
+
+
+def _process_one_task(
+    connection: Connection,
+    *,
+    task_row: dict[str, Any],
+    apply_changes: bool,
+    now_utc: datetime,
+    failure_threshold: int,
+) -> BackfillStats:
+    stats = BackfillStats(scanned=1)
+    run_id = task_row["current_run_id"] or uuid4()
+    running_started_at = _ensure_utc(task_row["running_started_at"])
+    last_heartbeat_at = _ensure_utc(task_row["last_heartbeat_at"])
+    next_run_at = _ensure_utc(task_row["next_run_at"])
+    started_at = running_started_at or last_heartbeat_at or next_run_at or now_utc
+    scheduled_for = next_run_at or started_at
+
+    execution_row = None
+    if task_row["current_run_id"] is not None:
+        execution_row = _matching_execution(
+            connection,
+            task_id=task_row["id"],
+            run_id=task_row["current_run_id"],
+            lock_row=apply_changes,
+        )
+
+    final_status = FAILED_STATUS
+    finished_at = now_utc
+    conversation_id = task_row["conversation_id"]
+
+    if execution_row is not None and execution_row["status"] in {
+        SUCCESS_STATUS,
+        FAILED_STATUS,
+    }:
+        final_status = execution_row["status"]
+        finished_at = _ensure_utc(execution_row["finished_at"]) or now_utc
+        conversation_id = execution_row["conversation_id"] or conversation_id
+        stats = stats.merge(reused_terminal_executions=1)
+    elif execution_row is not None:
+        conversation_id = execution_row["conversation_id"] or conversation_id
+        if apply_changes:
+            _fail_existing_execution(
+                connection,
+                execution_id=execution_row["id"],
+                started_at=started_at,
+                finished_at=finished_at,
+                conversation_id=conversation_id,
+            )
+        stats = stats.merge(failed_existing_executions=1)
+    else:
+        if apply_changes:
+            _insert_failed_execution(
+                connection,
+                task_row=task_row,
+                run_id=run_id,
+                scheduled_for=scheduled_for,
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+        stats = stats.merge(inserted_executions=1)
+
+    projection = _task_projection_after_terminal(
+        task_row,
+        final_status=final_status,
+        finished_at=finished_at,
+        failure_threshold=failure_threshold,
+        conversation_id=conversation_id,
+    )
+    if apply_changes:
+        _apply_task_projection(
+            connection,
+            task_id=task_row["id"],
+            projection=projection,
+        )
+    return stats.merge(updated_tasks=1)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill legacy schedule task running-state columns into execution rows "
+            "before revision 4b6c6e0d8a2f."
+        )
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the reconciliation instead of running in dry-run mode",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Optionally process only the first N legacy tasks",
+    )
+    return parser.parse_args()
+
+
+def _print_summary(
+    *,
+    mode: str,
+    stats: BackfillStats,
+    sample_ids: list[UUID],
+) -> None:
+    settings = _get_settings()
+    print(f"Mode: {mode}")
+    print(f"Schema: {settings.schema_name}")
+    print(f"Legacy tasks scanned: {stats.scanned}")
+    print(f"Tasks projected to terminal state: {stats.updated_tasks}")
+    print(f"Existing executions failed: {stats.failed_existing_executions}")
+    print(f"Terminal executions reused: {stats.reused_terminal_executions}")
+    print(f"Missing executions inserted: {stats.inserted_executions}")
+    if sample_ids:
+        print("Sample task ids:")
+        for task_id in sample_ids[:10]:
+            print(f"  - {task_id}")
+
+
+def main() -> None:
+    args = parse_args()
+    settings = _get_settings()
+    safe_url = make_url(settings.app_database_url_for_alembic).render_as_string(
+        hide_password=True
+    )
+    print(f"Database URL: {safe_url}")
+    print(
+        "This script must be run before applying revision 4b6c6e0d8a2f "
+        "and after draining old scheduler workers."
+    )
+
+    engine = create_engine(settings.app_database_url_for_alembic)
+    failure_threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
+    mode = "apply" if args.apply else "dry-run"
+
+    with engine.begin() if args.apply else engine.connect() as connection:
+        if not _ensure_legacy_columns_present(connection):
+            print(
+                "Legacy task running-state columns are already absent. "
+                "Nothing to backfill."
+            )
+            return
+
+        task_rows = _legacy_task_rows(
+            connection,
+            lock_rows=args.apply,
+            limit=args.limit,
+        )
+        stats = BackfillStats()
+        sample_ids = [row["id"] for row in task_rows]
+
+        for task_row in task_rows:
+            stats = stats.merge(
+                **_process_one_task(
+                    connection,
+                    task_row=task_row,
+                    apply_changes=args.apply,
+                    now_utc=_utc_now(),
+                    failure_threshold=failure_threshold,
+                ).__dict__
+            )
+
+        _print_summary(mode=mode, stats=stats, sample_ids=sample_ids)
+
+        if not args.apply:
+            print("Dry-run only. Re-run with --apply to write changes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_a2a_schedule_job.py
+++ b/backend/tests/test_a2a_schedule_job.py
@@ -93,10 +93,6 @@ def _mock_runtime_builder():
 async def _mark_task_claimed(session, *, task: A2AScheduleTask):
     run_id = uuid4()
     started_at = utc_now()
-    task.current_run_id = run_id
-    task.running_started_at = started_at
-    task.last_heartbeat_at = started_at
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
     session.add(
         A2AScheduleExecution(
             user_id=task.user_id,
@@ -104,6 +100,7 @@ async def _mark_task_claimed(session, *, task: A2AScheduleTask):
             run_id=run_id,
             scheduled_for=task.next_run_at or started_at,
             started_at=started_at,
+            last_heartbeat_at=started_at,
             status=A2AScheduleExecution.STATUS_RUNNING,
             conversation_id=task.conversation_id,
         )
@@ -160,10 +157,6 @@ async def test_claim_next_pending_execution_obeys_agent_concurrency_limit(
         next_run_at=now,
     )
     existing_run_id = uuid4()
-    task_a1.current_run_id = existing_run_id
-    task_a1.running_started_at = now - timedelta(minutes=1)
-    task_a1.last_heartbeat_at = now - timedelta(seconds=30)
-    task_a1.last_run_status = A2AScheduleTask.STATUS_RUNNING
     async_db_session.add(
         A2AScheduleExecution(
             user_id=user.id,
@@ -171,6 +164,7 @@ async def test_claim_next_pending_execution_obeys_agent_concurrency_limit(
             run_id=existing_run_id,
             scheduled_for=now - timedelta(minutes=1),
             started_at=now - timedelta(minutes=1),
+            last_heartbeat_at=now - timedelta(seconds=30),
             status=A2AScheduleExecution.STATUS_RUNNING,
         )
     )
@@ -218,10 +212,6 @@ async def test_claim_next_pending_execution_obeys_global_concurrency_limit(
         next_run_at=now,
     )
     running_run_id = uuid4()
-    task_a.current_run_id = running_run_id
-    task_a.running_started_at = now - timedelta(minutes=1)
-    task_a.last_heartbeat_at = now - timedelta(seconds=20)
-    task_a.last_run_status = A2AScheduleTask.STATUS_RUNNING
     async_db_session.add(
         A2AScheduleExecution(
             user_id=user.id,
@@ -229,6 +219,7 @@ async def test_claim_next_pending_execution_obeys_global_concurrency_limit(
             run_id=running_run_id,
             scheduled_for=now - timedelta(minutes=1),
             started_at=now - timedelta(minutes=1),
+            last_heartbeat_at=now - timedelta(seconds=20),
             status=A2AScheduleExecution.STATUS_RUNNING,
         )
     )
@@ -303,8 +294,7 @@ async def test_claim_next_pending_execution_sequential_holds_next_run_until_fina
     assert claim is not None
     assert claim.task_id == task.id
     await async_db_session.refresh(task)
-    assert task.last_run_status == A2AScheduleTask.STATUS_RUNNING
-    assert task.current_run_id is not None
+    assert task.last_run_status == A2AScheduleTask.STATUS_IDLE
     assert task.next_run_at is None
 
 
@@ -335,8 +325,14 @@ async def test_delete_running_task_marks_deferred_delete_and_hides_from_user_que
     assert task.delete_requested_at is not None
     assert task.enabled is False
     assert task.next_run_at is None
-    assert task.current_run_id == run_id
-    assert task.last_run_status == A2AScheduleTask.STATUS_RUNNING
+    execution = await async_db_session.scalar(
+        select(A2AScheduleExecution).where(
+            A2AScheduleExecution.task_id == task.id,
+            A2AScheduleExecution.run_id == run_id,
+        )
+    )
+    assert execution is not None
+    assert execution.status == A2AScheduleExecution.STATUS_RUNNING
 
     with pytest.raises(A2AScheduleNotFoundError):
         await a2a_schedule_service.get_task(
@@ -380,9 +376,6 @@ async def test_finalize_task_run_soft_deletes_when_delete_was_requested(
 
     assert task.deleted_at is not None
     assert task.delete_requested_at is None
-    assert task.current_run_id is None
-    assert task.running_started_at is None
-    assert task.last_heartbeat_at is None
 
 
 async def test_delete_task_returns_conflict_when_row_locked(
@@ -1118,10 +1111,7 @@ async def test_execute_claimed_task_skips_stale_run_id(
         agent_id=agent.id,
         next_run_at=now,
     )
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = uuid4()
-    task.running_started_at = now
-    await async_db_session.commit()
+    task_id = task.id
 
     stale_claim = _build_claim(task, run_id=uuid4())
     await _execute_claimed_task(claim=stale_claim)
@@ -1129,21 +1119,20 @@ async def test_execute_claimed_task_skips_stale_run_id(
 
     async with async_session_maker() as check_db:
         refreshed_task = await check_db.scalar(
-            select(A2AScheduleTask).where(A2AScheduleTask.id == task.id)
+            select(A2AScheduleTask).where(A2AScheduleTask.id == task_id)
         )
         executions = list(
             (
                 await check_db.scalars(
                     select(A2AScheduleExecution).where(
-                        A2AScheduleExecution.task_id == task.id
+                        A2AScheduleExecution.task_id == task_id
                     )
                 )
             ).all()
         )
 
     assert refreshed_task is not None
-    assert refreshed_task.current_run_id is not None
-    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_RUNNING
+    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_IDLE
     assert executions == []
 
 
@@ -1211,8 +1200,7 @@ async def test_execute_claimed_task_does_not_side_write_execution_on_finalize_mi
         )
 
     assert refreshed_task is not None
-    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_RUNNING
-    assert refreshed_task.current_run_id == run_id
+    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_IDLE
     assert len(executions) == 1
     assert executions[0].status == A2AScheduleExecution.STATUS_RUNNING
     assert executions[0].finished_at is None
@@ -1289,8 +1277,7 @@ async def test_execute_claimed_task_does_not_side_write_execution_on_finalize_lo
 
     assert "finalize deferred due to lock contention" in caplog.text
     assert refreshed_task is not None
-    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_RUNNING
-    assert refreshed_task.current_run_id == run_id
+    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_IDLE
     assert len(executions) == 1
     assert executions[0].status == A2AScheduleExecution.STATUS_RUNNING
     assert executions[0].finished_at is None
@@ -1312,15 +1299,13 @@ async def test_recover_stale_running_task_finalizes_matching_run(
     task_id = task.id
     run_id = uuid4()
     stale_started_at = now - timedelta(minutes=30)
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = stale_started_at
     execution = A2AScheduleExecution(
         user_id=user.id,
         task_id=task.id,
         run_id=run_id,
         scheduled_for=stale_started_at,
         started_at=stale_started_at,
+        last_heartbeat_at=stale_started_at,
         status=A2AScheduleExecution.STATUS_RUNNING,
     )
     async_db_session.add(execution)
@@ -1345,8 +1330,6 @@ async def test_recover_stale_running_task_finalizes_matching_run(
 
     assert refreshed_task is not None
     assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_FAILED
-    assert refreshed_task.current_run_id is None
-    assert refreshed_task.running_started_at is None
     assert refreshed_execution is not None
     assert refreshed_execution.status == A2AScheduleExecution.STATUS_FAILED
     assert refreshed_execution.finished_at is not None
@@ -1372,10 +1355,6 @@ async def test_recover_stale_running_task_soft_deletes_when_delete_was_requested
     task_id = task.id
     run_id = uuid4()
     stale_started_at = now - timedelta(minutes=30)
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = stale_started_at
-    task.last_heartbeat_at = stale_started_at
     task.delete_requested_at = now - timedelta(minutes=1)
     task.enabled = False
     task.next_run_at = None
@@ -1385,6 +1364,7 @@ async def test_recover_stale_running_task_soft_deletes_when_delete_was_requested
         run_id=run_id,
         scheduled_for=stale_started_at,
         started_at=stale_started_at,
+        last_heartbeat_at=stale_started_at,
         status=A2AScheduleExecution.STATUS_RUNNING,
     )
     async_db_session.add(execution)
@@ -1412,7 +1392,6 @@ async def test_recover_stale_running_task_soft_deletes_when_delete_was_requested
     assert refreshed_task is not None
     assert refreshed_task.deleted_at is not None
     assert refreshed_task.delete_requested_at is None
-    assert refreshed_task.current_run_id is None
     assert refreshed_execution is not None
     assert refreshed_execution.status == A2AScheduleExecution.STATUS_FAILED
 
@@ -1435,16 +1414,13 @@ async def test_recover_stale_running_task_skips_when_heartbeat_recent(
     task_id = task.id
     run_id = uuid4()
     stale_started_at = now - timedelta(minutes=30)
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = stale_started_at
-    task.last_heartbeat_at = now - timedelta(seconds=30)
     execution = A2AScheduleExecution(
         user_id=user.id,
         task_id=task.id,
         run_id=run_id,
         scheduled_for=stale_started_at,
         started_at=stale_started_at,
+        last_heartbeat_at=now - timedelta(seconds=30),
         status=A2AScheduleExecution.STATUS_RUNNING,
     )
     async_db_session.add(execution)
@@ -1469,8 +1445,7 @@ async def test_recover_stale_running_task_skips_when_heartbeat_recent(
         )
 
     assert refreshed_task is not None
-    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_RUNNING
-    assert refreshed_task.current_run_id == run_id
+    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_IDLE
     assert refreshed_execution is not None
     assert refreshed_execution.status == A2AScheduleExecution.STATUS_RUNNING
     assert refreshed_execution.finished_at is None
@@ -1494,16 +1469,13 @@ async def test_recover_stale_running_task_hard_timeout_wins_over_recent_heartbea
     task_id = task.id
     run_id = uuid4()
     stale_started_at = now - timedelta(minutes=30)
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = stale_started_at
-    task.last_heartbeat_at = now - timedelta(seconds=10)
     execution = A2AScheduleExecution(
         user_id=user.id,
         task_id=task.id,
         run_id=run_id,
         scheduled_for=stale_started_at,
         started_at=stale_started_at,
+        last_heartbeat_at=now - timedelta(seconds=10),
         status=A2AScheduleExecution.STATUS_RUNNING,
     )
     async_db_session.add(execution)
@@ -1529,13 +1501,12 @@ async def test_recover_stale_running_task_hard_timeout_wins_over_recent_heartbea
 
     assert refreshed_task is not None
     assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_FAILED
-    assert refreshed_task.current_run_id is None
     assert refreshed_execution is not None
     assert refreshed_execution.status == A2AScheduleExecution.STATUS_FAILED
     assert refreshed_execution.finished_at is not None
 
 
-async def test_recover_stale_running_task_backfills_missing_execution(
+async def test_recover_stale_running_task_requires_execution_row(
     async_db_session,
     async_session_maker,
 ) -> None:
@@ -1551,42 +1522,22 @@ async def test_recover_stale_running_task_backfills_missing_execution(
         next_run_at=now,
     )
     task_id = task.id
-    run_id = uuid4()
-    stale_started_at = now - timedelta(minutes=30)
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = stale_started_at
-    await async_db_session.commit()
 
     recovered = await a2a_schedule_service.recover_stale_running_tasks(
         async_db_session,
         now=now,
         timeout_seconds=60,
     )
-    assert recovered == 1
+    assert recovered == 0
     await async_db_session.rollback()
 
     async with async_session_maker() as check_db:
         refreshed_task = await check_db.scalar(
             select(A2AScheduleTask).where(A2AScheduleTask.id == task_id)
         )
-        executions = list(
-            (
-                await check_db.scalars(
-                    select(A2AScheduleExecution).where(
-                        A2AScheduleExecution.task_id == task_id,
-                        A2AScheduleExecution.run_id == run_id,
-                    )
-                )
-            ).all()
-        )
 
     assert refreshed_task is not None
-    assert refreshed_task.current_run_id is None
-    assert refreshed_task.running_started_at is None
-    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_FAILED
-    assert len(executions) == 1
-    assert executions[0].status == A2AScheduleExecution.STATUS_FAILED
+    assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_IDLE
 
 
 async def test_recover_stale_sequential_task_reschedules_next_run(
@@ -1611,9 +1562,6 @@ async def test_recover_stale_sequential_task_reschedules_next_run(
     stale_started_at = now - timedelta(minutes=30)
     task.cycle_type = A2AScheduleTask.CYCLE_SEQUENTIAL
     task.time_point = {"minutes": 60}
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = stale_started_at
     task.next_run_at = None
     execution = A2AScheduleExecution(
         user_id=user.id,
@@ -1621,6 +1569,7 @@ async def test_recover_stale_sequential_task_reschedules_next_run(
         run_id=run_id,
         scheduled_for=stale_started_at,
         started_at=stale_started_at,
+        last_heartbeat_at=stale_started_at,
         status=A2AScheduleExecution.STATUS_RUNNING,
     )
     async_db_session.add(execution)
@@ -1641,8 +1590,6 @@ async def test_recover_stale_sequential_task_reschedules_next_run(
 
     assert refreshed_task is not None
     assert refreshed_task.last_run_status == A2AScheduleTask.STATUS_FAILED
-    assert refreshed_task.current_run_id is None
-    assert refreshed_task.running_started_at is None
     assert refreshed_task.next_run_at is not None
     assert refreshed_task.next_run_at >= now + timedelta(minutes=59)
 
@@ -1664,15 +1611,13 @@ async def test_recover_stale_running_tasks_commits_per_recovered_task(
             next_run_at=now,
         )
         run_id = uuid4()
-        task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-        task.current_run_id = run_id
-        task.running_started_at = stale_started_at
         execution = A2AScheduleExecution(
             user_id=user.id,
             task_id=task.id,
             run_id=run_id,
             scheduled_for=stale_started_at,
             started_at=stale_started_at,
+            last_heartbeat_at=stale_started_at,
             status=A2AScheduleExecution.STATUS_RUNNING,
         )
         async_db_session.add(execution)

--- a/backend/tests/test_a2a_schedule_routes.py
+++ b/backend/tests/test_a2a_schedule_routes.py
@@ -343,9 +343,6 @@ async def test_schedule_mark_failed_transitions_running_task_and_is_idempotent(
     )
     started_at = utc_now() - timedelta(minutes=3)
     run_id = uuid4()
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = started_at
     async_db_session.add(
         A2AScheduleExecution(
             user_id=user.id,
@@ -353,6 +350,7 @@ async def test_schedule_mark_failed_transitions_running_task_and_is_idempotent(
             run_id=run_id,
             scheduled_for=started_at,
             started_at=started_at,
+            last_heartbeat_at=started_at,
             status=A2AScheduleExecution.STATUS_RUNNING,
         )
     )
@@ -372,13 +370,12 @@ async def test_schedule_mark_failed_transitions_running_task_and_is_idempotent(
         payload = resp.json()
         assert payload["id"] == str(task.id)
         assert payload["last_run_status"] == "failed"
+        assert payload["is_running"] is False
         assert payload["last_run_at"] is not None
 
         await async_db_session.refresh(task)
         failures_after_first_call = task.consecutive_failures
         assert task.last_run_status == A2AScheduleTask.STATUS_FAILED
-        assert task.current_run_id is None
-        assert task.running_started_at is None
         assert failures_after_first_call >= 1
 
         execution = await async_db_session.scalar(
@@ -424,9 +421,6 @@ async def test_schedule_mark_failed_sequential_reschedules_next_run(
     )
     started_at = utc_now() - timedelta(minutes=3)
     run_id = uuid4()
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = started_at
     task.next_run_at = None
     async_db_session.add(
         A2AScheduleExecution(
@@ -435,6 +429,7 @@ async def test_schedule_mark_failed_sequential_reschedules_next_run(
             run_id=run_id,
             scheduled_for=started_at,
             started_at=started_at,
+            last_heartbeat_at=started_at,
             status=A2AScheduleExecution.STATUS_RUNNING,
         )
     )
@@ -499,7 +494,7 @@ async def test_schedule_mark_failed_rejects_non_running_task(
         )
 
 
-async def test_schedule_mark_failed_backfills_missing_execution(
+async def test_schedule_mark_failed_rejects_missing_execution(
     async_db_session,
     async_session_maker,
 ):
@@ -520,11 +515,6 @@ async def test_schedule_mark_failed_backfills_missing_execution(
         time_point={"time": "09:00"},
         enabled=False,
     )
-    started_at = utc_now() - timedelta(minutes=2)
-    run_id = uuid4()
-    task.last_run_status = A2AScheduleTask.STATUS_RUNNING
-    task.current_run_id = run_id
-    task.running_started_at = started_at
     await async_db_session.commit()
     await async_db_session.refresh(task)
 
@@ -537,17 +527,11 @@ async def test_schedule_mark_failed_backfills_missing_execution(
             f"/me/a2a/schedules/{task.id}/mark-failed",
             json={},
         )
-        assert resp.status_code == 200
-
-        execution = await async_db_session.scalar(
-            select(A2AScheduleExecution).where(
-                A2AScheduleExecution.task_id == task.id,
-                A2AScheduleExecution.run_id == run_id,
-            )
+        assert resp.status_code == 400
+        assert (
+            "Only running tasks can be manually marked as failed"
+            in resp.json()["detail"]
         )
-        assert execution is not None
-        assert execution.status == A2AScheduleExecution.STATUS_FAILED
-        assert execution.error_message == "Stopped by user as failed"
 
 
 async def test_schedule_create_interval_normalizes_minutes(

--- a/backend/tests/test_issue_338_reuse_thread_cleanup.py
+++ b/backend/tests/test_issue_338_reuse_thread_cleanup.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from app.db.models.a2a_agent import A2AAgent
+from app.db.models.a2a_schedule_execution import A2AScheduleExecution
 from app.db.models.a2a_schedule_task import A2AScheduleTask
 from app.db.models.conversation_thread import ConversationThread
 from app.services.a2a_schedule_job import _execute_claimed_task
@@ -82,6 +83,23 @@ def _build_claim(task: A2AScheduleTask):
     )
 
 
+async def _mark_task_claimed(session, *, task: A2AScheduleTask, run_id):
+    started_at = utc_now()
+    session.add(
+        A2AScheduleExecution(
+            user_id=task.user_id,
+            task_id=task.id,
+            run_id=run_id,
+            scheduled_for=task.next_run_at or started_at,
+            started_at=started_at,
+            last_heartbeat_at=started_at,
+            status=A2AScheduleExecution.STATUS_RUNNING,
+            conversation_id=task.conversation_id,
+        )
+    )
+    await session.commit()
+
+
 async def test_execute_claimed_task_retains_history_on_reuse_policy_failure(
     async_db_session,
     async_session_maker,
@@ -135,8 +153,7 @@ async def test_execute_claimed_task_retains_history_on_reuse_policy_failure(
     )
 
     claim = _build_claim(task)
-    task.current_run_id = claim.run_id
-    await async_db_session.commit()
+    await _mark_task_claimed(async_db_session, task=task, run_id=claim.run_id)
 
     await _execute_claimed_task(claim=claim)
     await async_db_session.rollback()
@@ -183,8 +200,7 @@ async def test_execute_claimed_task_cleans_new_thread_on_failure(
     )
 
     claim = _build_claim(task)
-    task.current_run_id = claim.run_id
-    await async_db_session.commit()
+    await _mark_task_claimed(async_db_session, task=task, run_id=claim.run_id)
 
     await _execute_claimed_task(claim=claim)
     await async_db_session.rollback()

--- a/frontend/components/scheduled/ScheduledJobCard.tsx
+++ b/frontend/components/scheduled/ScheduledJobCard.tsx
@@ -15,6 +15,7 @@ import { buildChatRoute } from "@/lib/routes";
 import { toast } from "@/lib/toast";
 
 const executionStatusColor: Record<ScheduledJobExecution["status"], string> = {
+  pending: "text-amber-300",
   running: "text-blue-400",
   success: "text-emerald-400",
   failed: "text-red-400",
@@ -89,8 +90,7 @@ export function ScheduledJobCard({
 }: ScheduledJobCardProps) {
   const router = useRouter();
   const isReallyRunning =
-    job.last_run_status === "running" ||
-    executions.some((e) => e.status === "running");
+    Boolean(job.is_running) || executions.some((e) => e.status === "running");
   const tone = getCardTone(job, isReallyRunning);
   const intervalTimePoint =
     job.cycle_type === "interval" &&

--- a/frontend/components/scheduled/ScheduledJobForm.tsx
+++ b/frontend/components/scheduled/ScheduledJobForm.tsx
@@ -27,7 +27,7 @@ type ScheduledJobFormProps = {
   onCancel: () => void;
   showTitle?: boolean;
   timeZone?: string;
-  lastRunStatus?: string | null;
+  isRunning?: boolean;
 };
 
 export function ScheduledJobForm({
@@ -40,7 +40,7 @@ export function ScheduledJobForm({
   onCancel,
   showTitle = true,
   timeZone,
-  lastRunStatus,
+  isRunning = false,
 }: ScheduledJobFormProps) {
   const intervalStartAt = (() => {
     const startAt = (form.time_point as { start_at_local?: unknown })
@@ -126,7 +126,7 @@ export function ScheduledJobForm({
     };
   };
 
-  const isCurrentlyRunning = lastRunStatus === "running";
+  const isCurrentlyRunning = Boolean(isRunning);
 
   const renderLabel = (text: string) => (
     <Text className="mt-4 text-[11px] font-medium uppercase tracking-wider text-slate-500">

--- a/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
+++ b/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
@@ -52,7 +52,8 @@ describe("ScheduledJobCard visuals", () => {
       id: "1",
       name: "Job",
       enabled: true,
-      last_run_status: "running" as const,
+      is_running: true,
+      last_run_status: "success" as const,
       next_run_at_utc: "2026-02-23T10:00:00Z",
       schedule_timezone: "UTC",
     };
@@ -107,7 +108,8 @@ describe("ScheduledJobCard visuals", () => {
       id: "4",
       name: "Job",
       enabled: true,
-      last_run_status: "running" as const,
+      is_running: true,
+      last_run_status: "success" as const,
       next_run_at_utc: "2026-02-23T10:00:00Z",
       schedule_timezone: "UTC",
     };

--- a/frontend/lib/api/scheduledJobs.ts
+++ b/frontend/lib/api/scheduledJobs.ts
@@ -43,10 +43,11 @@ export type ScheduledJob = {
   enabled: boolean;
   conversation_policy: "new_each_run" | "reuse_single";
   conversation_id?: string | null;
+  is_running?: boolean;
   next_run_at_utc?: string | null;
   next_run_at_local?: string | null;
   last_run_at?: string | null;
-  last_run_status?: "idle" | "running" | "success" | "failed" | null;
+  last_run_status?: "idle" | "success" | "failed" | null;
   created_at: string;
   updated_at: string;
 };
@@ -54,9 +55,10 @@ export type ScheduledJob = {
 export type ScheduledJobExecution = {
   id: string;
   task_id: string;
-  status: "running" | "success" | "failed";
+  status: "pending" | "running" | "success" | "failed";
   scheduled_for: string;
-  started_at: string;
+  started_at?: string | null;
+  last_heartbeat_at?: string | null;
   finished_at?: string | null;
   error_message?: string | null;
   response_content?: string | null;

--- a/frontend/screens/ScheduledJobFormScreen.tsx
+++ b/frontend/screens/ScheduledJobFormScreen.tsx
@@ -151,7 +151,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
   const [saving, setSaving] = useState(false);
   const [loadingJob, setLoadingJob] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [lastRunStatus, setLastRunStatus] = useState<string | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
   const effectiveScheduleTimeZone = form.schedule_timezone || scheduleTimeZone;
 
   const initialSnapshotRef = useRef<Snapshot | null>(null);
@@ -198,7 +198,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
           conversation_policy: found.conversation_policy || "new_each_run",
         };
         setForm(next);
-        setLastRunStatus(found.last_run_status ?? null);
+        setIsRunning(Boolean(found.is_running));
         initialSnapshotRef.current = buildSnapshot(next);
       })
       .catch((error) => {
@@ -435,7 +435,7 @@ export function ScheduledJobFormScreen({ jobId }: { jobId?: string }) {
             editing={editing}
             agentOptions={agentOptions}
             timeZone={effectiveScheduleTimeZone}
-            lastRunStatus={lastRunStatus}
+            isRunning={isRunning}
             onChange={(patch) => setForm((prev) => ({ ...prev, ...patch }))}
             onSubmit={handleSubmit}
             onCancel={handleCancel}

--- a/frontend/screens/ScheduledJobsScreen.tsx
+++ b/frontend/screens/ScheduledJobsScreen.tsx
@@ -53,8 +53,8 @@ export function ScheduledJobsScreen() {
       if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
 
       if (a.enabled && b.enabled) {
-        const ar = a.last_run_status === "running";
-        const br = b.last_run_status === "running";
+        const ar = Boolean(a.is_running);
+        const br = Boolean(b.is_running);
         if (ar !== br) return ar ? -1 : 1;
 
         const at = a.next_run_at_utc

--- a/frontend/screens/__tests__/ScheduledJobsScreen.test.tsx
+++ b/frontend/screens/__tests__/ScheduledJobsScreen.test.tsx
@@ -98,7 +98,8 @@ describe("ScheduledJobsScreen sorting", () => {
       {
         id: "2",
         enabled: true,
-        last_run_status: "running",
+        is_running: true,
+        last_run_status: "success",
         next_run_at_utc: "2026-02-23T11:00:00Z",
         schedule_timezone: "UTC",
       },
@@ -119,7 +120,8 @@ describe("ScheduledJobsScreen sorting", () => {
       {
         id: "5",
         enabled: false,
-        last_run_status: "running",
+        is_running: true,
+        last_run_status: "failed",
         next_run_at_utc: "2026-02-23T08:00:00Z",
         schedule_timezone: "UTC",
       },


### PR DESCRIPTION
## 关联问题
- Closes #395

## 目标边界
- `A2AScheduleExecution` 成为唯一运行真相源
- `A2AScheduleTask` 只保留定义字段与终态投影，不再承载运行态字段
- 终态写入只能经单一 CAS 路径完成
- orphan running task 清理迁出热路径，改为一次性 backfill
- 迁移中的数据库不变量与 schema 常量保持一致

## 本次实现
- 修正 migration schema 常量，统一使用 `SCHEMA_NAME`
- 新增 revision `4b6c6e0d8a2f`：为 execution 增加 `last_heartbeat_at`，移除 task 侧 `current_run_id` / `running_started_at` / `last_heartbeat_at`，并移除旧 running 约束与索引
- 新增一次性脚本 `backend/scripts/backfill_schedule_execution_running_truth.py`
  - 默认 `dry-run`
  - `--apply` 时会把旧 task running 投影回填/收敛到 execution，并清空 task 侧运行态列
- `execution.status` 去掉默认值，所有写入路径必须显式赋值
- scheduler/worker 运行态、心跳、recover、manual-fail、finalize 全部收口到 execution
- API/前端不再把 `last_run_status=running` 当作运行真相，改为显式 `is_running`

## 验证
### Backend scoped
- `cd backend && uv run pre-commit run --files app/db/models/a2a_schedule_task.py app/services/a2a_schedule_service.py app/services/a2a_schedule_job.py app/schemas/a2a_schedule.py app/api/routers/a2a_schedules.py alembic/versions/20260311_1215_f0d714e35080_add_pending_status_to_a2a_schedule_.py alembic/versions/20260312_1400_4b6c6e0d8a2f_shift_schedule_running_truth_to_execution.py scripts/backfill_schedule_execution_running_truth.py tests/test_a2a_schedule_job.py tests/test_a2a_schedule_routes.py tests/test_issue_338_reuse_thread_cleanup.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_a2a_schedule_job.py tests/test_a2a_schedule_routes.py tests/test_issue_338_reuse_thread_cleanup.py tests/test_me_sessions_routes.py tests/test_unified_session_domain_routes.py`
  - 结果：`84 passed`

### Backend full
- `cd backend && uv sync --extra dev --locked`
- `cd backend && uv run pre-commit run --all-files --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest`
  - 结果：`483 passed in 193.55s`

### Frontend scoped
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/api/scheduledJobs.ts components/scheduled/ScheduledJobCard.tsx components/scheduled/ScheduledJobForm.tsx screens/ScheduledJobFormScreen.tsx screens/ScheduledJobsScreen.tsx components/scheduled/__tests__/ScheduledJobCard.test.tsx screens/__tests__/ScheduledJobsScreen.test.tsx screens/__tests__/ScheduledJobFormScreen.test.tsx --maxWorkers=25%`
  - 结果：`38 passed`

### Script sanity check
- `cd backend && uv run python scripts/backfill_schedule_execution_running_truth.py --help`

## 迁移说明
- 当前会话环境没有可用的本地数据库，因此没有在干净库里实跑 `alembic upgrade head`
- 迁移文件、backfill 脚本、代码与测试已完成静态/回归验证
- 正式执行顺序建议：
  1. 停旧 scheduler/worker
  2. `cd backend && uv run python scripts/backfill_schedule_execution_running_truth.py --apply`
  3. `cd backend && uv run alembic upgrade head`
  4. 部署新版本并恢复调度
