### PR TITLE
fix(stream): honor shared stream block metadata (#446)

### DIFF
--- a/backend/app/services/a2a_invoke_service.py
+++ b/backend/app/services/a2a_invoke_service.py
@@ -194,6 +194,9 @@ class A2AInvokeService:
         result_status = as_dict(result.get("status"))
         result_status_metadata = as_dict(result_status.get("metadata"))
         root_metadata = as_dict(root.get("metadata"))
+        artifact_shared_stream = (
+            cls._StreamTextAccumulator._extract_shared_stream_metadata(root, artifact)
+        )
 
         # Identity extraction
         msg_id = None
@@ -212,6 +215,7 @@ class A2AInvokeService:
             result,
             result_status,
             result_status_metadata,
+            artifact_shared_stream,
             root_metadata,
         ):
             if msg_id is None:
@@ -237,11 +241,12 @@ class A2AInvokeService:
         seq = cls._pick_int(root, ("seq",))
         if seq is None:
             for cand in (
-                root_metadata,
                 artifact,
                 artifact_metadata,
+                root_metadata,
+                artifact_shared_stream,
             ):
-                seq = cls._pick_int(cand, ("seq",))
+                seq = cls._pick_int(cand, ("seq", "sequence"))
                 if seq is not None:
                     break
 
@@ -352,7 +357,14 @@ class A2AInvokeService:
         cls, payload: dict[str, Any]
     ) -> int | None:
         root = as_dict(payload)
-        return cls._pick_int(root, ("seq",))
+        sequence = cls._pick_int(root, ("seq",))
+        if sequence is not None:
+            return sequence
+        artifact = as_dict(root.get("artifact"))
+        shared_stream = cls._StreamTextAccumulator._extract_shared_stream_metadata(
+            root, artifact
+        )
+        return cls._pick_int(shared_stream, ("sequence", "seq"))
 
     @classmethod
     def _extract_usage_from_candidate(cls, payload: dict[str, Any]) -> dict[str, Any]:
@@ -433,6 +445,9 @@ class A2AInvokeService:
             return None
         artifact_metadata = as_dict(artifact.get("metadata"))
         root_metadata = as_dict(payload.get("metadata"))
+        shared_stream = cls._StreamTextAccumulator._extract_shared_stream_metadata(
+            payload, artifact
+        )
 
         block_type = cls._StreamTextAccumulator._extract_artifact_type(
             payload, artifact
@@ -447,6 +462,7 @@ class A2AInvokeService:
             artifact,
             artifact_metadata,
             root_metadata,
+            shared_stream,
         ):
             if event_id is None:
                 event_id = cls._pick_non_empty_str(candidate, ("event_id", "eventId"))
@@ -475,6 +491,7 @@ class A2AInvokeService:
             or cls._pick_int(artifact, ("seq",))
             or cls._pick_int(artifact_metadata, ("seq",))
             or cls._pick_int(root_metadata, ("seq",))
+            or cls._pick_int(shared_stream, ("sequence", "seq"))
         )
         source = cls._StreamTextAccumulator._extract_artifact_source(payload, artifact)
         return {
@@ -703,6 +720,20 @@ class A2AInvokeService:
             return "".join(collected)
 
         @staticmethod
+        def _extract_shared_stream_metadata(
+            payload: dict[str, Any], artifact: dict[str, Any]
+        ) -> dict[str, Any]:
+            resolved: dict[str, Any] = {}
+            root_metadata = as_dict(payload.get("metadata"))
+            artifact_metadata = as_dict(artifact.get("metadata"))
+            for metadata in (root_metadata, artifact_metadata):
+                shared = as_dict(metadata.get("shared"))
+                stream = as_dict(shared.get("stream"))
+                if stream:
+                    resolved.update(stream)
+            return resolved
+
+        @staticmethod
         def _extract_artifact_type(
             payload: dict[str, Any], artifact: dict[str, Any]
         ) -> str | None:
@@ -712,8 +743,15 @@ class A2AInvokeService:
             root_metadata = payload.get("metadata")
             if not isinstance(root_metadata, dict):
                 root_metadata = {}
+            shared_stream = (
+                A2AInvokeService._StreamTextAccumulator._extract_shared_stream_metadata(
+                    payload, artifact
+                )
+            )
 
-            raw = metadata.get("block_type")
+            raw = shared_stream.get("block_type")
+            if not isinstance(raw, str) or not raw.strip():
+                raw = metadata.get("block_type")
             if not isinstance(raw, str) or not raw.strip():
                 raw = root_metadata.get("block_type")
 
@@ -739,7 +777,14 @@ class A2AInvokeService:
             root_metadata = payload.get("metadata")
             if not isinstance(root_metadata, dict):
                 root_metadata = {}
-            source = metadata.get("source")
+            shared_stream = (
+                A2AInvokeService._StreamTextAccumulator._extract_shared_stream_metadata(
+                    payload, artifact
+                )
+            )
+            source = shared_stream.get("source")
+            if not isinstance(source, str) or not source.strip():
+                source = metadata.get("source")
             if not isinstance(source, str) or not source.strip():
                 source = root_metadata.get("source")
             if isinstance(source, str) and source.strip():
@@ -937,6 +982,9 @@ class A2AInvokeService:
         artifact = as_dict(payload.get("artifact"))
         artifact_metadata = as_dict(artifact.get("metadata"))
         root_metadata = as_dict(payload.get("metadata"))
+        shared_stream = cls._StreamTextAccumulator._extract_shared_stream_metadata(
+            payload, artifact
+        )
 
         message_id = None
         for candidate in (
@@ -944,6 +992,7 @@ class A2AInvokeService:
             artifact,
             artifact_metadata,
             root_metadata,
+            shared_stream,
         ):
             if message_id is None:
                 message_id = cls._pick_non_empty_str(
@@ -961,6 +1010,7 @@ class A2AInvokeService:
             artifact,
             artifact_metadata,
             root_metadata,
+            shared_stream,
         ):
             if event_id is None:
                 event_id = cls._pick_non_empty_str(candidate, ("event_id", "eventId"))

--- a/backend/tests/test_a2a_invoke_service.py
+++ b/backend/tests/test_a2a_invoke_service.py
@@ -1542,6 +1542,30 @@ def test_extract_stream_identity_hints_includes_nested_status_task_fallback():
     assert hints["upstream_task_id"] == "task-from-status"
 
 
+def test_extract_stream_identity_hints_reads_shared_stream_metadata():
+    hints = a2a_invoke_service.extract_stream_identity_hints_from_serialized_event(
+        {
+            "kind": "artifact-update",
+            "artifact": {
+                "parts": [{"kind": "text", "text": "noop"}],
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "message_id": "msg-shared-stream",
+                            "event_id": "evt-shared-stream",
+                            "sequence": 12,
+                        }
+                    }
+                },
+            },
+        }
+    )
+
+    assert hints["upstream_message_id"] == "msg-shared-stream"
+    assert hints["upstream_event_id"] == "evt-shared-stream"
+    assert hints["upstream_event_seq"] == 12
+
+
 def test_extract_stream_chunk_reads_canonical_event_and_message_ids():
     chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
         {

--- a/backend/tests/test_a2a_invoke_service_contract_fallback.py
+++ b/backend/tests/test_a2a_invoke_service_contract_fallback.py
@@ -62,3 +62,31 @@ def test_extract_stream_chunk_reads_root_metadata_hints():
     assert chunk["block_type"] == "text"
     assert chunk["message_id"] == "msg-root"
     assert chunk["event_id"] == "evt-root"
+
+
+def test_extract_stream_chunk_prefers_shared_stream_block_type_over_text_part_kind():
+    chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
+        {
+            "kind": "artifact-update",
+            "artifact": {
+                "parts": [{"kind": "text", "text": '{"tool":"bash"}'}],
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "block_type": "tool_call",
+                            "source": "tool_part_update",
+                            "message_id": "msg-shared",
+                            "event_id": "evt-shared",
+                            "sequence": 7,
+                        }
+                    }
+                },
+            },
+        }
+    )
+    assert chunk is not None
+    assert chunk["block_type"] == "tool_call"
+    assert chunk["message_id"] == "msg-shared"
+    assert chunk["event_id"] == "evt-shared"
+    assert chunk["seq"] == 7
+    assert chunk["source"] == "tool_part_update"

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -220,6 +220,33 @@ describe("block-based stream parser and reducer", () => {
     expect(parsed?.blockType).toBe("reasoning");
   });
 
+  it("prefers shared.stream metadata for tool_call blocks carried in text parts", () => {
+    const parsed = extractStreamBlockUpdate({
+      kind: "artifact-update",
+      taskId: "task-10",
+      artifact: {
+        artifactId: "task-10:stream",
+        parts: [{ kind: "text", text: '{"tool":"bash","status":"running"}' }],
+        metadata: {
+          shared: {
+            stream: {
+              block_type: "tool_call",
+              source: "tool_part_update",
+              message_id: "msg-shared",
+              event_id: "evt-shared",
+              sequence: 10,
+            },
+          },
+        },
+      },
+    });
+    expect(parsed?.blockType).toBe("tool_call");
+    expect(parsed?.messageId).toBe("msg-shared");
+    expect(parsed?.eventId).toBe("evt-shared");
+    expect(parsed?.seq).toBe(10);
+    expect(parsed?.source).toBe("tool_part_update");
+  });
+
   it("infers text block type when explicit metadata is missing", () => {
     const parsed = extractStreamBlockUpdate({
       kind: "artifact-update",

--- a/frontend/lib/api/chat-utils.ts
+++ b/frontend/lib/api/chat-utils.ts
@@ -347,6 +347,21 @@ const buildFallbackEventId = ({
   return `chunk:${messageId}:${artifactId}`;
 };
 
+const extractSharedStreamMetadata = (
+  artifactMetadata: Record<string, unknown> | null,
+  rootMetadata: Record<string, unknown> | null,
+) => {
+  const resolved: Record<string, unknown> = {};
+  for (const metadata of [rootMetadata, artifactMetadata]) {
+    const shared = asRecord(metadata?.shared);
+    const stream = asRecord(shared?.stream);
+    if (stream) {
+      Object.assign(resolved, stream);
+    }
+  }
+  return Object.keys(resolved).length > 0 ? resolved : null;
+};
+
 export const extractStreamBlockUpdate = (
   data: Record<string, unknown>,
 ): StreamBlockUpdate | null => {
@@ -357,9 +372,11 @@ export const extractStreamBlockUpdate = (
   const artifact = asRecord(data.artifact);
   const rootMetadata = asRecord(data.metadata);
   const metadata = asRecord(artifact?.metadata) ?? rootMetadata;
+  const sharedStream = extractSharedStreamMetadata(metadata, rootMetadata);
   const parts = Array.isArray(artifact?.parts) ? artifact.parts : [];
   const textFromParts = extractTextFromParts(parts);
   const rawBlockType =
+    pickString(sharedStream, ["block_type"]) ??
     pickString(metadata, ["block_type"]) ??
     pickString(rootMetadata, ["block_type"]);
   const explicitBlockType = parseBlockType(rawBlockType);
@@ -374,7 +391,8 @@ export const extractStreamBlockUpdate = (
     pickInteger(data, ["seq"]) ??
     pickInteger(artifact ?? null, ["seq"]) ??
     pickInteger(metadata, ["seq"]) ??
-    pickInteger(rootMetadata, ["seq"]);
+    pickInteger(rootMetadata, ["seq"]) ??
+    pickInteger(sharedStream, ["sequence", "seq"]);
 
   const artifactId =
     pickString(artifact ?? null, ["artifact_id", "artifactId", "id"]) ?? null;
@@ -388,7 +406,8 @@ export const extractStreamBlockUpdate = (
     pickString(data, ["message_id", "messageId"]) ??
     pickString(artifact ?? null, ["message_id", "messageId"]) ??
     pickString(metadata, ["message_id", "messageId"]) ??
-    pickString(rootMetadata, ["message_id", "messageId"]);
+    pickString(rootMetadata, ["message_id", "messageId"]) ??
+    pickString(sharedStream, ["message_id", "messageId"]);
   const resolvedMessageId =
     upstreamMessageId ?? (taskIdHint ? `task:${taskIdHint}` : null);
   const resolvedArtifactId =
@@ -427,7 +446,8 @@ export const extractStreamBlockUpdate = (
     pickString(data, ["event_id", "eventId"]) ??
     pickString(artifact ?? null, ["event_id", "eventId"]) ??
     pickString(metadata, ["event_id", "eventId"]) ??
-    pickString(rootMetadata, ["event_id", "eventId"]);
+    pickString(rootMetadata, ["event_id", "eventId"]) ??
+    pickString(sharedStream, ["event_id", "eventId"]);
   const eventId = upstreamEventId
     ? upstreamEventId
     : buildFallbackEventId({
@@ -442,11 +462,13 @@ export const extractStreamBlockUpdate = (
       : "fallback_chunk";
 
   const source =
+    pickString(sharedStream, ["source"]) ??
     pickString(metadata, ["source"]) ??
     pickString(rootMetadata, ["source"]) ??
     null;
   const role = normalizeRole(
     pickString(data, ["role"]) ??
+      pickString(sharedStream, ["role"]) ??
       pickString(metadata, ["role"]) ??
       pickString(rootMetadata, ["role"]),
   );


### PR DESCRIPTION
## Summary

修复 `artifact.metadata.shared.stream` 仅存在于嵌套元数据时，hub 前后端将 `tool_call` / `reasoning` 误回退为 `text` 的问题。

本 PR 做了三件事：

1. backend 解析 `artifact-update` 时，优先读取 `artifact.metadata.shared.stream` 中的：
   - `block_type`
   - `source`
   - `message_id`
   - `event_id`
   - `sequence`
2. frontend 运行时解析流块时，采用同样的优先级。
3. 补充回归测试，覆盖 `shared.stream.tool_call + TextPart` 的样本。

## Linked Issues

- Closes #446
- 参考上游建议：
  - Intelligent-Internet/opencode-a2a-serve#155
  - liujuanjuan1984/codex-a2a-serve#25

## Acceptance Criteria

- 给定 `artifact.metadata.shared.stream.block_type = tool_call` 且 `parts.kind = text` 的样本：
  - backend 解析结果为 `tool_call`
  - frontend 解析结果为 `tool_call`
- 共享流元数据缺失时，保留当前 text fallback 行为
- 不引入现有 `text/reasoning/tool_call` 流块回归

## Verification

### Backend scoped

```bash
cd backend
uv run pre-commit run --files app/services/a2a_invoke_service.py tests/test_a2a_invoke_service.py tests/test_a2a_invoke_service_contract_fallback.py --config ../.pre-commit-config.yaml
uv run pytest tests/test_a2a_invoke_service.py tests/test_a2a_invoke_service_contract_fallback.py
```

结果：`58 passed`

### Frontend scoped

```bash
cd frontend
npm run lint
export NODE_OPTIONS="--max-old-space-size=1024"
npm run check-types
npm test -- --findRelatedTests lib/api/chat-utils.ts lib/__tests__/streamContract.test.ts --maxWorkers=25%
```

结果：`32 suites passed, 148 tests passed`
