### PR TITLE
refactor(backend): split A2A schedule service domains (#458)

### DIFF
--- a/backend/app/services/a2a_schedule_common.py
+++ b/backend/app/services/a2a_schedule_common.py
@@ -1,0 +1,106 @@
+"""Common types and errors for A2A schedule services."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from functools import wraps
+from typing import Any, TypeVar
+from uuid import UUID
+
+from sqlalchemy.exc import DBAPIError
+
+from app.db.locking import (
+    to_retryable_db_lock_error,
+    to_retryable_db_query_timeout_error,
+)
+
+
+class A2AScheduleError(RuntimeError):
+    """Base error for A2A schedule operations."""
+
+
+class A2AScheduleNotFoundError(A2AScheduleError):
+    """Raised when a schedule cannot be located for the user."""
+
+
+class A2AScheduleValidationError(A2AScheduleError):
+    """Raised when schedule payload validation fails."""
+
+
+class A2AScheduleQuotaError(A2AScheduleError):
+    """Raised when a schedule task operation exceeds user quotas."""
+
+
+class A2AScheduleConflictError(A2AScheduleError):
+    """Raised when a schedule task operation is in conflict with its current state."""
+
+
+class A2AScheduleServiceBusyError(A2AScheduleError):
+    """Raised when a schedule operation times out due to transient DB pressure."""
+
+
+@dataclass(frozen=True)
+class ClaimedA2AScheduleTask:
+    """Snapshot describing a due task claimed by the scheduler."""
+
+    task_id: UUID
+    user_id: UUID
+    agent_id: UUID
+    conversation_id: UUID | None
+    name: str
+    prompt: str
+    cycle_type: str
+    time_point: dict[str, Any]
+    scheduled_for: datetime
+    run_id: UUID
+
+
+_ScheduleResultT = TypeVar("_ScheduleResultT")
+
+
+def map_retryable_db_errors(
+    operation: str,
+) -> Callable[
+    [Callable[..., Awaitable[_ScheduleResultT]]],
+    Callable[..., Awaitable[_ScheduleResultT]],
+]:
+    def decorator(
+        fn: Callable[..., Awaitable[_ScheduleResultT]],
+    ) -> Callable[..., Awaitable[_ScheduleResultT]]:
+        @wraps(fn)
+        async def wrapper(
+            self: Any,
+            *args: Any,
+            **kwargs: Any,
+        ) -> _ScheduleResultT:
+            try:
+                return await fn(self, *args, **kwargs)
+            except DBAPIError as exc:
+                retryable_lock_error = to_retryable_db_lock_error(
+                    exc,
+                    lock_message=(
+                        f"{operation} is currently locked by another operation; retry shortly."
+                    ),
+                )
+                if retryable_lock_error is not None:
+                    raise A2AScheduleConflictError(str(retryable_lock_error)) from exc
+
+                retryable_timeout_error = to_retryable_db_query_timeout_error(
+                    exc,
+                    timeout_message=f"{operation} timed out; service busy, retry shortly.",
+                )
+                if retryable_timeout_error is not None:
+                    raise A2AScheduleServiceBusyError(
+                        str(retryable_timeout_error)
+                    ) from exc
+                raise
+
+        return wrapper
+
+    return decorator
+
+
+A2A_SCHEDULE_SOURCE = "scheduled"
+A2A_MANUAL_SOURCE = "manual"

--- a/backend/app/services/a2a_schedule_crud.py
+++ b/backend/app/services/a2a_schedule_crud.py
@@ -1,0 +1,394 @@
+"""CRUD-oriented operations for A2A schedules."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.models.a2a_schedule_execution import A2AScheduleExecution
+from app.db.models.a2a_schedule_task import A2AScheduleTask
+from app.db.transaction import commit_safely
+from app.services.a2a_schedule_common import (
+    A2AScheduleConflictError,
+    A2AScheduleNotFoundError,
+    A2AScheduleValidationError,
+    map_retryable_db_errors,
+)
+from app.services.a2a_schedule_projection import A2AScheduleProjectionService
+from app.services.a2a_schedule_support import A2AScheduleSupport
+from app.services.a2a_schedule_time import A2AScheduleTimeHelper
+from app.utils.timezone_util import ensure_utc, utc_now
+
+_MANUAL_FAILURE_MESSAGE = "Stopped by user as failed"
+
+
+class A2AScheduleCrudService:
+    """Task CRUD, validation, and quota enforcement."""
+
+    def __init__(
+        self,
+        *,
+        support: A2AScheduleSupport,
+        time_helper: A2AScheduleTimeHelper,
+        projection: A2AScheduleProjectionService,
+    ) -> None:
+        self._support = support
+        self._time_helper = time_helper
+        self._projection = projection
+
+    @map_retryable_db_errors("Schedule task list")
+    async def list_tasks(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        page: int,
+        size: int,
+    ) -> tuple[list[A2AScheduleTask], int]:
+        offset = (page - 1) * size
+        stmt = (
+            select(A2AScheduleTask)
+            .where(
+                A2AScheduleTask.user_id == user_id,
+                A2AScheduleTask.deleted_at.is_(None),
+                A2AScheduleTask.delete_requested_at.is_(None),
+            )
+            .order_by(A2AScheduleTask.created_at.desc())
+            .offset(offset)
+            .limit(size)
+        )
+        rows = await db.execute(stmt)
+        items = list(rows.scalars().all())
+        await self._projection.set_tasks_running_projection(db, tasks=items)
+
+        count_stmt = select(func.count(A2AScheduleTask.id)).where(
+            A2AScheduleTask.user_id == user_id,
+            A2AScheduleTask.deleted_at.is_(None),
+            A2AScheduleTask.delete_requested_at.is_(None),
+        )
+        total = int(await db.scalar(count_stmt) or 0)
+        return items, total
+
+    @map_retryable_db_errors("Schedule task read")
+    async def get_task(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+    ) -> A2AScheduleTask:
+        task = await self._support.get_task(db, user_id=user_id, task_id=task_id)
+        return await self._projection.set_task_running_projection(db, task=task)
+
+    @map_retryable_db_errors("Schedule task creation")
+    async def create_task(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        is_superuser: bool,
+        timezone_str: str,
+        name: str,
+        agent_id: UUID,
+        prompt: str,
+        cycle_type: str,
+        time_point: dict[str, Any],
+        enabled: bool,
+        conversation_policy: str = A2AScheduleTask.POLICY_NEW,
+    ) -> A2AScheduleTask:
+        await self._support.apply_nowait_write_timeouts(db)
+        await self._support.ensure_agent_owned(db, user_id=user_id, agent_id=agent_id)
+        if enabled:
+            await self._support.lock_user_row_for_quota(db, user_id=user_id)
+            await self._support.ensure_active_quota(
+                db, user_id=user_id, is_superuser=is_superuser
+            )
+
+        normalized_name = self._time_helper.normalize_name(name)
+        normalized_prompt = self._time_helper.normalize_prompt(prompt)
+        normalized_cycle = self._time_helper.normalize_cycle_type(cycle_type)
+        normalized_conversation_policy = (
+            self._time_helper.normalize_conversation_policy(conversation_policy)
+        )
+        timezone_value = self._time_helper.normalize_timezone_str(timezone_str)
+        normalized_point = self._time_helper.normalize_time_point(
+            cycle_type=normalized_cycle,
+            time_point=time_point,
+            is_superuser=is_superuser,
+            timezone_str=timezone_value,
+        )
+
+        next_run_at: datetime | None = None
+        if enabled:
+            next_run_at = self._time_helper.compute_next_run_at(
+                cycle_type=normalized_cycle,
+                time_point=normalized_point,
+                timezone_str=timezone_value,
+                after_utc=utc_now(),
+                is_superuser=is_superuser,
+            )
+
+        task = A2AScheduleTask(
+            user_id=user_id,
+            name=normalized_name,
+            agent_id=agent_id,
+            prompt=normalized_prompt,
+            cycle_type=normalized_cycle,
+            time_point=normalized_point,
+            conversation_policy=normalized_conversation_policy,
+            enabled=enabled,
+            next_run_at=next_run_at,
+            last_run_status=A2AScheduleTask.STATUS_IDLE,
+        )
+        db.add(task)
+        await commit_safely(db)
+        await db.refresh(task)
+        setattr(task, "is_running", False)
+        return task
+
+    @map_retryable_db_errors("Schedule task update")
+    async def update_task(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+        is_superuser: bool,
+        timezone_str: str,
+        name: str | None = None,
+        agent_id: UUID | None = None,
+        prompt: str | None = None,
+        cycle_type: str | None = None,
+        time_point: dict[str, Any] | None = None,
+        enabled: bool | None = None,
+        conversation_policy: str | None = None,
+    ) -> A2AScheduleTask:
+        await self._support.apply_nowait_write_timeouts(db)
+        await self._support.lock_user_row_for_quota(db, user_id=user_id)
+        task = await self._support.get_task_for_update(
+            db, user_id=user_id, task_id=task_id
+        )
+        timezone_value = self._time_helper.normalize_timezone_str(timezone_str)
+
+        if (
+            await self._projection.get_running_execution(
+                db,
+                task_id=task.id,
+                user_id=task.user_id,
+            )
+            is not None
+        ):
+            raise A2AScheduleConflictError(
+                "Task is currently running and cannot be edited."
+            )
+
+        if enabled is True and not task.enabled:
+            await self._support.ensure_active_quota(
+                db, user_id=user_id, is_superuser=is_superuser
+            )
+
+        if name is not None:
+            task.name = self._time_helper.normalize_name(name)
+
+        if prompt is not None:
+            task.prompt = self._time_helper.normalize_prompt(prompt)
+
+        if agent_id is not None:
+            await self._support.ensure_agent_owned(
+                db, user_id=user_id, agent_id=agent_id
+            )
+            task.agent_id = agent_id
+
+        next_cycle_type = task.cycle_type
+        next_time_point = dict(task.time_point or {})
+
+        if cycle_type is not None:
+            next_cycle_type = self._time_helper.normalize_cycle_type(cycle_type)
+
+        if time_point is not None:
+            next_time_point = dict(time_point)
+
+        schedule_changed = (cycle_type is not None) or (time_point is not None)
+        if schedule_changed:
+            normalized_point = self._time_helper.normalize_time_point(
+                cycle_type=next_cycle_type,
+                time_point=next_time_point,
+                is_superuser=is_superuser,
+                timezone_str=timezone_value,
+            )
+            task.cycle_type = next_cycle_type
+            task.time_point = normalized_point
+
+        if enabled is not None:
+            task.enabled = enabled
+
+        if conversation_policy is not None:
+            task.conversation_policy = self._time_helper.normalize_conversation_policy(
+                conversation_policy
+            )
+
+        should_recompute = False
+        if task.enabled and (schedule_changed or enabled is True):
+            should_recompute = True
+        if not task.enabled:
+            task.next_run_at = None
+
+        if should_recompute:
+            task.next_run_at = self._time_helper.compute_next_run_at(
+                cycle_type=task.cycle_type,
+                time_point=dict(task.time_point or {}),
+                timezone_str=timezone_value,
+                after_utc=utc_now(),
+                is_superuser=is_superuser,
+            )
+
+        await commit_safely(db)
+        await db.refresh(task)
+        setattr(task, "is_running", False)
+        return task
+
+    @map_retryable_db_errors("Schedule task toggle")
+    async def set_enabled(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+        enabled: bool,
+        is_superuser: bool,
+        timezone_str: str,
+    ) -> A2AScheduleTask:
+        await self._support.apply_nowait_write_timeouts(db)
+        await self._support.lock_user_row_for_quota(db, user_id=user_id)
+        task = await self._support.get_task_for_update(
+            db, user_id=user_id, task_id=task_id
+        )
+        if enabled and not task.enabled:
+            await self._support.ensure_active_quota(
+                db, user_id=user_id, is_superuser=is_superuser
+            )
+
+        task.enabled = enabled
+        if enabled:
+            timezone_value = self._time_helper.normalize_timezone_str(timezone_str)
+            task.next_run_at = self._time_helper.compute_next_run_at(
+                cycle_type=task.cycle_type,
+                time_point=dict(task.time_point or {}),
+                timezone_str=timezone_value,
+                after_utc=utc_now(),
+                is_superuser=is_superuser,
+            )
+        else:
+            task.next_run_at = None
+
+        await commit_safely(db)
+        await db.refresh(task)
+        return await self._projection.set_task_running_projection(db, task=task)
+
+    @map_retryable_db_errors("Schedule task deletion")
+    async def delete_task(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+    ) -> None:
+        await self._support.apply_nowait_write_timeouts(db)
+        task = await self._support.get_task_for_update(
+            db, user_id=user_id, task_id=task_id
+        )
+        running_execution = await self._projection.get_running_execution(
+            db,
+            task_id=task.id,
+            user_id=task.user_id,
+        )
+        if running_execution is not None:
+            task.delete_requested_at = utc_now()
+            task.enabled = False
+            task.next_run_at = None
+        else:
+            task.soft_delete()
+            task.enabled = False
+            task.next_run_at = None
+            task.delete_requested_at = None
+        await commit_safely(db)
+
+    @map_retryable_db_errors("Schedule task manual fail")
+    async def mark_task_failed_manually(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+        marked_by_user_id: UUID,
+        reason: str | None = None,
+        marked_at: datetime | None = None,
+    ) -> A2AScheduleTask:
+        del marked_by_user_id
+
+        await self._support.apply_nowait_write_timeouts(db)
+        now_utc = ensure_utc(marked_at or utc_now())
+        manual_error_message = self.build_manual_failure_reason(reason=reason)
+
+        stmt = (
+            select(A2AScheduleTask)
+            .where(
+                and_(
+                    A2AScheduleTask.id == task_id,
+                    A2AScheduleTask.user_id == user_id,
+                    A2AScheduleTask.deleted_at.is_(None),
+                    A2AScheduleTask.delete_requested_at.is_(None),
+                )
+            )
+            .with_for_update(nowait=True)
+            .limit(1)
+        )
+        task = await db.scalar(stmt)
+        if task is None:
+            raise A2AScheduleNotFoundError("Schedule task not found")
+
+        execution = await self._projection.get_running_execution(
+            db,
+            task_id=task.id,
+            user_id=task.user_id,
+            for_update=True,
+        )
+        if execution is None:
+            if task.last_run_status == A2AScheduleTask.STATUS_FAILED:
+                return await self._projection.set_task_running_projection(db, task=task)
+            raise A2AScheduleValidationError(
+                "Only running tasks can be manually marked as failed"
+            )
+
+        if execution.finished_at is None:
+            execution.finished_at = now_utc
+        execution.status = A2AScheduleExecution.STATUS_FAILED
+        execution.error_message = manual_error_message
+        if execution.conversation_id is None:
+            execution.conversation_id = task.conversation_id
+
+        threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
+        self._projection.apply_task_terminal_projection(
+            task,
+            final_status=A2AScheduleTask.STATUS_FAILED,
+            finished_at=now_utc,
+            failure_threshold=threshold,
+        )
+
+        await commit_safely(db)
+        await db.refresh(task)
+        setattr(task, "is_running", False)
+        return task
+
+    @staticmethod
+    def build_manual_failure_reason(
+        *,
+        reason: str | None,
+    ) -> str:
+        normalized_reason = (reason or "").strip()
+        return normalized_reason or _MANUAL_FAILURE_MESSAGE

--- a/backend/app/services/a2a_schedule_dispatch.py
+++ b/backend/app/services/a2a_schedule_dispatch.py
@@ -1,0 +1,453 @@
+"""Dispatch and recovery operations for A2A schedules."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.db.locking import to_retryable_db_lock_error
+from app.db.models.a2a_schedule_execution import A2AScheduleExecution
+from app.db.models.a2a_schedule_task import A2AScheduleTask
+from app.db.models.user import User
+from app.db.transaction import commit_safely
+from app.services.a2a_schedule_common import (
+    A2AScheduleValidationError,
+    ClaimedA2AScheduleTask,
+    map_retryable_db_errors,
+)
+from app.services.a2a_schedule_projection import A2AScheduleProjectionService
+from app.services.a2a_schedule_support import A2AScheduleSupport
+from app.services.a2a_schedule_time import A2AScheduleTimeHelper
+from app.services.ops_metrics import ops_metrics
+from app.utils.timezone_util import ensure_utc, utc_now
+
+logger = get_logger(__name__)
+
+
+class A2AScheduleDispatchService:
+    """Claim, finalize, and recovery behavior for scheduled runs."""
+
+    def __init__(
+        self,
+        *,
+        support: A2AScheduleSupport,
+        time_helper: A2AScheduleTimeHelper,
+        projection: A2AScheduleProjectionService,
+    ) -> None:
+        self._support = support
+        self._time_helper = time_helper
+        self._projection = projection
+
+    async def global_running_execution_count(
+        self,
+        db: AsyncSession,
+    ) -> int:
+        stmt = select(func.count(A2AScheduleExecution.id)).where(
+            A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING
+        )
+        return int((await db.scalar(stmt)) or 0)
+
+    async def enqueue_due_tasks(
+        self,
+        db: AsyncSession,
+        *,
+        now: datetime | None = None,
+        batch_size: int = 20,
+    ) -> int:
+        await self._support.apply_nowait_write_timeouts(db)
+        now_utc = ensure_utc(now or utc_now())
+
+        user_timezone_subquery = (
+            select(User.timezone)
+            .where(User.id == A2AScheduleTask.user_id)
+            .limit(1)
+            .scalar_subquery()
+        )
+        user_is_superuser_subquery = (
+            select(User.is_superuser)
+            .where(User.id == A2AScheduleTask.user_id)
+            .limit(1)
+            .scalar_subquery()
+        )
+
+        has_pending_subquery = (
+            select(1)
+            .where(
+                and_(
+                    A2AScheduleExecution.task_id == A2AScheduleTask.id,
+                    A2AScheduleExecution.status.in_(
+                        [
+                            A2AScheduleExecution.STATUS_PENDING,
+                            A2AScheduleExecution.STATUS_RUNNING,
+                        ]
+                    ),
+                )
+            )
+            .limit(1)
+            .scalar_subquery()
+            .exists()
+        )
+
+        stmt = (
+            select(
+                A2AScheduleTask,
+                user_timezone_subquery.label("user_timezone"),
+                user_is_superuser_subquery.label("user_is_superuser"),
+            )
+            .where(
+                and_(
+                    A2AScheduleTask.deleted_at.is_(None),
+                    A2AScheduleTask.delete_requested_at.is_(None),
+                    A2AScheduleTask.enabled.is_(True),
+                    A2AScheduleTask.next_run_at.is_not(None),
+                    A2AScheduleTask.next_run_at <= now_utc,
+                    ~has_pending_subquery,
+                )
+            )
+            .order_by(A2AScheduleTask.next_run_at.asc(), A2AScheduleTask.id.asc())
+            .limit(batch_size)
+            .with_for_update(skip_locked=True)
+        )
+
+        rows = await db.execute(stmt)
+        enqueued_count = 0
+
+        for row in rows:
+            selected_task = row[0]
+            timezone_value = self._time_helper.normalize_timezone_str(row[1])
+            is_superuser = bool(row[2])
+
+            scheduled_for = ensure_utc(selected_task.next_run_at or now_utc)
+            if selected_task.cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
+                next_run_at = None
+            else:
+                next_run_at = self._time_helper.compute_next_run_at(
+                    cycle_type=selected_task.cycle_type,
+                    time_point=dict(selected_task.time_point or {}),
+                    timezone_str=timezone_value,
+                    after_utc=scheduled_for,
+                    not_before_utc=now_utc,
+                    is_superuser=is_superuser,
+                )
+
+            run_id = uuid4()
+            selected_task.next_run_at = next_run_at
+
+            db.add(
+                A2AScheduleExecution(
+                    user_id=selected_task.user_id,
+                    task_id=selected_task.id,
+                    run_id=run_id,
+                    scheduled_for=scheduled_for,
+                    started_at=None,
+                    last_heartbeat_at=None,
+                    status=A2AScheduleExecution.STATUS_PENDING,
+                    conversation_id=selected_task.conversation_id,
+                )
+            )
+            enqueued_count += 1
+            logger.info("Task %s enqueued, run_id: %s", selected_task.id, run_id)
+
+        await commit_safely(db)
+        return enqueued_count
+
+    async def claim_next_pending_execution(
+        self,
+        db: AsyncSession,
+        *,
+        now: datetime | None = None,
+    ) -> ClaimedA2AScheduleTask | None:
+        await self._support.apply_skip_locked_write_timeouts(db)
+        now_utc = ensure_utc(now or utc_now())
+
+        global_concurrency_limit = max(
+            int(settings.a2a_schedule_global_concurrency_limit), 1
+        )
+        global_running_count = await self.global_running_execution_count(db)
+        if global_running_count >= global_concurrency_limit:
+            return None
+
+        concurrency_limit = max(int(settings.a2a_schedule_agent_concurrency_limit), 1)
+
+        from sqlalchemy.orm import aliased
+
+        task_alias = aliased(A2AScheduleTask)
+        exec_alias = aliased(A2AScheduleExecution)
+
+        running_count_subquery = (
+            select(func.count(exec_alias.id))
+            .join(task_alias, task_alias.id == exec_alias.task_id)
+            .where(
+                and_(
+                    task_alias.agent_id == A2AScheduleTask.agent_id,
+                    exec_alias.status == A2AScheduleExecution.STATUS_RUNNING,
+                )
+            )
+            .correlate(A2AScheduleTask)
+            .scalar_subquery()
+        )
+
+        stmt = (
+            select(A2AScheduleExecution)
+            .join(A2AScheduleTask, A2AScheduleTask.id == A2AScheduleExecution.task_id)
+            .where(
+                and_(
+                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_PENDING,
+                    or_(
+                        A2AScheduleTask.deleted_at.is_not(None),
+                        A2AScheduleTask.enabled.is_(False),
+                        running_count_subquery < concurrency_limit,
+                    ),
+                )
+            )
+            .order_by(
+                A2AScheduleExecution.scheduled_for.asc(), A2AScheduleExecution.id.asc()
+            )
+            .limit(1)
+            .with_for_update(of=A2AScheduleExecution, skip_locked=True)
+        )
+        execution = await db.scalar(stmt)
+        if execution is None:
+            return None
+
+        task_stmt = (
+            select(A2AScheduleTask)
+            .where(A2AScheduleTask.id == execution.task_id)
+            .with_for_update(nowait=True)
+            .limit(1)
+        )
+        try:
+            task = await db.scalar(task_stmt)
+        except DBAPIError as exc:
+            if to_retryable_db_lock_error(exc) is not None:
+                await db.rollback()
+                return None
+            raise
+        if task is None or task.deleted_at is not None or not task.enabled:
+            execution.status = A2AScheduleExecution.STATUS_FAILED
+            execution.finished_at = now_utc
+            execution.error_message = (
+                "Task disabled or deleted before execution started"
+            )
+            await commit_safely(db)
+            return None
+
+        execution.status = A2AScheduleExecution.STATUS_RUNNING
+        execution.started_at = now_utc
+        execution.last_heartbeat_at = now_utc
+
+        await commit_safely(db)
+
+        return ClaimedA2AScheduleTask(
+            task_id=task.id,
+            user_id=task.user_id,
+            agent_id=task.agent_id,
+            conversation_id=execution.conversation_id or task.conversation_id,
+            name=task.name,
+            prompt=task.prompt,
+            cycle_type=task.cycle_type,
+            time_point=dict(task.time_point or {}),
+            scheduled_for=execution.scheduled_for,
+            run_id=execution.run_id,
+        )
+
+    async def recover_stale_running_tasks(
+        self,
+        db: AsyncSession,
+        *,
+        now: datetime | None = None,
+        timeout_seconds: int = 600,
+        hard_timeout_seconds: int | None = None,
+    ) -> int:
+        now_utc = ensure_utc(now or utc_now())
+        timeout_seconds = max(int(timeout_seconds or 0), 1)
+        cutoff = now_utc - timedelta(seconds=timeout_seconds)
+        hard_timeout = (
+            max(int(hard_timeout_seconds or 0), 1) if hard_timeout_seconds else None
+        )
+        hard_cutoff = (
+            now_utc - timedelta(seconds=hard_timeout)
+            if hard_timeout is not None
+            else None
+        )
+        failure_threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
+
+        stale_predicates = [
+            func.coalesce(
+                A2AScheduleExecution.last_heartbeat_at,
+                A2AScheduleExecution.started_at,
+            )
+            <= cutoff
+        ]
+        if hard_cutoff is not None:
+            stale_predicates.append(A2AScheduleExecution.started_at <= hard_cutoff)
+
+        error_message = "Execution marked as failed by recovery: stale running task exceeded timeout"
+        recovered_count = 0
+        while True:
+            await self._support.apply_skip_locked_write_timeouts(db)
+            stale_where = and_(
+                A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
+                A2AScheduleTask.deleted_at.is_(None),
+                or_(*stale_predicates),
+            )
+            stmt = (
+                select(A2AScheduleExecution)
+                .join(
+                    A2AScheduleTask, A2AScheduleTask.id == A2AScheduleExecution.task_id
+                )
+                .where(stale_where)
+                .order_by(
+                    A2AScheduleExecution.started_at.asc(),
+                    A2AScheduleExecution.id.asc(),
+                )
+                .limit(1)
+                .with_for_update(of=A2AScheduleExecution, skip_locked=True)
+            )
+            execution = await db.scalar(stmt)
+            if execution is None:
+                stale_count_stmt = (
+                    select(func.count(A2AScheduleExecution.id))
+                    .join(
+                        A2AScheduleTask,
+                        A2AScheduleTask.id == A2AScheduleExecution.task_id,
+                    )
+                    .where(stale_where)
+                )
+                stale_remaining = int(await db.scalar(stale_count_stmt) or 0)
+                if stale_remaining > 0:
+                    ops_metrics.increment_schedule_recovery_lock_skipped_tasks(
+                        stale_remaining
+                    )
+                    logger.warning(
+                        "Skipped recovery for %d stale schedule task(s) due to row lock contention; retry next cycle.",
+                        stale_remaining,
+                        extra={
+                            "phase": "recovery",
+                            "stale_task_count": stale_remaining,
+                        },
+                    )
+                break
+
+            task_stmt = (
+                select(A2AScheduleTask)
+                .where(A2AScheduleTask.id == execution.task_id)
+                .with_for_update(nowait=True)
+            )
+            try:
+                task = await db.scalar(task_stmt)
+            except DBAPIError as exc:
+                if to_retryable_db_lock_error(exc) is not None:
+                    await db.rollback()
+                    continue
+                raise
+
+            if task is None:
+                await commit_safely(db)
+                continue
+
+            execution.status = A2AScheduleExecution.STATUS_FAILED
+            execution.finished_at = now_utc
+            execution.error_message = error_message
+            if execution.conversation_id is None:
+                execution.conversation_id = task.conversation_id
+
+            self._projection.apply_task_terminal_projection(
+                task,
+                final_status=A2AScheduleTask.STATUS_FAILED,
+                finished_at=now_utc,
+                failure_threshold=failure_threshold,
+                conversation_id=execution.conversation_id,
+            )
+            recovered_count += 1
+
+            await commit_safely(db)
+        return recovered_count
+
+    @map_retryable_db_errors("Schedule task finalize")
+    async def finalize_task_run(
+        self,
+        db: AsyncSession,
+        *,
+        task_id: UUID,
+        user_id: UUID,
+        run_id: UUID,
+        final_status: str,
+        finished_at: datetime,
+        conversation_id: UUID | None = None,
+        response_content: str | None = None,
+        error_message: str | None = None,
+        user_message_id: UUID | None = None,
+        agent_message_id: UUID | None = None,
+    ) -> bool:
+        await self._support.apply_nowait_write_timeouts(db)
+
+        exec_stmt = (
+            select(A2AScheduleExecution)
+            .where(
+                and_(
+                    A2AScheduleExecution.task_id == task_id,
+                    A2AScheduleExecution.user_id == user_id,
+                    A2AScheduleExecution.run_id == run_id,
+                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
+                )
+            )
+            .with_for_update(nowait=True)
+            .limit(1)
+        )
+        execution = await db.scalar(exec_stmt)
+        if execution is None:
+            return False
+
+        stmt = (
+            select(A2AScheduleTask)
+            .where(
+                and_(
+                    A2AScheduleTask.id == task_id,
+                    A2AScheduleTask.user_id == user_id,
+                )
+            )
+            .with_for_update(nowait=True)
+            .limit(1)
+        )
+        task = await db.scalar(stmt)
+        if task is None:
+            return False
+
+        threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
+        if final_status not in {
+            A2AScheduleTask.STATUS_SUCCESS,
+            A2AScheduleTask.STATUS_FAILED,
+        }:
+            raise A2AScheduleValidationError("Unsupported final status for task run")
+
+        execution.status = final_status
+        execution.finished_at = ensure_utc(finished_at)
+        execution.conversation_id = conversation_id
+        execution.response_content = response_content
+        execution.error_message = error_message
+        execution.user_message_id = user_message_id
+        execution.agent_message_id = agent_message_id
+        self._projection.apply_task_terminal_projection(
+            task,
+            final_status=final_status,
+            finished_at=finished_at,
+            failure_threshold=threshold,
+            conversation_id=conversation_id,
+        )
+
+        logger.info(
+            "Task %s finalized (run_id: %s) with status: %s, conv: %s",
+            task_id,
+            run_id,
+            final_status,
+            conversation_id,
+        )
+
+        return True

--- a/backend/app/services/a2a_schedule_projection.py
+++ b/backend/app/services/a2a_schedule_projection.py
@@ -1,0 +1,166 @@
+"""Projection helpers for A2A schedule task state."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.a2a_schedule_execution import A2AScheduleExecution
+from app.db.models.a2a_schedule_task import A2AScheduleTask
+from app.services.a2a_schedule_common import A2AScheduleValidationError
+from app.services.a2a_schedule_support import A2AScheduleSupport
+from app.services.a2a_schedule_time import A2AScheduleTimeHelper
+from app.utils.timezone_util import ensure_utc
+
+
+class A2AScheduleProjectionService:
+    """Read-model and terminal state projection helpers."""
+
+    def __init__(
+        self,
+        *,
+        support: A2AScheduleSupport,
+        time_helper: A2AScheduleTimeHelper,
+    ) -> None:
+        self._support = support
+        self._time_helper = time_helper
+
+    async def get_running_execution(
+        self,
+        db: AsyncSession,
+        *,
+        task_id: UUID,
+        user_id: UUID,
+        for_update: bool = False,
+    ) -> A2AScheduleExecution | None:
+        stmt = (
+            select(A2AScheduleExecution)
+            .where(
+                and_(
+                    A2AScheduleExecution.task_id == task_id,
+                    A2AScheduleExecution.user_id == user_id,
+                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
+                )
+            )
+            .order_by(A2AScheduleExecution.id.asc())
+            .limit(1)
+        )
+        if for_update:
+            stmt = stmt.with_for_update(nowait=True)
+        return await db.scalar(stmt)
+
+    async def set_task_running_projection(
+        self,
+        db: AsyncSession,
+        *,
+        task: A2AScheduleTask,
+    ) -> A2AScheduleTask:
+        running_execution = await self.get_running_execution(
+            db,
+            task_id=task.id,
+            user_id=task.user_id,
+        )
+        setattr(task, "is_running", running_execution is not None)
+        return task
+
+    async def set_tasks_running_projection(
+        self,
+        db: AsyncSession,
+        *,
+        tasks: list[A2AScheduleTask],
+    ) -> None:
+        if not tasks:
+            return
+
+        task_ids = [task.id for task in tasks]
+        running_task_ids = set(
+            (
+                await db.scalars(
+                    select(A2AScheduleExecution.task_id)
+                    .where(
+                        A2AScheduleExecution.task_id.in_(task_ids),
+                        A2AScheduleExecution.status
+                        == A2AScheduleExecution.STATUS_RUNNING,
+                    )
+                    .distinct()
+                )
+            ).all()
+        )
+        for task in tasks:
+            setattr(task, "is_running", task.id in running_task_ids)
+
+    async def list_executions(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+        page: int,
+        size: int,
+    ) -> tuple[list[A2AScheduleExecution], int]:
+        await self._support.get_task(db, user_id=user_id, task_id=task_id)
+
+        offset = (page - 1) * size
+        stmt = (
+            select(A2AScheduleExecution)
+            .where(
+                A2AScheduleExecution.user_id == user_id,
+                A2AScheduleExecution.task_id == task_id,
+            )
+            .order_by(
+                A2AScheduleExecution.started_at.desc(),
+                A2AScheduleExecution.id.desc(),
+            )
+            .offset(offset)
+            .limit(size)
+        )
+        rows = await db.execute(stmt)
+        items = list(rows.scalars().all())
+
+        count_stmt = select(func.count(A2AScheduleExecution.id)).where(
+            A2AScheduleExecution.user_id == user_id,
+            A2AScheduleExecution.task_id == task_id,
+        )
+        total = int(await db.scalar(count_stmt) or 0)
+        return items, total
+
+    def apply_task_terminal_projection(
+        self,
+        task: A2AScheduleTask,
+        *,
+        final_status: str,
+        finished_at: datetime,
+        failure_threshold: int,
+        conversation_id: UUID | None = None,
+    ) -> None:
+        finished_at_utc = ensure_utc(finished_at)
+        task.last_run_status = final_status
+        task.last_run_at = finished_at_utc
+        if conversation_id is not None:
+            task.conversation_id = conversation_id
+
+        if final_status == A2AScheduleTask.STATUS_SUCCESS:
+            task.consecutive_failures = 0
+        elif final_status == A2AScheduleTask.STATUS_FAILED:
+            task.consecutive_failures = (task.consecutive_failures or 0) + 1
+            if task.consecutive_failures >= failure_threshold:
+                task.enabled = False
+        else:
+            raise A2AScheduleValidationError("Unsupported final status for task run")
+
+        if task.delete_requested_at is not None:
+            task.soft_delete()
+            task.enabled = False
+            task.next_run_at = None
+            task.delete_requested_at = None
+        elif task.cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
+            if task.enabled:
+                task.next_run_at = self._time_helper.compute_sequential_next_run_at(
+                    time_point=dict(task.time_point or {}),
+                    after_utc=finished_at_utc,
+                )
+            else:
+                task.next_run_at = None

--- a/backend/app/services/a2a_schedule_service.py
+++ b/backend/app/services/a2a_schedule_service.py
@@ -1,284 +1,54 @@
-"""Business logic for user-configurable A2A schedules."""
+"""Facade for user-configurable A2A schedules."""
 
 from __future__ import annotations
 
-import calendar
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from datetime import datetime, time, timedelta, timezone
-from functools import wraps
-from typing import Any, Dict, Optional, TypeVar
-from uuid import UUID, uuid4
+from datetime import datetime
+from typing import Any
+from uuid import UUID
 
-from sqlalchemy import and_, func, or_, select
-from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
-from app.core.logging import get_logger
-from app.db.locking import (
-    set_postgres_local_timeouts,
-    to_retryable_db_lock_error,
-    to_retryable_db_query_timeout_error,
-)
-from app.db.models.a2a_agent import A2AAgent
 from app.db.models.a2a_schedule_execution import A2AScheduleExecution
 from app.db.models.a2a_schedule_task import A2AScheduleTask
-from app.db.models.user import User
-from app.db.transaction import commit_safely
-from app.services.ops_metrics import ops_metrics
-from app.utils.timezone_util import ensure_utc, resolve_timezone, utc_now
-
-_MANUAL_FAILURE_MESSAGE = "Stopped by user as failed"
-logger = get_logger(__name__)
-
-
-class A2AScheduleError(RuntimeError):
-    """Base error for A2A schedule operations."""
-
-
-class A2AScheduleNotFoundError(A2AScheduleError):
-    """Raised when a schedule cannot be located for the user."""
-
-
-class A2AScheduleValidationError(A2AScheduleError):
-    """Raised when schedule payload validation fails."""
-
-
-class A2AScheduleQuotaError(A2AScheduleError):
-    """Raised when a schedule task operation exceeds user quotas."""
-
-
-class A2AScheduleConflictError(A2AScheduleError):
-    """Raised when a schedule task operation is in conflict with its current state."""
-
-
-class A2AScheduleServiceBusyError(A2AScheduleError):
-    """Raised when a schedule operation times out due to transient DB pressure."""
-
-
-_ScheduleResultT = TypeVar("_ScheduleResultT")
-
-
-def _map_retryable_db_errors(
-    operation: str,
-) -> Callable[
-    [Callable[..., Awaitable[_ScheduleResultT]]],
-    Callable[..., Awaitable[_ScheduleResultT]],
-]:
-    def decorator(
-        fn: Callable[..., Awaitable[_ScheduleResultT]],
-    ) -> Callable[..., Awaitable[_ScheduleResultT]]:
-        @wraps(fn)
-        async def wrapper(
-            self: "A2AScheduleService",
-            *args: Any,
-            **kwargs: Any,
-        ) -> _ScheduleResultT:
-            try:
-                return await fn(self, *args, **kwargs)
-            except DBAPIError as exc:
-                retryable_lock_error = to_retryable_db_lock_error(
-                    exc,
-                    lock_message=(
-                        f"{operation} is currently locked by another operation; retry shortly."
-                    ),
-                )
-                if retryable_lock_error is not None:
-                    raise A2AScheduleConflictError(str(retryable_lock_error)) from exc
-
-                retryable_timeout_error = to_retryable_db_query_timeout_error(
-                    exc,
-                    timeout_message=f"{operation} timed out; service busy, retry shortly.",
-                )
-                if retryable_timeout_error is not None:
-                    raise A2AScheduleServiceBusyError(
-                        str(retryable_timeout_error)
-                    ) from exc
-                raise
-
-        return wrapper
-
-    return decorator
-
-
-@dataclass(frozen=True)
-class ClaimedA2AScheduleTask:
-    """Snapshot describing a due task claimed by the scheduler."""
-
-    task_id: UUID
-    user_id: UUID
-    agent_id: UUID
-    conversation_id: Optional[UUID]
-    name: str
-    prompt: str
-    cycle_type: str
-    time_point: Dict[str, Any]
-    scheduled_for: datetime
-    run_id: UUID
+from app.services.a2a_schedule_common import (
+    A2A_MANUAL_SOURCE,
+    A2A_SCHEDULE_SOURCE,
+    A2AScheduleConflictError,
+    A2AScheduleError,
+    A2AScheduleNotFoundError,
+    A2AScheduleQuotaError,
+    A2AScheduleServiceBusyError,
+    A2AScheduleValidationError,
+    ClaimedA2AScheduleTask,
+)
+from app.services.a2a_schedule_crud import A2AScheduleCrudService
+from app.services.a2a_schedule_dispatch import A2AScheduleDispatchService
+from app.services.a2a_schedule_projection import A2AScheduleProjectionService
+from app.services.a2a_schedule_support import A2AScheduleSupport
+from app.services.a2a_schedule_time import A2AScheduleTimeHelper
 
 
 class A2AScheduleService:
-    """CRUD, validation, and dispatch helpers for A2A schedules."""
+    """Stable façade for schedule CRUD, dispatch, and projection workflows."""
 
-    _schedule_minutes_min = 5
-    _schedule_minutes_max = 24 * 60
-    _default_write_lock_timeout_ms = 500
-    _default_write_statement_timeout_ms = 5000
-
-    _allowed_cycle_types = {
-        A2AScheduleTask.CYCLE_DAILY,
-        A2AScheduleTask.CYCLE_WEEKLY,
-        A2AScheduleTask.CYCLE_MONTHLY,
-        A2AScheduleTask.CYCLE_INTERVAL,
-        A2AScheduleTask.CYCLE_SEQUENTIAL,
-    }
-    _allowed_conversation_policies = {
-        A2AScheduleTask.POLICY_NEW,
-        A2AScheduleTask.POLICY_REUSE,
-    }
-
-    @staticmethod
-    def _normalize_timezone_str(timezone_str: str | None) -> str:
-        return (timezone_str or "UTC").strip() or "UTC"
-
-    async def _apply_default_write_timeouts(self, db: AsyncSession) -> None:
-        await set_postgres_local_timeouts(
-            db,
-            lock_timeout_ms=self._default_write_lock_timeout_ms,
-            statement_timeout_ms=self._default_write_statement_timeout_ms,
+    def __init__(self) -> None:
+        self._support = A2AScheduleSupport()
+        self._time_helper = A2AScheduleTimeHelper()
+        self._projection = A2AScheduleProjectionService(
+            support=self._support,
+            time_helper=self._time_helper,
+        )
+        self._crud = A2AScheduleCrudService(
+            support=self._support,
+            time_helper=self._time_helper,
+            projection=self._projection,
+        )
+        self._dispatch = A2AScheduleDispatchService(
+            support=self._support,
+            time_helper=self._time_helper,
+            projection=self._projection,
         )
 
-    async def _apply_nowait_write_timeouts(self, db: AsyncSession) -> None:
-        """Apply only statement timeout for NOWAIT lock paths.
-
-        NOWAIT does not wait for row locks, so lock_timeout is redundant there.
-        """
-
-        await set_postgres_local_timeouts(
-            db,
-            statement_timeout_ms=self._default_write_statement_timeout_ms,
-        )
-
-    async def _apply_skip_locked_write_timeouts(self, db: AsyncSession) -> None:
-        """Apply only statement timeout for SKIP LOCKED lock paths."""
-
-        await set_postgres_local_timeouts(
-            db,
-            statement_timeout_ms=self._default_write_statement_timeout_ms,
-        )
-
-    async def _lock_user_row_for_quota(
-        self, db: AsyncSession, *, user_id: UUID
-    ) -> None:
-        """Serialize per-user quota-changing operations using Postgres advisory locks."""
-        import hashlib
-
-        from sqlalchemy import text
-
-        lock_key_str = f"a2a_schedule_quota_{user_id.hex}"
-        # Convert first 8 bytes of hash to signed 64-bit int
-        hash_digest = hashlib.md5(lock_key_str.encode()).digest()
-        lock_id = int.from_bytes(hash_digest[:8], byteorder="big", signed=True)
-
-        stmt = text("SELECT pg_try_advisory_xact_lock(:lock_id)")
-        lock_acquired = await db.scalar(stmt, {"lock_id": lock_id})
-
-        if not lock_acquired:
-            raise A2AScheduleConflictError(
-                "Unable to acquire advisory lock for schedule quota check. Please try again."
-            )
-
-    async def _get_task_for_update(
-        self,
-        db: AsyncSession,
-        *,
-        user_id: UUID,
-        task_id: UUID,
-    ) -> A2AScheduleTask:
-        stmt = (
-            select(A2AScheduleTask)
-            .where(
-                and_(
-                    A2AScheduleTask.id == task_id,
-                    A2AScheduleTask.user_id == user_id,
-                    A2AScheduleTask.deleted_at.is_(None),
-                    A2AScheduleTask.delete_requested_at.is_(None),
-                )
-            )
-            .with_for_update(nowait=True)
-            .limit(1)
-        )
-        task = await db.scalar(stmt)
-        if task is None:
-            raise A2AScheduleNotFoundError("Schedule task not found")
-        return task
-
-    async def _get_running_execution(
-        self,
-        db: AsyncSession,
-        *,
-        task_id: UUID,
-        user_id: UUID,
-        for_update: bool = False,
-    ) -> A2AScheduleExecution | None:
-        stmt = (
-            select(A2AScheduleExecution)
-            .where(
-                and_(
-                    A2AScheduleExecution.task_id == task_id,
-                    A2AScheduleExecution.user_id == user_id,
-                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
-                )
-            )
-            .order_by(A2AScheduleExecution.id.asc())
-            .limit(1)
-        )
-        if for_update:
-            stmt = stmt.with_for_update(nowait=True)
-        return await db.scalar(stmt)
-
-    async def _set_task_running_projection(
-        self,
-        db: AsyncSession,
-        *,
-        task: A2AScheduleTask,
-    ) -> A2AScheduleTask:
-        running_execution = await self._get_running_execution(
-            db,
-            task_id=task.id,
-            user_id=task.user_id,
-        )
-        setattr(task, "is_running", running_execution is not None)
-        return task
-
-    async def _set_tasks_running_projection(
-        self,
-        db: AsyncSession,
-        *,
-        tasks: list[A2AScheduleTask],
-    ) -> None:
-        if not tasks:
-            return
-
-        task_ids = [task.id for task in tasks]
-        running_task_ids = set(
-            (
-                await db.scalars(
-                    select(A2AScheduleExecution.task_id)
-                    .where(
-                        A2AScheduleExecution.task_id.in_(task_ids),
-                        A2AScheduleExecution.status
-                        == A2AScheduleExecution.STATUS_RUNNING,
-                    )
-                    .distinct()
-                )
-            ).all()
-        )
-        for task in tasks:
-            setattr(task, "is_running", task.id in running_task_ids)
-
-    @_map_retryable_db_errors("Schedule task list")
     async def list_tasks(
         self,
         db: AsyncSession,
@@ -287,31 +57,8 @@ class A2AScheduleService:
         page: int,
         size: int,
     ) -> tuple[list[A2AScheduleTask], int]:
-        offset = (page - 1) * size
-        stmt = (
-            select(A2AScheduleTask)
-            .where(
-                A2AScheduleTask.user_id == user_id,
-                A2AScheduleTask.deleted_at.is_(None),
-                A2AScheduleTask.delete_requested_at.is_(None),
-            )
-            .order_by(A2AScheduleTask.created_at.desc())
-            .offset(offset)
-            .limit(size)
-        )
-        rows = await db.execute(stmt)
-        items = list(rows.scalars().all())
-        await self._set_tasks_running_projection(db, tasks=items)
+        return await self._crud.list_tasks(db, user_id=user_id, page=page, size=size)
 
-        count_stmt = select(func.count(A2AScheduleTask.id)).where(
-            A2AScheduleTask.user_id == user_id,
-            A2AScheduleTask.deleted_at.is_(None),
-            A2AScheduleTask.delete_requested_at.is_(None),
-        )
-        total = int(await db.scalar(count_stmt) or 0)
-        return items, total
-
-    @_map_retryable_db_errors("Schedule task read")
     async def get_task(
         self,
         db: AsyncSession,
@@ -319,10 +66,8 @@ class A2AScheduleService:
         user_id: UUID,
         task_id: UUID,
     ) -> A2AScheduleTask:
-        task = await self._get_task(db, user_id=user_id, task_id=task_id)
-        return await self._set_task_running_projection(db, task=task)
+        return await self._crud.get_task(db, user_id=user_id, task_id=task_id)
 
-    @_map_retryable_db_errors("Schedule task creation")
     async def create_task(
         self,
         db: AsyncSession,
@@ -334,61 +79,24 @@ class A2AScheduleService:
         agent_id: UUID,
         prompt: str,
         cycle_type: str,
-        time_point: Dict[str, Any],
+        time_point: dict[str, Any],
         enabled: bool,
         conversation_policy: str = A2AScheduleTask.POLICY_NEW,
     ) -> A2AScheduleTask:
-        await self._apply_nowait_write_timeouts(db)
-        await self._ensure_agent_owned(db, user_id=user_id, agent_id=agent_id)
-        if enabled:
-            await self._lock_user_row_for_quota(db, user_id=user_id)
-            await self._ensure_active_quota(
-                db, user_id=user_id, is_superuser=is_superuser
-            )
-
-        normalized_name = self._normalize_name(name)
-        normalized_prompt = self._normalize_prompt(prompt)
-        normalized_cycle = self._normalize_cycle_type(cycle_type)
-        normalized_conversation_policy = self._normalize_conversation_policy(
-            conversation_policy
-        )
-        timezone_value = self._normalize_timezone_str(timezone_str)
-        normalized_point = self._normalize_time_point(
-            cycle_type=normalized_cycle,
-            time_point=time_point,
-            is_superuser=is_superuser,
-            timezone_str=timezone_value,
-        )
-
-        next_run_at: Optional[datetime] = None
-        if enabled:
-            next_run_at = self.compute_next_run_at(
-                cycle_type=normalized_cycle,
-                time_point=normalized_point,
-                timezone_str=timezone_value,
-                after_utc=utc_now(),
-                is_superuser=is_superuser,
-            )
-
-        task = A2AScheduleTask(
+        return await self._crud.create_task(
+            db,
             user_id=user_id,
-            name=normalized_name,
+            is_superuser=is_superuser,
+            timezone_str=timezone_str,
+            name=name,
             agent_id=agent_id,
-            prompt=normalized_prompt,
-            cycle_type=normalized_cycle,
-            time_point=normalized_point,
-            conversation_policy=normalized_conversation_policy,
+            prompt=prompt,
+            cycle_type=cycle_type,
+            time_point=time_point,
             enabled=enabled,
-            next_run_at=next_run_at,
-            last_run_status=A2AScheduleTask.STATUS_IDLE,
+            conversation_policy=conversation_policy,
         )
-        db.add(task)
-        await commit_safely(db)
-        await db.refresh(task)
-        setattr(task, "is_running", False)
-        return task
 
-    @_map_retryable_db_errors("Schedule task update")
     async def update_task(
         self,
         db: AsyncSession,
@@ -397,95 +105,29 @@ class A2AScheduleService:
         task_id: UUID,
         is_superuser: bool,
         timezone_str: str,
-        name: Optional[str] = None,
-        agent_id: Optional[UUID] = None,
-        prompt: Optional[str] = None,
-        cycle_type: Optional[str] = None,
-        time_point: Optional[Dict[str, Any]] = None,
-        enabled: Optional[bool] = None,
-        conversation_policy: Optional[str] = None,
+        name: str | None = None,
+        agent_id: UUID | None = None,
+        prompt: str | None = None,
+        cycle_type: str | None = None,
+        time_point: dict[str, Any] | None = None,
+        enabled: bool | None = None,
+        conversation_policy: str | None = None,
     ) -> A2AScheduleTask:
-        await self._apply_nowait_write_timeouts(db)
-        await self._lock_user_row_for_quota(db, user_id=user_id)
-        task = await self._get_task_for_update(db, user_id=user_id, task_id=task_id)
-        timezone_value = self._normalize_timezone_str(timezone_str)
+        return await self._crud.update_task(
+            db,
+            user_id=user_id,
+            task_id=task_id,
+            is_superuser=is_superuser,
+            timezone_str=timezone_str,
+            name=name,
+            agent_id=agent_id,
+            prompt=prompt,
+            cycle_type=cycle_type,
+            time_point=time_point,
+            enabled=enabled,
+            conversation_policy=conversation_policy,
+        )
 
-        if (
-            await self._get_running_execution(
-                db,
-                task_id=task.id,
-                user_id=task.user_id,
-            )
-            is not None
-        ):
-            raise A2AScheduleConflictError(
-                "Task is currently running and cannot be edited."
-            )
-
-        if enabled is True and not task.enabled:
-            await self._ensure_active_quota(
-                db, user_id=user_id, is_superuser=is_superuser
-            )
-
-        if name is not None:
-            task.name = self._normalize_name(name)
-
-        if prompt is not None:
-            task.prompt = self._normalize_prompt(prompt)
-
-        if agent_id is not None:
-            await self._ensure_agent_owned(db, user_id=user_id, agent_id=agent_id)
-            task.agent_id = agent_id
-
-        next_cycle_type = task.cycle_type
-        next_time_point = dict(task.time_point or {})
-
-        if cycle_type is not None:
-            next_cycle_type = self._normalize_cycle_type(cycle_type)
-
-        if time_point is not None:
-            next_time_point = dict(time_point)
-
-        schedule_changed = (cycle_type is not None) or (time_point is not None)
-        if schedule_changed:
-            normalized_point = self._normalize_time_point(
-                cycle_type=next_cycle_type,
-                time_point=next_time_point,
-                is_superuser=is_superuser,
-                timezone_str=timezone_value,
-            )
-            task.cycle_type = next_cycle_type
-            task.time_point = normalized_point
-
-        if enabled is not None:
-            task.enabled = enabled
-
-        if conversation_policy is not None:
-            task.conversation_policy = self._normalize_conversation_policy(
-                conversation_policy
-            )
-
-        should_recompute = False
-        if task.enabled and (schedule_changed or enabled is True):
-            should_recompute = True
-        if not task.enabled:
-            task.next_run_at = None
-
-        if should_recompute:
-            task.next_run_at = self.compute_next_run_at(
-                cycle_type=task.cycle_type,
-                time_point=dict(task.time_point or {}),
-                timezone_str=timezone_value,
-                after_utc=utc_now(),
-                is_superuser=is_superuser,
-            )
-
-        await commit_safely(db)
-        await db.refresh(task)
-        setattr(task, "is_running", False)
-        return task
-
-    @_map_retryable_db_errors("Schedule task toggle")
     async def set_enabled(
         self,
         db: AsyncSession,
@@ -496,32 +138,15 @@ class A2AScheduleService:
         is_superuser: bool,
         timezone_str: str,
     ) -> A2AScheduleTask:
-        await self._apply_nowait_write_timeouts(db)
-        await self._lock_user_row_for_quota(db, user_id=user_id)
-        task = await self._get_task_for_update(db, user_id=user_id, task_id=task_id)
-        if enabled and not task.enabled:
-            await self._ensure_active_quota(
-                db, user_id=user_id, is_superuser=is_superuser
-            )
+        return await self._crud.set_enabled(
+            db,
+            user_id=user_id,
+            task_id=task_id,
+            enabled=enabled,
+            is_superuser=is_superuser,
+            timezone_str=timezone_str,
+        )
 
-        task.enabled = enabled
-        if enabled:
-            timezone_value = self._normalize_timezone_str(timezone_str)
-            task.next_run_at = self.compute_next_run_at(
-                cycle_type=task.cycle_type,
-                time_point=dict(task.time_point or {}),
-                timezone_str=timezone_value,
-                after_utc=utc_now(),
-                is_superuser=is_superuser,
-            )
-        else:
-            task.next_run_at = None
-
-        await commit_safely(db)
-        await db.refresh(task)
-        return await self._set_task_running_projection(db, task=task)
-
-    @_map_retryable_db_errors("Schedule task deletion")
     async def delete_task(
         self,
         db: AsyncSession,
@@ -529,26 +154,8 @@ class A2AScheduleService:
         user_id: UUID,
         task_id: UUID,
     ) -> None:
-        await self._apply_nowait_write_timeouts(db)
-        task = await self._get_task_for_update(db, user_id=user_id, task_id=task_id)
-        running_execution = await self._get_running_execution(
-            db,
-            task_id=task.id,
-            user_id=task.user_id,
-        )
-        if running_execution is not None:
-            # Keep the row alive until the current run reaches a terminal status.
-            task.delete_requested_at = utc_now()
-            task.enabled = False
-            task.next_run_at = None
-        else:
-            task.soft_delete()
-            task.enabled = False
-            task.next_run_at = None
-            task.delete_requested_at = None
-        await commit_safely(db)
+        await self._crud.delete_task(db, user_id=user_id, task_id=task_id)
 
-    @_map_retryable_db_errors("Schedule task manual fail")
     async def mark_task_failed_manually(
         self,
         db: AsyncSession,
@@ -556,66 +163,18 @@ class A2AScheduleService:
         user_id: UUID,
         task_id: UUID,
         marked_by_user_id: UUID,
-        reason: Optional[str] = None,
-        marked_at: Optional[datetime] = None,
+        reason: str | None = None,
+        marked_at: datetime | None = None,
     ) -> A2AScheduleTask:
-        await self._apply_nowait_write_timeouts(db)
-        now_utc = ensure_utc(marked_at or utc_now())
-        manual_error_message = self._build_manual_failure_reason(
-            reason=reason,
-        )
-
-        stmt = (
-            select(A2AScheduleTask)
-            .where(
-                and_(
-                    A2AScheduleTask.id == task_id,
-                    A2AScheduleTask.user_id == user_id,
-                    A2AScheduleTask.deleted_at.is_(None),
-                    A2AScheduleTask.delete_requested_at.is_(None),
-                )
-            )
-            .with_for_update(nowait=True)
-            .limit(1)
-        )
-        task = await db.scalar(stmt)
-        if task is None:
-            raise A2AScheduleNotFoundError("Schedule task not found")
-
-        execution = await self._get_running_execution(
+        return await self._crud.mark_task_failed_manually(
             db,
-            task_id=task.id,
-            user_id=task.user_id,
-            for_update=True,
-        )
-        if execution is None:
-            if task.last_run_status == A2AScheduleTask.STATUS_FAILED:
-                return await self._set_task_running_projection(db, task=task)
-            raise A2AScheduleValidationError(
-                "Only running tasks can be manually marked as failed"
-            )
-
-        if execution.finished_at is None:
-            execution.finished_at = now_utc
-        execution.status = A2AScheduleExecution.STATUS_FAILED
-        execution.error_message = manual_error_message
-        if execution.conversation_id is None:
-            execution.conversation_id = task.conversation_id
-
-        threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
-        self._apply_task_terminal_projection(
-            task,
-            final_status=A2AScheduleTask.STATUS_FAILED,
-            finished_at=now_utc,
-            failure_threshold=threshold,
+            user_id=user_id,
+            task_id=task_id,
+            marked_by_user_id=marked_by_user_id,
+            reason=reason,
+            marked_at=marked_at,
         )
 
-        await commit_safely(db)
-        await db.refresh(task)
-        setattr(task, "is_running", False)
-        return task
-
-    @_map_retryable_db_errors("Schedule execution list")
     async def list_executions(
         self,
         db: AsyncSession,
@@ -625,405 +184,50 @@ class A2AScheduleService:
         page: int,
         size: int,
     ) -> tuple[list[A2AScheduleExecution], int]:
-        await self._get_task(db, user_id=user_id, task_id=task_id)
-
-        offset = (page - 1) * size
-        stmt = (
-            select(A2AScheduleExecution)
-            .where(
-                A2AScheduleExecution.user_id == user_id,
-                A2AScheduleExecution.task_id == task_id,
-            )
-            .order_by(
-                A2AScheduleExecution.started_at.desc(),
-                A2AScheduleExecution.id.desc(),
-            )
-            .offset(offset)
-            .limit(size)
+        return await self._projection.list_executions(
+            db,
+            user_id=user_id,
+            task_id=task_id,
+            page=page,
+            size=size,
         )
-        rows = await db.execute(stmt)
-        items = list(rows.scalars().all())
-
-        count_stmt = select(func.count(A2AScheduleExecution.id)).where(
-            A2AScheduleExecution.user_id == user_id,
-            A2AScheduleExecution.task_id == task_id,
-        )
-        total = int(await db.scalar(count_stmt) or 0)
-        return items, total
-
-    def _apply_task_terminal_projection(
-        self,
-        task: A2AScheduleTask,
-        *,
-        final_status: str,
-        finished_at: datetime,
-        failure_threshold: int,
-        conversation_id: UUID | None = None,
-    ) -> None:
-        finished_at_utc = ensure_utc(finished_at)
-        task.last_run_status = final_status
-        task.last_run_at = finished_at_utc
-        if conversation_id is not None:
-            task.conversation_id = conversation_id
-
-        if final_status == A2AScheduleTask.STATUS_SUCCESS:
-            task.consecutive_failures = 0
-        elif final_status == A2AScheduleTask.STATUS_FAILED:
-            task.consecutive_failures = (task.consecutive_failures or 0) + 1
-            if task.consecutive_failures >= failure_threshold:
-                task.enabled = False
-        else:
-            raise A2AScheduleValidationError("Unsupported final status for task run")
-
-        if task.delete_requested_at is not None:
-            task.soft_delete()
-            task.enabled = False
-            task.next_run_at = None
-            task.delete_requested_at = None
-        elif task.cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
-            if task.enabled:
-                task.next_run_at = self._compute_sequential_next_run_at(
-                    time_point=dict(task.time_point or {}),
-                    after_utc=finished_at_utc,
-                )
-            else:
-                task.next_run_at = None
-
-    async def _global_running_execution_count(
-        self,
-        db: AsyncSession,
-    ) -> int:
-        stmt = select(func.count(A2AScheduleExecution.id)).where(
-            A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING
-        )
-        return int((await db.scalar(stmt)) or 0)
 
     async def enqueue_due_tasks(
         self,
         db: AsyncSession,
         *,
-        now: Optional[datetime] = None,
+        now: datetime | None = None,
         batch_size: int = 20,
     ) -> int:
-        await self._apply_nowait_write_timeouts(db)
-        now_utc = ensure_utc(now or utc_now())
-
-        user_timezone_subquery = (
-            select(User.timezone)
-            .where(User.id == A2AScheduleTask.user_id)
-            .limit(1)
-            .scalar_subquery()
+        return await self._dispatch.enqueue_due_tasks(
+            db,
+            now=now,
+            batch_size=batch_size,
         )
-        user_is_superuser_subquery = (
-            select(User.is_superuser)
-            .where(User.id == A2AScheduleTask.user_id)
-            .limit(1)
-            .scalar_subquery()
-        )
-
-        has_pending_subquery = (
-            select(1)
-            .where(
-                and_(
-                    A2AScheduleExecution.task_id == A2AScheduleTask.id,
-                    A2AScheduleExecution.status.in_(
-                        [
-                            A2AScheduleExecution.STATUS_PENDING,
-                            A2AScheduleExecution.STATUS_RUNNING,
-                        ]
-                    ),
-                )
-            )
-            .limit(1)
-            .scalar_subquery()
-            .exists()
-        )
-
-        stmt = (
-            select(
-                A2AScheduleTask,
-                user_timezone_subquery.label("user_timezone"),
-                user_is_superuser_subquery.label("user_is_superuser"),
-            )
-            .where(
-                and_(
-                    A2AScheduleTask.deleted_at.is_(None),
-                    A2AScheduleTask.delete_requested_at.is_(None),
-                    A2AScheduleTask.enabled.is_(True),
-                    A2AScheduleTask.next_run_at.is_not(None),
-                    A2AScheduleTask.next_run_at <= now_utc,
-                    ~has_pending_subquery,
-                )
-            )
-            .order_by(A2AScheduleTask.next_run_at.asc(), A2AScheduleTask.id.asc())
-            .limit(batch_size)
-            .with_for_update(skip_locked=True)
-        )
-
-        rows = await db.execute(stmt)
-        enqueued_count = 0
-
-        for row in rows:
-            selected_task = row[0]
-            timezone_value = self._normalize_timezone_str(row[1])
-            is_superuser = bool(row[2])
-
-            scheduled_for = ensure_utc(selected_task.next_run_at or now_utc)
-            if selected_task.cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
-                next_run_at = None
-            else:
-                next_run_at = self.compute_next_run_at(
-                    cycle_type=selected_task.cycle_type,
-                    time_point=dict(selected_task.time_point or {}),
-                    timezone_str=timezone_value,
-                    after_utc=scheduled_for,
-                    not_before_utc=now_utc,
-                    is_superuser=is_superuser,
-                )
-
-            run_id = uuid4()
-            selected_task.next_run_at = next_run_at
-
-            db.add(
-                A2AScheduleExecution(
-                    user_id=selected_task.user_id,
-                    task_id=selected_task.id,
-                    run_id=run_id,
-                    scheduled_for=scheduled_for,
-                    started_at=None,
-                    last_heartbeat_at=None,
-                    status=A2AScheduleExecution.STATUS_PENDING,
-                    conversation_id=selected_task.conversation_id,
-                )
-            )
-            enqueued_count += 1
-            logger.info(f"Task {selected_task.id} enqueued, run_id: {run_id}")
-
-        await commit_safely(db)
-        return enqueued_count
 
     async def claim_next_pending_execution(
         self,
         db: AsyncSession,
         *,
-        now: Optional[datetime] = None,
-    ) -> Optional[ClaimedA2AScheduleTask]:
-        await self._apply_skip_locked_write_timeouts(db)
-        now_utc = ensure_utc(now or utc_now())
-
-        global_concurrency_limit = max(
-            int(settings.a2a_schedule_global_concurrency_limit), 1
-        )
-        global_running_count = await self._global_running_execution_count(db)
-        if global_running_count >= global_concurrency_limit:
-            return None
-
-        # Concurrency limit per agent
-        concurrency_limit = max(int(settings.a2a_schedule_agent_concurrency_limit), 1)
-
-        from sqlalchemy.orm import aliased
-
-        TaskAlias = aliased(A2AScheduleTask)
-        ExecAlias = aliased(A2AScheduleExecution)
-
-        running_count_subquery = (
-            select(func.count(ExecAlias.id))
-            .join(TaskAlias, TaskAlias.id == ExecAlias.task_id)
-            .where(
-                and_(
-                    TaskAlias.agent_id == A2AScheduleTask.agent_id,
-                    ExecAlias.status == A2AScheduleExecution.STATUS_RUNNING,
-                )
-            )
-            .correlate(A2AScheduleTask)
-            .scalar_subquery()
-        )
-
-        # Lock execution row
-        stmt = (
-            select(A2AScheduleExecution)
-            .join(A2AScheduleTask, A2AScheduleTask.id == A2AScheduleExecution.task_id)
-            .where(
-                and_(
-                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_PENDING,
-                    or_(
-                        A2AScheduleTask.deleted_at.is_not(None),
-                        A2AScheduleTask.enabled.is_(False),
-                        running_count_subquery < concurrency_limit,
-                    ),
-                )
-            )
-            .order_by(
-                A2AScheduleExecution.scheduled_for.asc(), A2AScheduleExecution.id.asc()
-            )
-            .limit(1)
-            .with_for_update(of=A2AScheduleExecution, skip_locked=True)
-        )
-        execution = await db.scalar(stmt)
-        if execution is None:
-            return None
-
-        task_stmt = (
-            select(A2AScheduleTask)
-            .where(A2AScheduleTask.id == execution.task_id)
-            .with_for_update(nowait=True)
-            .limit(1)
-        )
-        try:
-            task = await db.scalar(task_stmt)
-        except DBAPIError as exc:
-            if to_retryable_db_lock_error(exc) is not None:
-                await db.rollback()
-                return None
-            raise
-        if task is None or task.deleted_at is not None or not task.enabled:
-            execution.status = A2AScheduleExecution.STATUS_FAILED
-            execution.finished_at = now_utc
-            execution.error_message = (
-                "Task disabled or deleted before execution started"
-            )
-            await commit_safely(db)
-            return None
-
-        execution.status = A2AScheduleExecution.STATUS_RUNNING
-        execution.started_at = now_utc
-        execution.last_heartbeat_at = now_utc
-
-        await commit_safely(db)
-
-        return ClaimedA2AScheduleTask(
-            task_id=task.id,
-            user_id=task.user_id,
-            agent_id=task.agent_id,
-            conversation_id=execution.conversation_id or task.conversation_id,
-            name=task.name,
-            prompt=task.prompt,
-            cycle_type=task.cycle_type,
-            time_point=dict(task.time_point or {}),
-            scheduled_for=execution.scheduled_for,
-            run_id=execution.run_id,
-        )
+        now: datetime | None = None,
+    ) -> ClaimedA2AScheduleTask | None:
+        return await self._dispatch.claim_next_pending_execution(db, now=now)
 
     async def recover_stale_running_tasks(
         self,
         db: AsyncSession,
         *,
-        now: Optional[datetime] = None,
+        now: datetime | None = None,
         timeout_seconds: int = 600,
         hard_timeout_seconds: int | None = None,
     ) -> int:
-        """Recover stale running tasks by run_id and close them deterministically."""
-
-        now_utc = ensure_utc(now or utc_now())
-        timeout_seconds = max(int(timeout_seconds or 0), 1)
-        cutoff = now_utc - timedelta(seconds=timeout_seconds)
-        hard_timeout = (
-            max(int(hard_timeout_seconds or 0), 1) if hard_timeout_seconds else None
+        return await self._dispatch.recover_stale_running_tasks(
+            db,
+            now=now,
+            timeout_seconds=timeout_seconds,
+            hard_timeout_seconds=hard_timeout_seconds,
         )
-        hard_cutoff = (
-            now_utc - timedelta(seconds=hard_timeout)
-            if hard_timeout is not None
-            else None
-        )
-        failure_threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
 
-        stale_predicates = [
-            func.coalesce(
-                A2AScheduleExecution.last_heartbeat_at,
-                A2AScheduleExecution.started_at,
-            )
-            <= cutoff
-        ]
-        if hard_cutoff is not None:
-            stale_predicates.append(A2AScheduleExecution.started_at <= hard_cutoff)
-
-        error_message = "Execution marked as failed by recovery: stale running task exceeded timeout"
-        recovered_count = 0
-        while True:
-            # SET LOCAL timeouts are transaction-scoped; re-apply after each commit.
-            await self._apply_skip_locked_write_timeouts(db)
-            stale_where = and_(
-                A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
-                A2AScheduleTask.deleted_at.is_(None),
-                or_(*stale_predicates),
-            )
-            stmt = (
-                select(A2AScheduleExecution)
-                .join(
-                    A2AScheduleTask, A2AScheduleTask.id == A2AScheduleExecution.task_id
-                )
-                .where(stale_where)
-                .order_by(
-                    A2AScheduleExecution.started_at.asc(),
-                    A2AScheduleExecution.id.asc(),
-                )
-                .limit(1)
-                .with_for_update(of=A2AScheduleExecution, skip_locked=True)
-            )
-            execution = await db.scalar(stmt)
-            if execution is None:
-                stale_count_stmt = (
-                    select(func.count(A2AScheduleExecution.id))
-                    .join(
-                        A2AScheduleTask,
-                        A2AScheduleTask.id == A2AScheduleExecution.task_id,
-                    )
-                    .where(stale_where)
-                )
-                stale_remaining = int(await db.scalar(stale_count_stmt) or 0)
-                if stale_remaining > 0:
-                    ops_metrics.increment_schedule_recovery_lock_skipped_tasks(
-                        stale_remaining
-                    )
-                    logger.warning(
-                        "Skipped recovery for %d stale schedule task(s) due to row lock contention; retry next cycle.",
-                        stale_remaining,
-                        extra={
-                            "phase": "recovery",
-                            "stale_task_count": stale_remaining,
-                        },
-                    )
-                break
-
-            task_stmt = (
-                select(A2AScheduleTask)
-                .where(A2AScheduleTask.id == execution.task_id)
-                .with_for_update(nowait=True)
-            )
-            try:
-                task = await db.scalar(task_stmt)
-            except DBAPIError as e:
-                if to_retryable_db_lock_error(e) is not None:
-                    # Could not lock the task because someone else (e.g. finalize) holds it.
-                    # We rollback and skip for now.
-                    await db.rollback()
-                    continue
-                raise
-
-            if task is None:
-                # Task might have been finalized or deleted by the time we locked it.
-                await commit_safely(db)
-                continue
-
-            execution.status = A2AScheduleExecution.STATUS_FAILED
-            execution.finished_at = now_utc
-            execution.error_message = error_message
-            if execution.conversation_id is None:
-                execution.conversation_id = task.conversation_id
-
-            self._apply_task_terminal_projection(
-                task,
-                final_status=A2AScheduleTask.STATUS_FAILED,
-                finished_at=now_utc,
-                failure_threshold=failure_threshold,
-                conversation_id=execution.conversation_id,
-            )
-            recovered_count += 1
-
-            await commit_safely(db)
-        return recovered_count
-
-    @_map_retryable_db_errors("Schedule task finalize")
     async def finalize_task_run(
         self,
         db: AsyncSession,
@@ -1039,324 +243,19 @@ class A2AScheduleService:
         user_message_id: UUID | None = None,
         agent_message_id: UUID | None = None,
     ) -> bool:
-        """Finalize one claimed run only if execution is still running."""
-
-        await self._apply_nowait_write_timeouts(db)
-
-        # CAS on execution table first
-        exec_stmt = (
-            select(A2AScheduleExecution)
-            .where(
-                and_(
-                    A2AScheduleExecution.task_id == task_id,
-                    A2AScheduleExecution.user_id == user_id,
-                    A2AScheduleExecution.run_id == run_id,
-                    A2AScheduleExecution.status == A2AScheduleExecution.STATUS_RUNNING,
-                )
-            )
-            .with_for_update(nowait=True)
-            .limit(1)
-        )
-        execution = await db.scalar(exec_stmt)
-        if execution is None:
-            return False
-
-        stmt = (
-            select(A2AScheduleTask)
-            .where(
-                and_(
-                    A2AScheduleTask.id == task_id,
-                    A2AScheduleTask.user_id == user_id,
-                )
-            )
-            .with_for_update(nowait=True)
-            .limit(1)
-        )
-        task = await db.scalar(stmt)
-        if task is None:
-            return False
-
-        threshold = max(int(settings.a2a_schedule_task_failure_threshold), 1)
-        if final_status not in {
-            A2AScheduleTask.STATUS_SUCCESS,
-            A2AScheduleTask.STATUS_FAILED,
-        }:
-            raise A2AScheduleValidationError("Unsupported final status for task run")
-
-        execution.status = final_status
-        execution.finished_at = ensure_utc(finished_at)
-        execution.conversation_id = conversation_id
-        execution.response_content = response_content
-        execution.error_message = error_message
-        execution.user_message_id = user_message_id
-        execution.agent_message_id = agent_message_id
-        self._apply_task_terminal_projection(
-            task,
+        return await self._dispatch.finalize_task_run(
+            db,
+            task_id=task_id,
+            user_id=user_id,
+            run_id=run_id,
             final_status=final_status,
             finished_at=finished_at,
-            failure_threshold=threshold,
             conversation_id=conversation_id,
+            response_content=response_content,
+            error_message=error_message,
+            user_message_id=user_message_id,
+            agent_message_id=agent_message_id,
         )
-
-        logger.info(
-            f"Task {task_id} finalized (run_id: {run_id}) "
-            f"with status: {final_status}, conv: {conversation_id}"
-        )
-
-        return True
-
-    async def _get_task(
-        self,
-        db: AsyncSession,
-        *,
-        user_id: UUID,
-        task_id: UUID,
-    ) -> A2AScheduleTask:
-        stmt = select(A2AScheduleTask).where(
-            and_(
-                A2AScheduleTask.id == task_id,
-                A2AScheduleTask.user_id == user_id,
-                A2AScheduleTask.deleted_at.is_(None),
-                A2AScheduleTask.delete_requested_at.is_(None),
-            )
-        )
-        task = await db.scalar(stmt)
-        if task is None:
-            raise A2AScheduleNotFoundError("Schedule task not found")
-        return task
-
-    async def _ensure_agent_owned(
-        self,
-        db: AsyncSession,
-        *,
-        user_id: UUID,
-        agent_id: UUID,
-    ) -> None:
-        stmt = select(A2AAgent.id).where(
-            and_(
-                A2AAgent.id == agent_id,
-                A2AAgent.user_id == user_id,
-                A2AAgent.agent_scope == A2AAgent.SCOPE_PERSONAL,
-                A2AAgent.enabled.is_(True),
-                A2AAgent.deleted_at.is_(None),
-            )
-        )
-        found = await db.scalar(stmt)
-        if found is None:
-            raise A2AScheduleValidationError(
-                "Target agent is missing, disabled, or not owned by current user"
-            )
-
-    async def _ensure_active_quota(
-        self,
-        db: AsyncSession,
-        *,
-        user_id: UUID,
-        is_superuser: bool,
-    ) -> None:
-        if is_superuser:
-            return
-
-        limit = max(settings.a2a_schedule_max_active_tasks_per_user, 0)
-        if limit == 0:
-            raise A2AScheduleQuotaError(
-                "Scheduled tasks are currently disabled for non-admin users."
-            )
-
-        stmt = select(func.count(A2AScheduleTask.id)).where(
-            and_(
-                A2AScheduleTask.user_id == user_id,
-                A2AScheduleTask.enabled.is_(True),
-                A2AScheduleTask.deleted_at.is_(None),
-                A2AScheduleTask.delete_requested_at.is_(None),
-            )
-        )
-        active_count = int((await db.scalar(stmt)) or 0)
-
-        if active_count >= limit:
-            raise A2AScheduleQuotaError(
-                f"Maximum active schedule tasks limit ({limit}) reached."
-            )
-
-    def _normalize_name(self, value: str) -> str:
-        normalized = (value or "").strip()
-        if not normalized:
-            raise A2AScheduleValidationError("Task name is required")
-        if len(normalized) > 120:
-            raise A2AScheduleValidationError("Task name must be <= 120 characters")
-        return normalized
-
-    def _normalize_prompt(self, value: str) -> str:
-        normalized = (value or "").strip()
-        if not normalized:
-            raise A2AScheduleValidationError("Prompt is required")
-        if len(normalized) > 128_000:
-            raise A2AScheduleValidationError("Prompt exceeds max length")
-        return normalized
-
-    @staticmethod
-    def _build_manual_failure_reason(
-        *,
-        reason: Optional[str],
-    ) -> str:
-        normalized_reason = (reason or "").strip()
-        return normalized_reason or _MANUAL_FAILURE_MESSAGE
-
-    def _normalize_cycle_type(self, value: str) -> str:
-        normalized = (value or "").strip().lower()
-        if normalized not in self._allowed_cycle_types:
-            raise A2AScheduleValidationError(
-                "cycle_type must be one of daily, weekly, monthly, interval, sequential"
-            )
-        return normalized
-
-    def _normalize_conversation_policy(self, value: str) -> str:
-        normalized = (value or "").strip().lower()
-        if normalized not in self._allowed_conversation_policies:
-            raise A2AScheduleValidationError(
-                "conversation_policy must be one of new_each_run, reuse_single"
-            )
-        return normalized
-
-    def _normalize_time_point(
-        self,
-        *,
-        cycle_type: str,
-        time_point: Dict[str, Any],
-        is_superuser: bool = False,
-        timezone_str: str = "UTC",
-    ) -> Dict[str, Any]:
-        if not isinstance(time_point, dict):
-            raise A2AScheduleValidationError("time_point must be an object")
-
-        if cycle_type == A2AScheduleTask.CYCLE_INTERVAL:
-            minutes_raw = time_point.get("minutes", time_point.get("interval_minutes"))
-            minutes = self._normalize_schedule_minutes(
-                minutes_raw,
-                cycle_type="interval",
-            )
-            interval_start_at_local = self._normalize_interval_start_at_local(
-                time_point.get("start_at_local")
-            )
-            normalized: Dict[str, Any] = {"minutes": minutes}
-            if interval_start_at_local is not None:
-                normalized["start_at_local"] = interval_start_at_local
-                normalized["start_at_utc"] = self._to_utc_from_local_iso(
-                    interval_start_at_local,
-                    timezone_str=timezone_str,
-                )
-            return normalized
-        if cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
-            minutes_raw = time_point.get("minutes", time_point.get("interval_minutes"))
-            minutes = self._normalize_schedule_minutes(
-                minutes_raw,
-                cycle_type="sequential",
-            )
-            if time_point.get("start_at_local") not in (None, "") or time_point.get(
-                "start_at_utc"
-            ) not in (None, ""):
-                raise A2AScheduleValidationError(
-                    "sequential does not support start_at_local/start_at_utc; use minutes only"
-                )
-            return {"minutes": minutes}
-
-        hh, mm = self._parse_hhmm(time_point.get("time"))
-        normalized: Dict[str, Any] = {"time": f"{hh:02d}:{mm:02d}"}
-
-        if cycle_type == A2AScheduleTask.CYCLE_DAILY:
-            return normalized
-
-        if cycle_type == A2AScheduleTask.CYCLE_WEEKLY:
-            weekday = self._coerce_int(time_point.get("weekday"))
-            # Contract: ISO weekday (1=Monday ... 7=Sunday). Keep this consistent
-            # with other calendar settings like `calendar.first_day_of_week`.
-            if weekday is None or weekday < 1 or weekday > 7:
-                raise A2AScheduleValidationError(
-                    "weekly time_point requires weekday in range 1..7 (1=Monday, 7=Sunday)"
-                )
-            normalized["weekday"] = weekday
-            return normalized
-
-        if cycle_type == A2AScheduleTask.CYCLE_MONTHLY:
-            day = self._coerce_int(time_point.get("day"))
-            if day is None or day < 1 or day > 31:
-                raise A2AScheduleValidationError(
-                    "monthly time_point requires day in range 1..31"
-                )
-            normalized["day"] = day
-            return normalized
-
-        raise A2AScheduleValidationError("Unsupported cycle_type")
-
-    def _normalize_schedule_minutes(
-        self,
-        value: Any,
-        *,
-        cycle_type: str,
-    ) -> int:
-        minutes = self._coerce_int(value)
-        if minutes is None:
-            raise A2AScheduleValidationError(
-                f"{cycle_type} time_point requires minutes"
-            )
-        return max(self._schedule_minutes_min, min(self._schedule_minutes_max, minutes))
-
-    def _sanitize_schedule_minutes_for_read(self, value: Any) -> int:
-        minutes = self._coerce_int(value)
-        if minutes is None:
-            return self._schedule_minutes_min
-        return max(self._schedule_minutes_min, min(self._schedule_minutes_max, minutes))
-
-    @staticmethod
-    def _format_local_minute_iso(dt: datetime) -> str:
-        return dt.strftime("%Y-%m-%dT%H:%M")
-
-    @classmethod
-    def _normalize_interval_start_at_local(
-        cls,
-        value: Any,
-    ) -> Optional[str]:
-        if value is None or value == "":
-            return None
-        if isinstance(value, str):
-            trimmed = value.strip()
-            if not trimmed:
-                return None
-            try:
-                dt = datetime.fromisoformat(trimmed)
-            except ValueError as exc:
-                raise A2AScheduleValidationError(
-                    "interval time_point.start_at_local must be a valid ISO datetime"
-                ) from exc
-            if dt.tzinfo is not None:
-                raise A2AScheduleValidationError(
-                    "interval time_point.start_at_local must be timezone-naive "
-                    "(without Z or offset)"
-                )
-            return cls._format_local_minute_iso(dt)
-        if isinstance(value, datetime):
-            if value.tzinfo is not None:
-                raise A2AScheduleValidationError(
-                    "interval time_point.start_at_local must be timezone-naive "
-                    "(without Z or offset)"
-                )
-            return cls._format_local_minute_iso(value)
-
-        raise A2AScheduleValidationError(
-            "interval time_point.start_at_local must be an ISO datetime string"
-        )
-
-    @classmethod
-    def _to_utc_from_local_iso(cls, value: str, *, timezone_str: str) -> str:
-        try:
-            local_naive = datetime.fromisoformat(value)
-        except ValueError as exc:
-            raise A2AScheduleValidationError(
-                "interval time_point.start_at_local must be a valid ISO datetime"
-            ) from exc
-        timezone_value = cls._normalize_timezone_str(timezone_str)
-        tz = resolve_timezone(timezone_value, default="UTC")
-        return ensure_utc(local_naive.replace(tzinfo=tz)).isoformat()
 
     def format_local_datetime(
         self,
@@ -1364,384 +263,42 @@ class A2AScheduleService:
         *,
         timezone_str: str,
     ) -> str | None:
-        if value is None:
-            return None
-        timezone_value = self._normalize_timezone_str(timezone_str)
-        tz = resolve_timezone(timezone_value, default="UTC")
-        local_dt = ensure_utc(value).astimezone(tz)
-        return self._format_local_minute_iso(local_dt)
+        return self._time_helper.format_local_datetime(
+            value,
+            timezone_str=timezone_str,
+        )
 
     def serialize_time_point_for_response(
         self,
         *,
         cycle_type: str,
-        time_point: Dict[str, Any] | None,
+        time_point: dict[str, Any] | None,
         timezone_str: str,
-    ) -> Dict[str, Any]:
-        payload = dict(time_point or {})
-        if cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
-            minutes = self._sanitize_schedule_minutes_for_read(
-                payload.get("minutes", payload.get("interval_minutes"))
-            )
-            return {"minutes": minutes}
-        if cycle_type != A2AScheduleTask.CYCLE_INTERVAL:
-            return payload
-
-        timezone_value = self._normalize_timezone_str(timezone_str)
-        normalized: Dict[str, Any] = {
-            "minutes": self._sanitize_schedule_minutes_for_read(
-                payload.get("minutes", payload.get("interval_minutes"))
-            )
-        }
-
-        start_at_local = payload.get("start_at_local")
-        if isinstance(start_at_local, str) and start_at_local.strip():
-            raw_local = start_at_local.strip()
-            normalized["start_at_local"] = raw_local
-            try:
-                normalized_local = self._normalize_interval_start_at_local(raw_local)
-            except A2AScheduleValidationError:
-                normalized_local = None
-            if normalized_local is not None:
-                normalized["start_at_local"] = normalized_local
-                normalized["start_at_utc"] = self._to_utc_from_local_iso(
-                    normalized_local,
-                    timezone_str=timezone_value,
-                )
-
-        start_at_utc = payload.get("start_at_utc")
-        if isinstance(start_at_utc, str) and start_at_utc.strip():
-            raw_utc = start_at_utc.strip()
-            if "start_at_utc" not in normalized:
-                normalized["start_at_utc"] = raw_utc
-            if "start_at_local" not in normalized:
-                try:
-                    start_at_dt = self._resolve_interval_start_at_utc(raw_utc)
-                except A2AScheduleValidationError:
-                    start_at_dt = None
-                if start_at_dt is not None:
-                    normalized["start_at_local"] = self.format_local_datetime(
-                        start_at_dt,
-                        timezone_str=timezone_value,
-                    )
-
-        return normalized
-
-    @staticmethod
-    def _resolve_interval_start_at_utc(value: Any) -> Optional[datetime]:
-        if value is None:
-            return None
-
-        if isinstance(value, datetime):
-            return ensure_utc(value)
-
-        if not isinstance(value, str):
-            return None
-
-        trimmed = value.strip()
-        if not trimmed:
-            return None
-
-        try:
-            dt = datetime.fromisoformat(trimmed)
-        except ValueError as exc:
-            if trimmed.endswith("Z"):
-                dt = datetime.fromisoformat(trimmed.replace("Z", "+00:00"))
-            else:
-                raise A2AScheduleValidationError(
-                    "interval time_point.start_at_utc is not a valid ISO datetime"
-                ) from exc
-
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-
-        return ensure_utc(dt)
-
-    def _compute_sequential_next_run_at(
-        self,
-        *,
-        time_point: Dict[str, Any] | None,
-        after_utc: datetime,
-    ) -> datetime:
-        minutes = self._sanitize_schedule_minutes_for_read(
-            (time_point or {}).get(
-                "minutes", (time_point or {}).get("interval_minutes")
-            )
+    ) -> dict[str, Any]:
+        return self._time_helper.serialize_time_point_for_response(
+            cycle_type=cycle_type,
+            time_point=time_point,
+            timezone_str=timezone_str,
         )
-        return ensure_utc(after_utc) + timedelta(minutes=minutes)
-
-    @staticmethod
-    def _next_interval_candidate(
-        after_utc: datetime,
-        interval: timedelta,
-        start_at_utc: Optional[datetime],
-        guard_utc: datetime,
-    ) -> datetime:
-        anchor = ensure_utc(start_at_utc) if start_at_utc else None
-        after = ensure_utc(after_utc)
-        if anchor is None:
-            candidate = after + interval
-            if candidate <= guard_utc:
-                interval_seconds = max(interval.total_seconds(), 1.0)
-                return candidate + timedelta(
-                    seconds=(guard_utc - candidate).total_seconds()
-                    // interval_seconds
-                    * interval_seconds
-                    + interval_seconds
-                )
-            return candidate
-        else:
-            if after < anchor:
-                candidate = anchor
-            else:
-                interval_seconds = max(interval.total_seconds(), 1.0)
-                delta_seconds = (after - anchor).total_seconds()
-                steps = int((delta_seconds + interval_seconds - 1) // interval_seconds)
-                candidate = anchor + timedelta(seconds=steps * interval_seconds)
-
-                if candidate <= guard_utc:
-                    additional_steps = (
-                        int((guard_utc - candidate).total_seconds() // interval_seconds)
-                        + 1
-                    )
-                    return candidate + timedelta(
-                        seconds=additional_steps * interval_seconds
-                    )
-            return candidate
-
-        return candidate
-
-    @staticmethod
-    def _coerce_int(value: Any) -> Optional[int]:
-        try:
-            if value is None:
-                return None
-            return int(value)
-        except (TypeError, ValueError):
-            return None
-
-    @staticmethod
-    def _parse_hhmm(value: Any) -> tuple[int, int]:
-        raw = str(value or "").strip()
-        pieces = raw.split(":", 1)
-        if len(pieces) != 2:
-            raise A2AScheduleValidationError("time_point.time must be HH:MM")
-        hour = A2AScheduleService._coerce_int(pieces[0])
-        minute = A2AScheduleService._coerce_int(pieces[1])
-        if hour is None or minute is None:
-            raise A2AScheduleValidationError("time_point.time must be HH:MM")
-        if hour < 0 or hour > 23 or minute < 0 or minute > 59:
-            raise A2AScheduleValidationError("time_point.time must be HH:MM")
-        return hour, minute
-
-    @staticmethod
-    def _monthly_candidate(
-        *,
-        year: int,
-        month: int,
-        day: int,
-        hour: int,
-        minute: int,
-        tz,
-    ) -> datetime:
-        last_day = calendar.monthrange(year, month)[1]
-        resolved_day = min(day, last_day)
-        return datetime(year, month, resolved_day, hour, minute, tzinfo=tz)
-
-    @staticmethod
-    def _resolve_local_wall_clock(candidate_local: datetime) -> datetime:
-        """Resolve local wall-clock ambiguity and DST gaps deterministically.
-
-        - Non-existent local times (DST spring-forward gap) are shifted forward to
-          the first valid local timestamp after round-tripping via UTC.
-        - Ambiguous local times (DST fall-back overlap) are pinned to fold=0
-          (the first occurrence).
-        """
-        if candidate_local.tzinfo is None:
-            return candidate_local
-
-        normalized = candidate_local.astimezone(timezone.utc).astimezone(
-            candidate_local.tzinfo
-        )
-        original_wall = (
-            candidate_local.year,
-            candidate_local.month,
-            candidate_local.day,
-            candidate_local.hour,
-            candidate_local.minute,
-            candidate_local.second,
-            candidate_local.microsecond,
-        )
-        normalized_wall = (
-            normalized.year,
-            normalized.month,
-            normalized.day,
-            normalized.hour,
-            normalized.minute,
-            normalized.second,
-            normalized.microsecond,
-        )
-        if normalized_wall != original_wall:
-            return normalized.replace(fold=0)
-
-        return candidate_local.replace(fold=0)
-
-    def _next_occurrence_local(
-        self,
-        *,
-        cycle_type: str,
-        time_point: Dict[str, Any],
-        after_local: datetime,
-        is_superuser: bool = False,
-    ) -> datetime:
-        if cycle_type == A2AScheduleTask.CYCLE_INTERVAL:
-            minutes = self._normalize_schedule_minutes(
-                time_point.get("minutes", time_point.get("interval_minutes")),
-                cycle_type="interval",
-            )
-            return after_local + timedelta(minutes=minutes)
-
-        hh, mm = self._parse_hhmm(time_point.get("time"))
-        target_time = time(hour=hh, minute=mm)
-
-        if cycle_type == A2AScheduleTask.CYCLE_DAILY:
-            candidate = datetime.combine(
-                after_local.date(),
-                target_time,
-                tzinfo=after_local.tzinfo,
-            )
-            candidate = self._resolve_local_wall_clock(candidate)
-            if candidate <= after_local:
-                candidate = self._resolve_local_wall_clock(
-                    candidate + timedelta(days=1)
-                )
-            return candidate
-
-        if cycle_type == A2AScheduleTask.CYCLE_WEEKLY:
-            weekday = self._coerce_int(time_point.get("weekday"))
-            if weekday is None or weekday < 1 or weekday > 7:
-                raise A2AScheduleValidationError("Invalid weekday")
-
-            # ISO weekday (1=Monday ... 7=Sunday) aligns with datetime.isoweekday().
-            delta_days = (weekday - after_local.isoweekday()) % 7
-            candidate_date = after_local.date() + timedelta(days=delta_days)
-            candidate = datetime.combine(
-                candidate_date,
-                target_time,
-                tzinfo=after_local.tzinfo,
-            )
-            candidate = self._resolve_local_wall_clock(candidate)
-            if candidate <= after_local:
-                candidate = self._resolve_local_wall_clock(
-                    candidate + timedelta(days=7)
-                )
-            return candidate
-
-        if cycle_type == A2AScheduleTask.CYCLE_MONTHLY:
-            day = self._coerce_int(time_point.get("day"))
-            if day is None or day < 1 or day > 31:
-                raise A2AScheduleValidationError("Invalid day")
-
-            candidate = self._monthly_candidate(
-                year=after_local.year,
-                month=after_local.month,
-                day=day,
-                hour=hh,
-                minute=mm,
-                tz=after_local.tzinfo,
-            )
-            candidate = self._resolve_local_wall_clock(candidate)
-            if candidate <= after_local:
-                if after_local.month == 12:
-                    year = after_local.year + 1
-                    month = 1
-                else:
-                    year = after_local.year
-                    month = after_local.month + 1
-
-                candidate = self._monthly_candidate(
-                    year=year,
-                    month=month,
-                    day=day,
-                    hour=hh,
-                    minute=mm,
-                    tz=after_local.tzinfo,
-                )
-                candidate = self._resolve_local_wall_clock(candidate)
-            return candidate
-
-        raise A2AScheduleValidationError("Unsupported cycle_type")
 
     def compute_next_run_at(
         self,
         *,
         cycle_type: str,
-        time_point: Dict[str, Any],
+        time_point: dict[str, Any],
         timezone_str: str,
         after_utc: datetime,
-        not_before_utc: Optional[datetime] = None,
+        not_before_utc: datetime | None = None,
         is_superuser: bool = False,
     ) -> datetime:
-        normalized_cycle = self._normalize_cycle_type(cycle_type)
-        timezone_value = self._normalize_timezone_str(timezone_str)
-        normalized_point = self._normalize_time_point(
-            cycle_type=normalized_cycle,
+        return self._time_helper.compute_next_run_at(
+            cycle_type=cycle_type,
             time_point=time_point,
-            is_superuser=is_superuser,
-            timezone_str=timezone_value,
-        )
-        if normalized_cycle == A2AScheduleTask.CYCLE_SEQUENTIAL:
-            after = ensure_utc(after_utc)
-            guard = ensure_utc(not_before_utc or after_utc)
-            baseline = after if after >= guard else guard
-            return self._compute_sequential_next_run_at(
-                time_point=normalized_point,
-                after_utc=baseline,
-            )
-
-        if normalized_cycle == A2AScheduleTask.CYCLE_INTERVAL:
-            minutes = self._normalize_schedule_minutes(
-                normalized_point.get(
-                    "minutes", normalized_point.get("interval_minutes")
-                ),
-                cycle_type="interval",
-            )
-            interval = timedelta(minutes=minutes)
-            after = ensure_utc(after_utc)
-            guard = ensure_utc(not_before_utc or after_utc)
-            start_at = self._resolve_interval_start_at_utc(
-                normalized_point.get("start_at_utc")
-            )
-            return self._next_interval_candidate(
-                after_utc=after,
-                interval=interval,
-                start_at_utc=start_at,
-                guard_utc=guard,
-            )
-
-        tz = resolve_timezone(timezone_value, default="UTC")
-        after_local = ensure_utc(after_utc).astimezone(tz)
-        guard_utc = ensure_utc(not_before_utc or after_utc)
-
-        candidate_local = self._next_occurrence_local(
-            cycle_type=normalized_cycle,
-            time_point=normalized_point,
-            after_local=after_local,
+            timezone_str=timezone_str,
+            after_utc=after_utc,
+            not_before_utc=not_before_utc,
             is_superuser=is_superuser,
         )
-        while ensure_utc(candidate_local) <= guard_utc:
-            candidate_local = self._next_occurrence_local(
-                cycle_type=normalized_cycle,
-                time_point=normalized_point,
-                after_local=candidate_local,
-                is_superuser=is_superuser,
-            )
-
-        return candidate_local.astimezone(timezone.utc)
-
-
-A2A_SCHEDULE_SOURCE = "scheduled"
-A2A_MANUAL_SOURCE = "manual"
 
 
 a2a_schedule_service = A2AScheduleService()

--- a/backend/app/services/a2a_schedule_support.py
+++ b/backend/app/services/a2a_schedule_support.py
@@ -1,0 +1,157 @@
+"""Shared persistence helpers for A2A schedule services."""
+
+from __future__ import annotations
+
+import hashlib
+from uuid import UUID
+
+from sqlalchemy import and_, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.locking import set_postgres_local_timeouts
+from app.db.models.a2a_agent import A2AAgent
+from app.db.models.a2a_schedule_task import A2AScheduleTask
+from app.services.a2a_schedule_common import (
+    A2AScheduleConflictError,
+    A2AScheduleNotFoundError,
+    A2AScheduleQuotaError,
+    A2AScheduleValidationError,
+)
+
+
+class A2AScheduleSupport:
+    """Shared low-level helpers used across schedule domains."""
+
+    _default_write_lock_timeout_ms = 500
+    _default_write_statement_timeout_ms = 5000
+
+    async def apply_default_write_timeouts(self, db: AsyncSession) -> None:
+        await set_postgres_local_timeouts(
+            db,
+            lock_timeout_ms=self._default_write_lock_timeout_ms,
+            statement_timeout_ms=self._default_write_statement_timeout_ms,
+        )
+
+    async def apply_nowait_write_timeouts(self, db: AsyncSession) -> None:
+        await set_postgres_local_timeouts(
+            db,
+            statement_timeout_ms=self._default_write_statement_timeout_ms,
+        )
+
+    async def apply_skip_locked_write_timeouts(self, db: AsyncSession) -> None:
+        await set_postgres_local_timeouts(
+            db,
+            statement_timeout_ms=self._default_write_statement_timeout_ms,
+        )
+
+    async def lock_user_row_for_quota(self, db: AsyncSession, *, user_id: UUID) -> None:
+        lock_key_str = f"a2a_schedule_quota_{user_id.hex}"
+        hash_digest = hashlib.md5(lock_key_str.encode()).digest()
+        lock_id = int.from_bytes(hash_digest[:8], byteorder="big", signed=True)
+
+        stmt = text("SELECT pg_try_advisory_xact_lock(:lock_id)")
+        lock_acquired = await db.scalar(stmt, {"lock_id": lock_id})
+
+        if not lock_acquired:
+            raise A2AScheduleConflictError(
+                "Unable to acquire advisory lock for schedule quota check. Please try again."
+            )
+
+    async def get_task_for_update(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+    ) -> A2AScheduleTask:
+        stmt = (
+            select(A2AScheduleTask)
+            .where(
+                and_(
+                    A2AScheduleTask.id == task_id,
+                    A2AScheduleTask.user_id == user_id,
+                    A2AScheduleTask.deleted_at.is_(None),
+                    A2AScheduleTask.delete_requested_at.is_(None),
+                )
+            )
+            .with_for_update(nowait=True)
+            .limit(1)
+        )
+        task = await db.scalar(stmt)
+        if task is None:
+            raise A2AScheduleNotFoundError("Schedule task not found")
+        return task
+
+    async def get_task(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        task_id: UUID,
+    ) -> A2AScheduleTask:
+        stmt = select(A2AScheduleTask).where(
+            and_(
+                A2AScheduleTask.id == task_id,
+                A2AScheduleTask.user_id == user_id,
+                A2AScheduleTask.deleted_at.is_(None),
+                A2AScheduleTask.delete_requested_at.is_(None),
+            )
+        )
+        task = await db.scalar(stmt)
+        if task is None:
+            raise A2AScheduleNotFoundError("Schedule task not found")
+        return task
+
+    async def ensure_agent_owned(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        agent_id: UUID,
+    ) -> None:
+        stmt = select(A2AAgent.id).where(
+            and_(
+                A2AAgent.id == agent_id,
+                A2AAgent.user_id == user_id,
+                A2AAgent.agent_scope == A2AAgent.SCOPE_PERSONAL,
+                A2AAgent.enabled.is_(True),
+                A2AAgent.deleted_at.is_(None),
+            )
+        )
+        found = await db.scalar(stmt)
+        if found is None:
+            raise A2AScheduleValidationError(
+                "Target agent is missing, disabled, or not owned by current user"
+            )
+
+    async def ensure_active_quota(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        is_superuser: bool,
+    ) -> None:
+        if is_superuser:
+            return
+
+        limit = max(settings.a2a_schedule_max_active_tasks_per_user, 0)
+        if limit == 0:
+            raise A2AScheduleQuotaError(
+                "Scheduled tasks are currently disabled for non-admin users."
+            )
+
+        stmt = select(func.count(A2AScheduleTask.id)).where(
+            and_(
+                A2AScheduleTask.user_id == user_id,
+                A2AScheduleTask.enabled.is_(True),
+                A2AScheduleTask.deleted_at.is_(None),
+                A2AScheduleTask.delete_requested_at.is_(None),
+            )
+        )
+        active_count = int((await db.scalar(stmt)) or 0)
+
+        if active_count >= limit:
+            raise A2AScheduleQuotaError(
+                f"Maximum active schedule tasks limit ({limit}) reached."
+            )

--- a/backend/app/services/a2a_schedule_time.py
+++ b/backend/app/services/a2a_schedule_time.py
@@ -1,0 +1,572 @@
+"""Time normalization and scheduling helpers for A2A schedules."""
+
+from __future__ import annotations
+
+import calendar
+from datetime import datetime, time, timedelta, timezone
+from typing import Any
+
+from app.db.models.a2a_schedule_task import A2AScheduleTask
+from app.services.a2a_schedule_common import A2AScheduleValidationError
+from app.utils.timezone_util import ensure_utc, resolve_timezone
+
+
+class A2AScheduleTimeHelper:
+    """Normalize schedule payloads and compute next run timestamps."""
+
+    _schedule_minutes_min = 5
+    _schedule_minutes_max = 24 * 60
+
+    _allowed_cycle_types = {
+        A2AScheduleTask.CYCLE_DAILY,
+        A2AScheduleTask.CYCLE_WEEKLY,
+        A2AScheduleTask.CYCLE_MONTHLY,
+        A2AScheduleTask.CYCLE_INTERVAL,
+        A2AScheduleTask.CYCLE_SEQUENTIAL,
+    }
+    _allowed_conversation_policies = {
+        A2AScheduleTask.POLICY_NEW,
+        A2AScheduleTask.POLICY_REUSE,
+    }
+
+    @staticmethod
+    def normalize_timezone_str(timezone_str: str | None) -> str:
+        return (timezone_str or "UTC").strip() or "UTC"
+
+    def normalize_name(self, value: str) -> str:
+        normalized = (value or "").strip()
+        if not normalized:
+            raise A2AScheduleValidationError("Task name is required")
+        if len(normalized) > 120:
+            raise A2AScheduleValidationError("Task name must be <= 120 characters")
+        return normalized
+
+    def normalize_prompt(self, value: str) -> str:
+        normalized = (value or "").strip()
+        if not normalized:
+            raise A2AScheduleValidationError("Prompt is required")
+        if len(normalized) > 128_000:
+            raise A2AScheduleValidationError("Prompt exceeds max length")
+        return normalized
+
+    def normalize_cycle_type(self, value: str) -> str:
+        normalized = (value or "").strip().lower()
+        if normalized not in self._allowed_cycle_types:
+            raise A2AScheduleValidationError(
+                "cycle_type must be one of daily, weekly, monthly, interval, sequential"
+            )
+        return normalized
+
+    def normalize_conversation_policy(self, value: str) -> str:
+        normalized = (value or "").strip().lower()
+        if normalized not in self._allowed_conversation_policies:
+            raise A2AScheduleValidationError(
+                "conversation_policy must be one of new_each_run, reuse_single"
+            )
+        return normalized
+
+    def normalize_time_point(
+        self,
+        *,
+        cycle_type: str,
+        time_point: dict[str, Any],
+        is_superuser: bool = False,
+        timezone_str: str = "UTC",
+    ) -> dict[str, Any]:
+        del is_superuser
+
+        if not isinstance(time_point, dict):
+            raise A2AScheduleValidationError("time_point must be an object")
+
+        if cycle_type == A2AScheduleTask.CYCLE_INTERVAL:
+            minutes_raw = time_point.get("minutes", time_point.get("interval_minutes"))
+            minutes = self.normalize_schedule_minutes(
+                minutes_raw,
+                cycle_type="interval",
+            )
+            interval_start_at_local = self.normalize_interval_start_at_local(
+                time_point.get("start_at_local")
+            )
+            normalized: dict[str, Any] = {"minutes": minutes}
+            if interval_start_at_local is not None:
+                normalized["start_at_local"] = interval_start_at_local
+                normalized["start_at_utc"] = self.to_utc_from_local_iso(
+                    interval_start_at_local,
+                    timezone_str=timezone_str,
+                )
+            return normalized
+        if cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
+            minutes_raw = time_point.get("minutes", time_point.get("interval_minutes"))
+            minutes = self.normalize_schedule_minutes(
+                minutes_raw,
+                cycle_type="sequential",
+            )
+            if time_point.get("start_at_local") not in (None, "") or time_point.get(
+                "start_at_utc"
+            ) not in (None, ""):
+                raise A2AScheduleValidationError(
+                    "sequential does not support start_at_local/start_at_utc; use minutes only"
+                )
+            return {"minutes": minutes}
+
+        hh, mm = self.parse_hhmm(time_point.get("time"))
+        normalized: dict[str, Any] = {"time": f"{hh:02d}:{mm:02d}"}
+
+        if cycle_type == A2AScheduleTask.CYCLE_DAILY:
+            return normalized
+
+        if cycle_type == A2AScheduleTask.CYCLE_WEEKLY:
+            weekday = self.coerce_int(time_point.get("weekday"))
+            if weekday is None or weekday < 1 or weekday > 7:
+                raise A2AScheduleValidationError(
+                    "weekly time_point requires weekday in range 1..7 (1=Monday, 7=Sunday)"
+                )
+            normalized["weekday"] = weekday
+            return normalized
+
+        if cycle_type == A2AScheduleTask.CYCLE_MONTHLY:
+            day = self.coerce_int(time_point.get("day"))
+            if day is None or day < 1 or day > 31:
+                raise A2AScheduleValidationError(
+                    "monthly time_point requires day in range 1..31"
+                )
+            normalized["day"] = day
+            return normalized
+
+        raise A2AScheduleValidationError("Unsupported cycle_type")
+
+    def normalize_schedule_minutes(
+        self,
+        value: Any,
+        *,
+        cycle_type: str,
+    ) -> int:
+        minutes = self.coerce_int(value)
+        if minutes is None:
+            raise A2AScheduleValidationError(
+                f"{cycle_type} time_point requires minutes"
+            )
+        return max(self._schedule_minutes_min, min(self._schedule_minutes_max, minutes))
+
+    def sanitize_schedule_minutes_for_read(self, value: Any) -> int:
+        minutes = self.coerce_int(value)
+        if minutes is None:
+            return self._schedule_minutes_min
+        return max(self._schedule_minutes_min, min(self._schedule_minutes_max, minutes))
+
+    @staticmethod
+    def format_local_minute_iso(dt: datetime) -> str:
+        return dt.strftime("%Y-%m-%dT%H:%M")
+
+    @classmethod
+    def normalize_interval_start_at_local(
+        cls,
+        value: Any,
+    ) -> str | None:
+        if value is None or value == "":
+            return None
+        if isinstance(value, str):
+            trimmed = value.strip()
+            if not trimmed:
+                return None
+            try:
+                dt = datetime.fromisoformat(trimmed)
+            except ValueError as exc:
+                raise A2AScheduleValidationError(
+                    "interval time_point.start_at_local must be a valid ISO datetime"
+                ) from exc
+            if dt.tzinfo is not None:
+                raise A2AScheduleValidationError(
+                    "interval time_point.start_at_local must be timezone-naive "
+                    "(without Z or offset)"
+                )
+            return cls.format_local_minute_iso(dt)
+        if isinstance(value, datetime):
+            if value.tzinfo is not None:
+                raise A2AScheduleValidationError(
+                    "interval time_point.start_at_local must be timezone-naive "
+                    "(without Z or offset)"
+                )
+            return cls.format_local_minute_iso(value)
+
+        raise A2AScheduleValidationError(
+            "interval time_point.start_at_local must be an ISO datetime string"
+        )
+
+    @classmethod
+    def to_utc_from_local_iso(cls, value: str, *, timezone_str: str) -> str:
+        try:
+            local_naive = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise A2AScheduleValidationError(
+                "interval time_point.start_at_local must be a valid ISO datetime"
+            ) from exc
+        timezone_value = cls.normalize_timezone_str(timezone_str)
+        tz = resolve_timezone(timezone_value, default="UTC")
+        return ensure_utc(local_naive.replace(tzinfo=tz)).isoformat()
+
+    def format_local_datetime(
+        self,
+        value: datetime | None,
+        *,
+        timezone_str: str,
+    ) -> str | None:
+        if value is None:
+            return None
+        timezone_value = self.normalize_timezone_str(timezone_str)
+        tz = resolve_timezone(timezone_value, default="UTC")
+        local_dt = ensure_utc(value).astimezone(tz)
+        return self.format_local_minute_iso(local_dt)
+
+    def serialize_time_point_for_response(
+        self,
+        *,
+        cycle_type: str,
+        time_point: dict[str, Any] | None,
+        timezone_str: str,
+    ) -> dict[str, Any]:
+        payload = dict(time_point or {})
+        if cycle_type == A2AScheduleTask.CYCLE_SEQUENTIAL:
+            minutes = self.sanitize_schedule_minutes_for_read(
+                payload.get("minutes", payload.get("interval_minutes"))
+            )
+            return {"minutes": minutes}
+        if cycle_type != A2AScheduleTask.CYCLE_INTERVAL:
+            return payload
+
+        timezone_value = self.normalize_timezone_str(timezone_str)
+        normalized: dict[str, Any] = {
+            "minutes": self.sanitize_schedule_minutes_for_read(
+                payload.get("minutes", payload.get("interval_minutes"))
+            )
+        }
+
+        start_at_local = payload.get("start_at_local")
+        if isinstance(start_at_local, str) and start_at_local.strip():
+            raw_local = start_at_local.strip()
+            normalized["start_at_local"] = raw_local
+            try:
+                normalized_local = self.normalize_interval_start_at_local(raw_local)
+            except A2AScheduleValidationError:
+                normalized_local = None
+            if normalized_local is not None:
+                normalized["start_at_local"] = normalized_local
+                normalized["start_at_utc"] = self.to_utc_from_local_iso(
+                    normalized_local,
+                    timezone_str=timezone_value,
+                )
+
+        start_at_utc = payload.get("start_at_utc")
+        if isinstance(start_at_utc, str) and start_at_utc.strip():
+            raw_utc = start_at_utc.strip()
+            if "start_at_utc" not in normalized:
+                normalized["start_at_utc"] = raw_utc
+            if "start_at_local" not in normalized:
+                try:
+                    start_at_dt = self.resolve_interval_start_at_utc(raw_utc)
+                except A2AScheduleValidationError:
+                    start_at_dt = None
+                if start_at_dt is not None:
+                    normalized["start_at_local"] = self.format_local_datetime(
+                        start_at_dt,
+                        timezone_str=timezone_value,
+                    )
+
+        return normalized
+
+    @staticmethod
+    def resolve_interval_start_at_utc(value: Any) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return ensure_utc(value)
+        if not isinstance(value, str):
+            return None
+
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+
+        try:
+            dt = datetime.fromisoformat(trimmed)
+        except ValueError as exc:
+            if trimmed.endswith("Z"):
+                dt = datetime.fromisoformat(trimmed.replace("Z", "+00:00"))
+            else:
+                raise A2AScheduleValidationError(
+                    "interval time_point.start_at_utc is not a valid ISO datetime"
+                ) from exc
+
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+
+        return ensure_utc(dt)
+
+    def compute_sequential_next_run_at(
+        self,
+        *,
+        time_point: dict[str, Any] | None,
+        after_utc: datetime,
+    ) -> datetime:
+        minutes = self.sanitize_schedule_minutes_for_read(
+            (time_point or {}).get(
+                "minutes", (time_point or {}).get("interval_minutes")
+            )
+        )
+        return ensure_utc(after_utc) + timedelta(minutes=minutes)
+
+    @staticmethod
+    def next_interval_candidate(
+        *,
+        after_utc: datetime,
+        interval: timedelta,
+        start_at_utc: datetime | None,
+        guard_utc: datetime,
+    ) -> datetime:
+        anchor = ensure_utc(start_at_utc) if start_at_utc else None
+        after = ensure_utc(after_utc)
+        if anchor is None:
+            candidate = after + interval
+            if candidate <= guard_utc:
+                interval_seconds = max(interval.total_seconds(), 1.0)
+                return candidate + timedelta(
+                    seconds=(guard_utc - candidate).total_seconds()
+                    // interval_seconds
+                    * interval_seconds
+                    + interval_seconds
+                )
+            return candidate
+        if after < anchor:
+            candidate = anchor
+        else:
+            interval_seconds = max(interval.total_seconds(), 1.0)
+            delta_seconds = (after - anchor).total_seconds()
+            steps = int((delta_seconds + interval_seconds - 1) // interval_seconds)
+            candidate = anchor + timedelta(seconds=steps * interval_seconds)
+
+            if candidate <= guard_utc:
+                additional_steps = (
+                    int((guard_utc - candidate).total_seconds() // interval_seconds) + 1
+                )
+                return candidate + timedelta(
+                    seconds=additional_steps * interval_seconds
+                )
+        return candidate
+
+    @staticmethod
+    def coerce_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def parse_hhmm(value: Any) -> tuple[int, int]:
+        raw = str(value or "").strip()
+        pieces = raw.split(":", 1)
+        if len(pieces) != 2:
+            raise A2AScheduleValidationError("time_point.time must be HH:MM")
+        hour = A2AScheduleTimeHelper.coerce_int(pieces[0])
+        minute = A2AScheduleTimeHelper.coerce_int(pieces[1])
+        if hour is None or minute is None:
+            raise A2AScheduleValidationError("time_point.time must be HH:MM")
+        if hour < 0 or hour > 23 or minute < 0 or minute > 59:
+            raise A2AScheduleValidationError("time_point.time must be HH:MM")
+        return hour, minute
+
+    @staticmethod
+    def monthly_candidate(
+        *,
+        year: int,
+        month: int,
+        day: int,
+        hour: int,
+        minute: int,
+        tz: Any,
+    ) -> datetime:
+        last_day = calendar.monthrange(year, month)[1]
+        resolved_day = min(day, last_day)
+        return datetime(year, month, resolved_day, hour, minute, tzinfo=tz)
+
+    @staticmethod
+    def resolve_local_wall_clock(candidate_local: datetime) -> datetime:
+        if candidate_local.tzinfo is None:
+            return candidate_local
+
+        normalized = candidate_local.astimezone(timezone.utc).astimezone(
+            candidate_local.tzinfo
+        )
+        original_wall = (
+            candidate_local.year,
+            candidate_local.month,
+            candidate_local.day,
+            candidate_local.hour,
+            candidate_local.minute,
+            candidate_local.second,
+            candidate_local.microsecond,
+        )
+        normalized_wall = (
+            normalized.year,
+            normalized.month,
+            normalized.day,
+            normalized.hour,
+            normalized.minute,
+            normalized.second,
+            normalized.microsecond,
+        )
+        if normalized_wall != original_wall:
+            return normalized.replace(fold=0)
+
+        return candidate_local.replace(fold=0)
+
+    def next_occurrence_local(
+        self,
+        *,
+        cycle_type: str,
+        time_point: dict[str, Any],
+        after_local: datetime,
+        is_superuser: bool = False,
+    ) -> datetime:
+        del is_superuser
+
+        if cycle_type == A2AScheduleTask.CYCLE_INTERVAL:
+            minutes = self.normalize_schedule_minutes(
+                time_point.get("minutes", time_point.get("interval_minutes")),
+                cycle_type="interval",
+            )
+            return after_local + timedelta(minutes=minutes)
+
+        hh, mm = self.parse_hhmm(time_point.get("time"))
+        target_time = time(hour=hh, minute=mm)
+
+        if cycle_type == A2AScheduleTask.CYCLE_DAILY:
+            candidate = datetime.combine(
+                after_local.date(),
+                target_time,
+                tzinfo=after_local.tzinfo,
+            )
+            candidate = self.resolve_local_wall_clock(candidate)
+            if candidate <= after_local:
+                candidate = self.resolve_local_wall_clock(candidate + timedelta(days=1))
+            return candidate
+
+        if cycle_type == A2AScheduleTask.CYCLE_WEEKLY:
+            weekday = self.coerce_int(time_point.get("weekday"))
+            if weekday is None or weekday < 1 or weekday > 7:
+                raise A2AScheduleValidationError("Invalid weekday")
+
+            delta_days = (weekday - after_local.isoweekday()) % 7
+            candidate_date = after_local.date() + timedelta(days=delta_days)
+            candidate = datetime.combine(
+                candidate_date,
+                target_time,
+                tzinfo=after_local.tzinfo,
+            )
+            candidate = self.resolve_local_wall_clock(candidate)
+            if candidate <= after_local:
+                candidate = self.resolve_local_wall_clock(candidate + timedelta(days=7))
+            return candidate
+
+        if cycle_type == A2AScheduleTask.CYCLE_MONTHLY:
+            day = self.coerce_int(time_point.get("day"))
+            if day is None or day < 1 or day > 31:
+                raise A2AScheduleValidationError("Invalid day")
+
+            candidate = self.monthly_candidate(
+                year=after_local.year,
+                month=after_local.month,
+                day=day,
+                hour=hh,
+                minute=mm,
+                tz=after_local.tzinfo,
+            )
+            candidate = self.resolve_local_wall_clock(candidate)
+            if candidate <= after_local:
+                if after_local.month == 12:
+                    year = after_local.year + 1
+                    month = 1
+                else:
+                    year = after_local.year
+                    month = after_local.month + 1
+
+                candidate = self.monthly_candidate(
+                    year=year,
+                    month=month,
+                    day=day,
+                    hour=hh,
+                    minute=mm,
+                    tz=after_local.tzinfo,
+                )
+                candidate = self.resolve_local_wall_clock(candidate)
+            return candidate
+
+        raise A2AScheduleValidationError("Unsupported cycle_type")
+
+    def compute_next_run_at(
+        self,
+        *,
+        cycle_type: str,
+        time_point: dict[str, Any],
+        timezone_str: str,
+        after_utc: datetime,
+        not_before_utc: datetime | None = None,
+        is_superuser: bool = False,
+    ) -> datetime:
+        normalized_cycle = self.normalize_cycle_type(cycle_type)
+        timezone_value = self.normalize_timezone_str(timezone_str)
+        normalized_point = self.normalize_time_point(
+            cycle_type=normalized_cycle,
+            time_point=time_point,
+            is_superuser=is_superuser,
+            timezone_str=timezone_value,
+        )
+        if normalized_cycle == A2AScheduleTask.CYCLE_SEQUENTIAL:
+            after = ensure_utc(after_utc)
+            guard = ensure_utc(not_before_utc or after_utc)
+            baseline = after if after >= guard else guard
+            return self.compute_sequential_next_run_at(
+                time_point=normalized_point,
+                after_utc=baseline,
+            )
+
+        if normalized_cycle == A2AScheduleTask.CYCLE_INTERVAL:
+            minutes = self.normalize_schedule_minutes(
+                normalized_point.get(
+                    "minutes", normalized_point.get("interval_minutes")
+                ),
+                cycle_type="interval",
+            )
+            interval = timedelta(minutes=minutes)
+            after = ensure_utc(after_utc)
+            guard = ensure_utc(not_before_utc or after_utc)
+            start_at = self.resolve_interval_start_at_utc(
+                normalized_point.get("start_at_utc")
+            )
+            return self.next_interval_candidate(
+                after_utc=after,
+                interval=interval,
+                start_at_utc=start_at,
+                guard_utc=guard,
+            )
+
+        tz = resolve_timezone(timezone_value, default="UTC")
+        after_local = ensure_utc(after_utc).astimezone(tz)
+        guard_utc = ensure_utc(not_before_utc or after_utc)
+
+        candidate_local = self.next_occurrence_local(
+            cycle_type=normalized_cycle,
+            time_point=normalized_point,
+            after_local=after_local,
+            is_superuser=is_superuser,
+        )
+        while ensure_utc(candidate_local) <= guard_utc:
+            candidate_local = self.next_occurrence_local(
+                cycle_type=normalized_cycle,
+                time_point=normalized_point,
+                after_local=candidate_local,
+                is_superuser=is_superuser,
+            )
+
+        return candidate_local.astimezone(timezone.utc)

--- a/backend/tests/test_a2a_schedule_job.py
+++ b/backend/tests/test_a2a_schedule_job.py
@@ -1636,11 +1636,11 @@ async def test_recover_stale_running_tasks_commits_per_recovered_task(
         timeout_apply_call_count += 1
 
     monkeypatch.setattr(
-        "app.services.a2a_schedule_service.commit_safely",
+        "app.services.a2a_schedule_dispatch.commit_safely",
         _counting_commit,
     )
     monkeypatch.setattr(
-        "app.services.a2a_schedule_service.set_postgres_local_timeouts",
+        "app.services.a2a_schedule_support.set_postgres_local_timeouts",
         _counting_set_timeouts,
     )
 


### PR DESCRIPTION
## 关联提交
- `dde2347 refactor(backend): split A2A schedule service domains (#458)`

## 需求评估
### 1. 需求是否合理、是否仍然有效
- `#458` 仍然合理且有效。主干中的 `A2AScheduleService` 之前同时承担 CRUD、quota/lock、due task enqueue、claim、stale recovery、terminal projection、time normalization / next-run 计算，职责跨越多个生命周期阶段。
- 相比 issue 提出时，当前代码还叠加了更多 recovery 与 time semantics 细节，因此继续维持单文件实现的风险更高。

### 2. 实施方案是否符合当前最佳实践
- 本 PR 没有机械地把方法分散到几个文件，而是采用 façade + domain collaborators + shared support/helper 的拆分方式。
- 这个方向与近期 `#461` 的重构做法一致，能在不改变路由和 job 调用面的前提下收紧边界，并为后续调度域演进留出更清晰的挂载点。

## 模块变更
### 1. façade 与公共类型
- 保留 `backend/app/services/a2a_schedule_service.py` 作为稳定 façade，对外 API 不变。
- 新增 `backend/app/services/a2a_schedule_common.py`，抽出错误类型、`ClaimedA2AScheduleTask` 和 DB 重试映射装饰器。

### 2. 共享支撑
- 新增 `backend/app/services/a2a_schedule_support.py`，承载写超时设置、quota advisory lock、task lookup、agent ownership、active quota 校验。

### 3. 时间与时间点语义
- 新增 `backend/app/services/a2a_schedule_time.py`，承载 schedule payload 归一化、timezone/local wall-clock 处理、next run 计算与 response `time_point` 序列化。

### 4. CRUD / Dispatch / Projection
- 新增 `backend/app/services/a2a_schedule_crud.py`，承载 list/get/create/update/toggle/delete/manual fail。
- 新增 `backend/app/services/a2a_schedule_dispatch.py`，承载 enqueue/claim/recover/finalize。
- 新增 `backend/app/services/a2a_schedule_projection.py`，承载 running projection、execution list、terminal projection。

### 5. 测试调整
- 更新 `backend/tests/test_a2a_schedule_job.py` 的 monkeypatch 打桩路径，使其对齐新的 `dispatch` / `support` 模块。

## 代码审查结论
### 1. 合理性与稳健性
- 这次改动合理，且实现边界清晰：CRUD、调度运行时、投影、共享 DB 支撑、时间计算被显式分层，`A2AScheduleService` 不再承担具体实现细节。
- 对外入口保持稳定，现有路由与 `a2a_schedule_job` 无需修改调用协议，降低了重构回归风险。

### 2. 是否存在偏差、遗漏、冗余或风险
- 未发现阻塞合并的问题。
- 当前残余点主要是非阻塞性的：`a2a_schedule_time.py` 仍然偏大，且同时承载了时间语义与一部分基础字段归一化，但这没有偏离 `#458` 的目标，也不构成功能风险。
- `closes #458` 是准确的；`#462`、`#375`、`#244` 更适合作为 `related`，不应标注为 `closes`。

## 相关 issues
- Closes #458
- Related: #462
- Related: #375
- Related: #244

## 验证
- `cd backend && uv run pre-commit run --files app/services/a2a_schedule_service.py app/services/a2a_schedule_common.py app/services/a2a_schedule_support.py app/services/a2a_schedule_time.py app/services/a2a_schedule_projection.py app/services/a2a_schedule_crud.py app/services/a2a_schedule_dispatch.py tests/test_a2a_schedule_job.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_a2a_schedule_routes.py tests/test_a2a_schedule_job.py tests/test_a2a_schedule_timezone_semantics.py tests/test_me_sessions_routes.py tests/test_unified_session_domain_routes.py tests/test_issue_338_reuse_thread_cleanup.py`
- 结果：`92 passed in 58.42s`
