### PR TITLE
fix(stream): consume canonical tool_call data-part updates (#473)

### DIFF
--- a/backend/app/services/a2a_stream_payloads.py
+++ b/backend/app/services/a2a_stream_payloads.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from app.utils.payload_extract import as_dict
@@ -49,6 +50,47 @@ def extract_stream_text_from_parts(parts: Any) -> str:
         if isinstance(content, str):
             collected.append(content)
     return "".join(collected)
+
+
+def _serialize_stream_data_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except TypeError:
+        return json.dumps(repr(value), ensure_ascii=False)
+
+
+def extract_stream_data_from_parts(parts: Any) -> str:
+    if not isinstance(parts, list):
+        return ""
+    collected: list[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        raw_kind = part.get("kind") or part.get("type")
+        normalized_kind = (
+            raw_kind.strip().lower() if isinstance(raw_kind, str) else None
+        )
+        if normalized_kind != "data" and "data" not in part:
+            continue
+        serialized = _serialize_stream_data_value(part.get("data"))
+        if serialized:
+            collected.append(serialized)
+    return "\n".join(collected)
+
+
+def extract_stream_content_from_parts(parts: Any, *, block_type: str) -> str:
+    if block_type == "tool_call":
+        return extract_stream_data_from_parts(parts) or extract_stream_text_from_parts(
+            parts
+        )
+    return extract_stream_text_from_parts(parts)
 
 
 def extract_shared_stream_metadata(
@@ -156,7 +198,9 @@ def extract_stream_chunk_from_serialized_event(
         if message_id is None:
             message_id = _pick_non_empty_str(candidate, ("message_id", "messageId"))
 
-    delta = extract_stream_text_from_parts(artifact.get("parts"))
+    delta = extract_stream_content_from_parts(
+        artifact.get("parts"), block_type=block_type
+    )
     if not delta:
         return None
 
@@ -205,7 +249,10 @@ def analyze_stream_chunk_contract(
     block_type = extract_artifact_type(payload, artifact)
     if block_type is None:
         return None, "missing_or_invalid_block_type"
-    if extract_stream_text_from_parts(artifact.get("parts")) == "":
+    if (
+        extract_stream_content_from_parts(artifact.get("parts"), block_type=block_type)
+        == ""
+    ):
         return None, "missing_text_parts"
     return None, "invalid_artifact_update_shape"
 

--- a/backend/tests/test_a2a_invoke_service.py
+++ b/backend/tests/test_a2a_invoke_service.py
@@ -127,6 +127,37 @@ def _artifact_event(
     return payload
 
 
+def _artifact_data_event(
+    *,
+    artifact_id: str,
+    data: dict,
+    block_type: str,
+    source: str | None = None,
+    append: bool | None = None,
+    message_id: str | None = None,
+    event_id: str | None = None,
+) -> dict:
+    metadata: dict[str, str] = {}
+    artifact_key = artifact_id.replace(":", "-").replace("/", "-")
+    metadata["block_type"] = block_type
+    if source:
+        metadata["source"] = source
+    metadata["message_id"] = message_id or f"msg-{artifact_key}"
+    metadata["event_id"] = event_id or f"evt-{artifact_key}"
+
+    payload: dict = {
+        "kind": "artifact-update",
+        "artifact": {
+            "artifact_id": artifact_id,
+            "parts": [{"kind": "data", "data": data}],
+            "metadata": metadata,
+        },
+    }
+    if append is not None:
+        payload["append"] = append
+    return payload
+
+
 @pytest.mark.asyncio
 async def test_sse_error_event_contains_unified_error_code():
     response = a2a_invoke_service.stream_sse(
@@ -669,6 +700,50 @@ async def test_sse_warns_missing_text_parts_when_identity_ids_absent(caplog):
             "content": "legacy",
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_sse_accepts_tool_call_data_parts_without_non_contract_warning(caplog):
+    caplog.set_level(logging.WARNING)
+    response = a2a_invoke_service.stream_sse(
+        gateway=_GatewayWithEvents(
+            [
+                _artifact_data_event(
+                    artifact_id="task-tool:stream",
+                    block_type="tool_call",
+                    source="tool_part_update",
+                    data={
+                        "call_id": "call-1",
+                        "tool": "read",
+                        "status": "pending",
+                        "input": {},
+                    },
+                ),
+                {"kind": "status-update", "final": True},
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+    )
+    frames: list[str] = []
+    async for chunk in response.body_iterator:
+        frames.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    warning_records = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING"
+        and record.message == "Dropped non-contract artifact-update event"
+    ]
+    assert warning_records == []
+    payload = "".join(frames)
+    assert '"kind": "artifact-update"' in payload
+    assert '"block_type": "tool_call"' in payload
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_a2a_invoke_service_contract_fallback.py
+++ b/backend/tests/test_a2a_invoke_service_contract_fallback.py
@@ -90,3 +90,43 @@ def test_extract_stream_chunk_prefers_shared_stream_block_type_over_text_part_ki
     assert chunk["event_id"] == "evt-shared"
     assert chunk["seq"] == 7
     assert chunk["source"] == "tool_part_update"
+
+
+def test_extract_stream_chunk_reads_tool_call_content_from_data_parts():
+    chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
+        {
+            "kind": "artifact-update",
+            "artifact": {
+                "parts": [
+                    {
+                        "kind": "data",
+                        "data": {
+                            "call_id": "call-1",
+                            "tool": "read",
+                            "status": "pending",
+                            "input": {},
+                        },
+                    }
+                ],
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "block_type": "tool_call",
+                            "source": "tool_part_update",
+                            "message_id": "msg-data",
+                            "event_id": "evt-data",
+                            "sequence": 8,
+                        }
+                    }
+                },
+            },
+        }
+    )
+    assert chunk is not None
+    assert chunk["block_type"] == "tool_call"
+    assert chunk["content"] == (
+        '{"call_id":"call-1","input":{},"status":"pending","tool":"read"}'
+    )
+    assert chunk["message_id"] == "msg-data"
+    assert chunk["event_id"] == "evt-data"
+    assert chunk["seq"] == 8

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -247,6 +247,45 @@ describe("block-based stream parser and reducer", () => {
     expect(parsed?.source).toBe("tool_part_update");
   });
 
+  it("parses tool_call blocks carried in data parts", () => {
+    const parsed = extractStreamBlockUpdate({
+      kind: "artifact-update",
+      taskId: "task-10",
+      artifact: {
+        artifactId: "task-10:stream",
+        parts: [
+          {
+            kind: "data",
+            data: {
+              call_id: "call-1",
+              tool: "read",
+              status: "pending",
+              input: {},
+            },
+          },
+        ],
+        metadata: {
+          shared: {
+            stream: {
+              block_type: "tool_call",
+              source: "tool_part_update",
+              message_id: "msg-data",
+              event_id: "evt-data",
+              sequence: 11,
+            },
+          },
+        },
+      },
+    });
+    expect(parsed?.blockType).toBe("tool_call");
+    expect(parsed?.delta).toBe(
+      '{"call_id":"call-1","input":{},"status":"pending","tool":"read"}',
+    );
+    expect(parsed?.messageId).toBe("msg-data");
+    expect(parsed?.eventId).toBe("evt-data");
+    expect(parsed?.seq).toBe(11);
+  });
+
   it("infers text block type when explicit metadata is missing", () => {
     const parsed = extractStreamBlockUpdate({
       kind: "artifact-update",

--- a/frontend/lib/api/chat-utils.ts
+++ b/frontend/lib/api/chat-utils.ts
@@ -160,6 +160,56 @@ const extractTextFromParts = (parts: unknown[]) =>
     .filter((item): item is string => Boolean(item))
     .join("");
 
+const sortSerializableValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortSerializableValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortSerializableValue(
+          (value as Record<string, unknown>)[key],
+        );
+        return acc;
+      }, {});
+  }
+  return value;
+};
+
+const serializeDataPartValue = (value: unknown): string | null => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(sortSerializableValue(value));
+  } catch {
+    return JSON.stringify(String(value));
+  }
+};
+
+const extractDataFromParts = (parts: unknown[]) =>
+  parts
+    .map((part) => {
+      if (!part || typeof part !== "object") {
+        return null;
+      }
+      const typed = part as {
+        kind?: unknown;
+        type?: unknown;
+        data?: unknown;
+      };
+      const rawKind = typed.kind ?? typed.type;
+      const normalizedKind =
+        typeof rawKind === "string" ? rawKind.trim().toLowerCase() : null;
+      if (normalizedKind !== "data" && !("data" in typed)) {
+        return null;
+      }
+      return serializeDataPartValue(typed.data);
+    })
+    .filter((item): item is string => Boolean(item))
+    .join("\n");
+
 const asRecord = (value: unknown): Record<string, unknown> | null =>
   value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -411,6 +461,7 @@ export const extractStreamBlockUpdate = (
   const sharedStream = extractSharedStreamMetadata(metadata, rootMetadata);
   const parts = Array.isArray(artifact?.parts) ? artifact.parts : [];
   const textFromParts = extractTextFromParts(parts);
+  const dataFromParts = extractDataFromParts(parts);
   const rawBlockType =
     pickString(sharedStream, ["block_type"]) ??
     pickString(metadata, ["block_type"]) ??
@@ -457,7 +508,9 @@ export const extractStreamBlockUpdate = (
   const messageId = resolvedMessageId ?? `artifact:${resolvedArtifactId}`;
 
   const delta =
-    textFromParts ||
+    (blockType === "tool_call"
+      ? dataFromParts || textFromParts
+      : textFromParts) ||
     pickRawString(data, ["delta"]) ||
     pickRawString(artifact ?? null, ["delta"]) ||
     pickRawString(data, ["content", "text"]) ||


### PR DESCRIPTION
## 背景

本 PR 聚焦修复 Hub 对最新 canonical `tool_call` 流契约的消费缺口。

上游 `opencode-a2a-server` 在 PR `#156` 中已将 `tool_call` 流块从 `TextPart` 明确切换为 `DataPart(data={...})`，同时继续使用 `metadata.shared.stream.block_type = "tool_call"` 作为块语义权威字段。Hub 现有实现已经能正确读取 canonical `block_type`，但前后端都仍把“可消费 stream chunk”错误地收窄为“必须能抽出文本 delta”，导致 `tool_call + DataPart` 在运行时被忽略，并进一步触发前端长期停留在 streaming、后端记录 `missing_text_parts` warning 的问题。

## 模块一：Backend Stream Payloads

涉及文件：
- `backend/app/services/a2a_stream_payloads.py`
- `backend/tests/test_a2a_invoke_service.py`
- `backend/tests/test_a2a_invoke_service_contract_fallback.py`

改动说明：
- 为 `tool_call` 新增 `parts[].data` 内容提取逻辑，并对结构化 payload 做稳定 JSON 序列化，避免同一事件在不同消费路径下内容不一致。
- 保留原有 `tool_call` 文本载荷回退，避免对仍使用 `TextPart` 的兼容路径造成破坏。
- 调整非契约诊断判断，使 canonical `tool_call + DataPart` 不再被误记为 `missing_text_parts`。
- 新增 parser 与 SSE 回归测试，覆盖：
  - `shared.stream.block_type = tool_call` + `parts.kind = data`
  - SSE 流中该事件不再触发 non-contract warning

## 模块二：Frontend Stream Parser

涉及文件：
- `frontend/lib/api/chat-utils.ts`
- `frontend/lib/__tests__/streamContract.test.ts`

改动说明：
- 前端流解析增加 `parts[].data` 提取，并与后端保持同样的稳定 JSON 序列化策略。
- `extractStreamBlockUpdate()` 在 `blockType === "tool_call"` 时优先消费 `data parts`，读不到时再回退到文本载荷。
- 不修改现有 `ToolCallBlock` UI 组件结构，先复用现有字符串展示链路，保证本次修复聚焦契约消费正确性。
- 新增前端契约测试，覆盖 `tool_call DataPart` 的解析结果与关键 identity 字段。

## 模块三：Issue 关系

- Closes #473
- Related #443
  - 本 PR 继续沿用 canonical contract 的收口方向，没有回退到 provider-specific 特判。
- Related #446
  - 本 PR 不是重复修复，而是补齐 `#446` 未覆盖的 `tool_call + DataPart(data)` 场景。
- Related #464
  - 两者都涉及 shared stream contract，但 `#464` 聚焦 capability discovery / fallback policy，本 PR不处理 extension 声明层。
- Related #190
  - 两者都涉及 mixed stream / tool_call 路径，但 `#190` 偏测试固化与时序覆盖，本 PR只修正 DataPart 消费缺口。

## 验证证据

### Backend

```text
cd backend && uv run pre-commit run --files app/services/a2a_stream_payloads.py tests/test_a2a_invoke_service_contract_fallback.py tests/test_a2a_invoke_service.py --config ../.pre-commit-config.yaml
Passed

cd backend && uv run pytest tests/test_a2a_invoke_service_contract_fallback.py tests/test_a2a_invoke_service.py
61 passed in 1.46s
```

### Frontend

```text
cd frontend && npm run lint
Passed

cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types
Passed

cd frontend && npm test -- --findRelatedTests lib/api/chat-utils.ts lib/__tests__/streamContract.test.ts --maxWorkers=25%
32 suites passed / 159 tests
```

## 说明

- 本 PR 的实现是“新增 canonical 兼容并保留旧文本回退”，不是“一次性移除旧形态”。
- 当前仍以字符串形式展示 `tool_call` 内容，后续如果要演进为结构化工具调用 UI，可以在此基础上继续收敛数据模型。