### PR TITLE
fix(stream): flush first non-text block placeholder during streaming (#478)

### DIFF
--- a/frontend/store/__tests__/chatRuntime.test.ts
+++ b/frontend/store/__tests__/chatRuntime.test.ts
@@ -319,6 +319,248 @@ describe("executeChatRuntime empty-content recovery", () => {
     expect(streamedAgentMessage?.status).toBe("done");
   });
 
+  it("renders a tool_call placeholder during stream before any text block arrives", async () => {
+    const conversationId = "conv-stream-tool-call-1";
+    const agentId = "agent-tool-call-1";
+    const userMessageId = "user-msg-tool-call-1";
+    const agentMessageId = "agent-msg-tool-call-1";
+
+    addConversationMessage(conversationId, {
+      id: userMessageId,
+      role: "user",
+      content: "hello",
+      createdAt: "2026-03-12T06:10:00.000Z",
+      status: "done",
+    });
+    addConversationMessage(conversationId, {
+      id: agentMessageId,
+      role: "agent",
+      content: "",
+      blocks: [],
+      createdAt: "2026-03-12T06:10:01.000Z",
+      status: "streaming",
+    });
+
+    let state: ChatRuntimeState = {
+      sessions: {
+        [conversationId]: {
+          ...createAgentSession(agentId),
+          streamState: "streaming",
+          lastUserMessageId: userMessageId,
+          lastAgentMessageId: agentMessageId,
+        },
+      },
+    };
+
+    const get = () => state;
+    const set: ChatRuntimeSetState<ChatRuntimeState> = (partial) => {
+      const next =
+        typeof partial === "function"
+          ? partial(state as ChatRuntimeState)
+          : partial;
+      state = {
+        ...state,
+        ...(next as Partial<ChatRuntimeState>),
+      };
+    };
+
+    let renderedDuringStream = false;
+    mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
+      async (params: {
+        callbacks: {
+          onData: (data: Record<string, unknown>) => boolean | void;
+        };
+      }) => {
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "working" },
+          final: false,
+        });
+        params.callbacks.onData({
+          kind: "artifact-update",
+          append: false,
+          message_id: agentMessageId,
+          event_id: `${agentMessageId}:1`,
+          seq: 1,
+          artifact: {
+            artifactId: `${agentMessageId}:stream`,
+            parts: [
+              {
+                kind: "data",
+                data: {
+                  call_id: "call-1",
+                  tool: "bash",
+                  status: "running",
+                  input: { command: "pwd" },
+                },
+              },
+            ],
+            metadata: {
+              shared: {
+                stream: {
+                  block_type: "tool_call",
+                  source: "tool_part_update",
+                  message_id: agentMessageId,
+                  event_id: `${agentMessageId}:1`,
+                  sequence: 1,
+                },
+              },
+            },
+          },
+        });
+
+        const agentMessage = getConversationMessages(conversationId).find(
+          (message) => message.id === agentMessageId,
+        );
+        renderedDuringStream =
+          agentMessage?.status === "streaming" &&
+          (agentMessage.blocks?.length ?? 0) > 0 &&
+          agentMessage?.blocks?.[0]?.type === "tool_call";
+
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "completed" },
+          final: true,
+        });
+        return true;
+      },
+    );
+
+    await executeChatRuntime(
+      conversationId,
+      agentId,
+      "personal",
+      {
+        query: "hello",
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      },
+      agentMessageId,
+      get,
+      set,
+    );
+
+    expect(renderedDuringStream).toBe(true);
+    expect(mockedListSessionMessagesPage).not.toHaveBeenCalled();
+  });
+
+  it("renders a reasoning placeholder during stream before completion", async () => {
+    const conversationId = "conv-stream-reasoning-1";
+    const agentId = "agent-reasoning-1";
+    const userMessageId = "user-msg-reasoning-1";
+    const agentMessageId = "agent-msg-reasoning-1";
+
+    addConversationMessage(conversationId, {
+      id: userMessageId,
+      role: "user",
+      content: "hello",
+      createdAt: "2026-03-12T06:20:00.000Z",
+      status: "done",
+    });
+    addConversationMessage(conversationId, {
+      id: agentMessageId,
+      role: "agent",
+      content: "",
+      blocks: [],
+      createdAt: "2026-03-12T06:20:01.000Z",
+      status: "streaming",
+    });
+
+    let state: ChatRuntimeState = {
+      sessions: {
+        [conversationId]: {
+          ...createAgentSession(agentId),
+          streamState: "streaming",
+          lastUserMessageId: userMessageId,
+          lastAgentMessageId: agentMessageId,
+        },
+      },
+    };
+
+    const get = () => state;
+    const set: ChatRuntimeSetState<ChatRuntimeState> = (partial) => {
+      const next =
+        typeof partial === "function"
+          ? partial(state as ChatRuntimeState)
+          : partial;
+      state = {
+        ...state,
+        ...(next as Partial<ChatRuntimeState>),
+      };
+    };
+
+    let renderedDuringStream = false;
+    mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
+      async (params: {
+        callbacks: {
+          onData: (data: Record<string, unknown>) => boolean | void;
+        };
+      }) => {
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "working" },
+          final: false,
+        });
+        params.callbacks.onData({
+          kind: "artifact-update",
+          append: false,
+          message_id: agentMessageId,
+          event_id: `${agentMessageId}:1`,
+          seq: 1,
+          artifact: {
+            artifactId: `${agentMessageId}:stream`,
+            parts: [{ kind: "text", text: "Reasoning in progress" }],
+            metadata: {
+              shared: {
+                stream: {
+                  block_type: "reasoning",
+                  source: "reasoning_part_update",
+                  message_id: agentMessageId,
+                  event_id: `${agentMessageId}:1`,
+                  sequence: 1,
+                },
+              },
+            },
+          },
+        });
+
+        const agentMessage = getConversationMessages(conversationId).find(
+          (message) => message.id === agentMessageId,
+        );
+        renderedDuringStream =
+          agentMessage?.status === "streaming" &&
+          (agentMessage.blocks?.length ?? 0) > 0 &&
+          agentMessage?.blocks?.[0]?.type === "reasoning";
+
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "completed" },
+          final: true,
+        });
+        return true;
+      },
+    );
+
+    await executeChatRuntime(
+      conversationId,
+      agentId,
+      "personal",
+      {
+        query: "hello",
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      },
+      agentMessageId,
+      get,
+      set,
+    );
+
+    expect(renderedDuringStream).toBe(true);
+    expect(mockedListSessionMessagesPage).not.toHaveBeenCalled();
+  });
+
   it("keeps pending interrupt until a matching resolved event arrives", async () => {
     const conversationId = "conv-interrupt-pending-1";
     const agentId = "agent-interrupt-1";

--- a/frontend/store/chatRuntime.ts
+++ b/frontend/store/chatRuntime.ts
@@ -546,6 +546,24 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
   };
 
   const appendStreamChunk = (chunk: StreamBlockUpdate) => {
+    const shouldFlushImmediatelyForNonTextPlaceholder = (
+      targetMessageId: string,
+    ) => {
+      if (chunk.blockType !== "tool_call" && chunk.blockType !== "reasoning") {
+        return false;
+      }
+      if ((chunkBufferByMessageId.get(targetMessageId)?.length ?? 0) > 1) {
+        return false;
+      }
+      const targetMessage = getConversationMessages(conversationId).find(
+        (message) => message.id === targetMessageId,
+      );
+      if (!targetMessage || targetMessage.role !== "agent") {
+        return false;
+      }
+      return (targetMessage.blocks?.length ?? 0) === 0;
+    };
+
     const resolveChunkMessageId = () => {
       const mapped = streamMessageIdMap.get(chunk.messageId);
       if (mapped) {
@@ -595,6 +613,11 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
     const chunks = chunkBufferByMessageId.get(targetMessageId) ?? [];
     chunks.push(chunk);
     chunkBufferByMessageId.set(targetMessageId, chunks);
+
+    if (shouldFlushImmediatelyForNonTextPlaceholder(targetMessageId)) {
+      flushChunkBuffer();
+      return;
+    }
 
     if (!bufferTimeout) {
       bufferTimeout = setTimeout(flushChunkBuffer, 16);


### PR DESCRIPTION
## 背景

继续会话或普通流式回复时，`tool_call` / `reasoning` 这类非文本块在 streaming 期间没有及时出现占位。用户只能看到整条 agent 回复一直处于 `Streaming...`，直到块类型切换、文本块到达或流结束后，前面积累的非文本块才一起出现。

本 PR 聚焦恢复“首个非文本块一到达就可见”的渐进反馈，不扩大到结构化块 UI 设计调整。

## Frontend Runtime

- 文件：`frontend/store/chatRuntime.ts`
- 为首个 `tool_call` / `reasoning` chunk 增加即时 flush。
- 当目标 agent 消息尚无任何 `blocks` 时，首个非文本块会立即写入 `message.blocks`，从而尽快渲染 `Show Tool Call` / `Show Reasoning` 占位。
- 后续连续同类型 chunk 仍保留现有轻量批处理，避免无意义高频重绘。

## Frontend Tests

- 文件：`frontend/store/__tests__/chatRuntime.test.ts`
- 新增 `tool_call` 回归测试：即使没有 text block，streaming 期间也必须先出现 block 占位。
- 新增 `reasoning` 回归测试：同样要求在流结束前出现 block 占位。
- 保留现有 text progressive rendering 测试，确保文本流行为不回退。

## 文档

- 本 PR 未引入额外文档变更；当前改动范围仅限前端运行时与回归测试。

## Issue 关系

- Closes #478
- Related #126
- Related #475

## 验证

- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests store/chatRuntime.ts store/__tests__/chatRuntime.test.ts --maxWorkers=25%`
- 结果：`24 suites passed / 109 tests`
