### PR TITLE
feat(ui): optimize chat composer input bar on focus

### DIFF
--- a/frontend/components/chat/ChatComposer.tsx
+++ b/frontend/components/chat/ChatComposer.tsx
@@ -63,9 +63,9 @@ export function ChatComposer({
         </View>
       ) : null}
 
-      {!isFocused && (
-        <View className="mb-2 flex-row items-center justify-between rounded-xl bg-black/25 px-2 py-1">
-          <View className="flex-row items-center gap-2">
+      <View className="mb-2 flex-row items-center justify-between rounded-xl bg-black/25 px-2 py-1">
+        <View className="flex-row items-center gap-2">
+          {!isFocused && (
             <Pressable
               className="h-9 max-w-[180px] flex-row items-center gap-2 rounded-xl bg-slate-800/40 px-3"
               onPress={onOpenModelPicker}
@@ -85,49 +85,49 @@ export function ChatComposer({
                 {modelLabel}
               </Text>
             </Pressable>
+          )}
 
+          <Pressable
+            className={`h-9 w-14 items-center justify-center rounded-xl ${
+              showShortcutManager ? "bg-primary" : "bg-slate-800/40"
+            }`}
+            onPress={onOpenShortcutManager}
+            accessibilityRole="button"
+            accessibilityLabel="Open shortcut manager"
+          >
+            <Ionicons
+              name={showShortcutManager ? "flash" : "flash-outline"}
+              size={18}
+              color={showShortcutManager ? "#000000" : "#FFFFFF"}
+            />
+          </Pressable>
+
+          {input.length > 0 && (
             <Pressable
-              className={`h-9 w-14 items-center justify-center rounded-xl ${
-                showShortcutManager ? "bg-primary" : "bg-slate-800/40"
-              }`}
-              onPress={onOpenShortcutManager}
+              className="h-9 w-14 items-center justify-center rounded-xl bg-slate-800/40"
+              onPress={() => {
+                onInputChange("");
+                inputRef.current?.focus();
+              }}
               accessibilityRole="button"
-              accessibilityLabel="Open shortcut manager"
+              accessibilityLabel="Clear input"
             >
-              <Ionicons
-                name={showShortcutManager ? "flash" : "flash-outline"}
-                size={18}
-                color={showShortcutManager ? "#000000" : "#FFFFFF"}
-              />
+              <Ionicons name="trash-outline" size={18} color="#FFFFFF" />
             </Pressable>
+          )}
 
-            {input.length > 0 && (
-              <Pressable
-                className="h-9 w-14 items-center justify-center rounded-xl bg-slate-800/40"
-                onPress={() => {
-                  onInputChange("");
-                  inputRef.current?.focus();
-                }}
-                accessibilityRole="button"
-                accessibilityLabel="Clear input"
-              >
-                <Ionicons name="trash-outline" size={18} color="#FFFFFF" />
-              </Pressable>
-            )}
-
-            {showScrollToBottom && (
-              <Pressable
-                className="h-9 w-14 items-center justify-center rounded-xl bg-slate-800/40"
-                onPress={onScrollToBottom}
-                accessibilityRole="button"
-                accessibilityLabel="Scroll to bottom"
-              >
-                <Ionicons name="chevron-down" size={18} color="#FFFFFF" />
-              </Pressable>
-            )}
-          </View>
+          {showScrollToBottom && (
+            <Pressable
+              className="h-9 w-14 items-center justify-center rounded-xl bg-slate-800/40"
+              onPress={onScrollToBottom}
+              accessibilityRole="button"
+              accessibilityLabel="Scroll to bottom"
+            >
+              <Ionicons name="chevron-down" size={18} color="#FFFFFF" />
+            </Pressable>
+          )}
         </View>
-      )}
+      </View>
 
       <View className="flex-row items-end gap-2 rounded-2xl bg-surface p-2">
         <TextInput

--- a/frontend/components/chat/__tests__/ChatComposer.test.tsx
+++ b/frontend/components/chat/__tests__/ChatComposer.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from "@testing-library/react-native";
 import React from "react";
+import { TextInput } from "react-native";
 
 import { ChatComposer } from "../ChatComposer";
 
@@ -76,5 +77,23 @@ describe("ChatComposer clear button", () => {
     );
 
     expect(getByText("openai / gpt-5")).toBeTruthy();
+  });
+
+  it("hides only the model picker while keeping other actions available on focus", () => {
+    const { getByLabelText, queryByLabelText, UNSAFE_getByType } = render(
+      <ChatComposer
+        {...mockProps}
+        input="hello"
+        showScrollToBottom
+        onScrollToBottom={jest.fn()}
+      />,
+    );
+
+    fireEvent(UNSAFE_getByType(TextInput), "focus");
+
+    expect(queryByLabelText("Choose model")).toBeNull();
+    expect(getByLabelText("Open shortcut manager")).toBeTruthy();
+    expect(getByLabelText("Clear input")).toBeTruthy();
+    expect(getByLabelText("Scroll to bottom")).toBeTruthy();
   });
 });


### PR DESCRIPTION
### 修复/优化内容 (Changes)
- 在 `ChatComposer` 中将原本带有歧义的模型选择图标 `git-branch-outline` 替换为了 `hardware-chip-outline`。
- 新增焦点状态监听，在 `TextInput` 获得焦点 (`isFocused === true`) 时，自动隐藏模型选择、快捷指令等上方按钮区域，从而释放屏幕垂直空间。
- 将“发送按钮”下移到输入框同行，确保在顶部工具栏隐藏时依然能够顺利发送消息，避免破坏基础聊天体验。

### 关联 Issues
closes #482
