### PR TITLE
feat(shortcuts): optimize agent specific shortcuts sorting (#481)

### DIFF
--- a/frontend/hooks/__tests__/useShortcutsQuery.test.tsx
+++ b/frontend/hooks/__tests__/useShortcutsQuery.test.tsx
@@ -80,4 +80,61 @@ describe("useShortcutsQuery", () => {
     const globalShortcuts = result.current.getShortcutsForAgent(null);
     expect(globalShortcuts.every((s) => s.agentId === null)).toBe(true);
   });
+
+  it("preserves the original order within agent-specific and system shortcut groups", async () => {
+    (listShortcuts as jest.Mock).mockResolvedValue([
+      {
+        id: "system-b",
+        title: "System B",
+        prompt: "System prompt B",
+        is_default: false,
+        order: 11,
+        agent_id: null,
+      },
+      {
+        id: "agent-1-b",
+        title: "Agent 1 B",
+        prompt: "Agent 1 prompt B",
+        is_default: false,
+        order: 8,
+        agent_id: "agent-1",
+      },
+      {
+        id: "agent-1-a",
+        title: "Agent 1 A",
+        prompt: "Agent 1 prompt A",
+        is_default: false,
+        order: 2,
+        agent_id: "agent-1",
+      },
+      {
+        id: "system-a",
+        title: "System A",
+        prompt: "System prompt A",
+        is_default: false,
+        order: 1,
+        agent_id: null,
+      },
+    ]);
+
+    const { result } = renderHook(() => useShortcutsQuery(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const agent1Shortcuts = result.current.getShortcutsForAgent("agent-1");
+
+    expect(agent1Shortcuts.map((shortcut) => shortcut.id)).toEqual([
+      "agent-1-a",
+      "agent-1-b",
+      "11111111-1111-1111-1111-111111111111",
+      "22222222-2222-2222-2222-222222222222",
+      "system-a",
+      "33333333-3333-3333-3333-333333333333",
+      "44444444-4444-4444-4444-444444444444",
+      "55555555-5555-5555-5555-555555555555",
+      "system-b",
+    ]);
+  });
 });

--- a/frontend/hooks/useShortcutsQuery.ts
+++ b/frontend/hooks/useShortcutsQuery.ts
@@ -102,14 +102,11 @@ export const useShortcutsQuery = () => {
     if (!agentId) {
       return shortcuts.filter((item) => item.agentId === null);
     }
-    const filteredShortcuts = shortcuts.filter(
-      (item) => item.agentId === null || item.agentId === agentId,
+    const agentSpecificShortcuts = shortcuts.filter(
+      (item) => item.agentId === agentId,
     );
-    return filteredShortcuts.sort((a, b) => {
-      if (a.agentId === agentId && b.agentId === null) return -1;
-      if (a.agentId === null && b.agentId === agentId) return 1;
-      return 0;
-    });
+    const systemShortcuts = shortcuts.filter((item) => item.agentId === null);
+    return [...agentSpecificShortcuts, ...systemShortcuts];
   };
 
   return {


### PR DESCRIPTION
### 描述 (Description)
针对 Agent 专属快捷指令优先显示的优化。

**变更模块:**
- **Hooks (`frontend/hooks/useShortcutsQuery.ts`)**
  修改 `getShortcutsForAgent` 方法。当过滤出当前 Agent 专属和系统通用的快捷指令后，按 `agentId` 进行重排序：专属快捷指令置前，系统默认（`agentId === null`）置后。相同类型的快捷指令将保持原始排序逻辑（由上游已经处理好的 `sortShortcuts` 决定）。
- **Tests (`frontend/hooks/__tests__/useShortcutsQuery.test.tsx`)**
  新增单元测试用例，覆盖不同情景下返回列表排序优先级的准确性，确保 Agent 专属的选项总是排在首位。

**相关 Issues**
closes #481 

### 审查与测试基线 (Verification)
- [x] 新增测试用例已验证排序逻辑准确。
