### PR TITLE
fix(frontend): override vulnerable flatted and undici versions (#480)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7632,9 +7632,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -15009,9 +15009,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,7 +76,9 @@
   },
   "overrides": {
     "minimatch": "^10.2.2",
-    "markdown-it": "^12.3.2"
+    "markdown-it": "^12.3.2",
+    "flatted": "^3.4.1",
+    "undici": "^6.24.0"
   },
   "expo": {
     "install": {


### PR DESCRIPTION
## 概述

本 PR 聚焦 Issue #480 的第一阶段修复：在不升级 Expo 主版本、也不对 Jest 工具链做激进变更的前提下，先通过 `overrides` 收敛当前 `frontend` 依赖树中的两个 `high` 级别告警。

Partially addresses #480

## 改动说明

### 依赖覆盖

- 在 `frontend/package.json` 中新增：
  - `flatted: ^3.4.1`
  - `undici: ^6.24.0`
- 保留现有的 `minimatch` 与 `markdown-it` overrides

### 锁文件更新

- 重新生成 `frontend/package-lock.json`
- 实际解析结果：
  - `flatted` 从 `3.3.3` 提升到 `3.4.1`
  - `undici` 从 `6.23.0` 提升到 `6.24.0`

## 结果

- `cd frontend && npm audit`：从 `2 high + 5 low` 收敛为 `0 high + 5 low`
- `cd frontend && npm audit --omit=dev`：从 `1 high` 收敛为 `0`

当前剩余 `5` 项 `low` 告警仍位于 `jest-expo -> jsdom -> http-proxy-agent -> @tootallnate/once` 测试链路，本 PR 不使用 `npm audit fix --force` 激进处理，以避免破坏 Expo 54 测试环境。

## 风险与边界

- `flatted` 位于 ESLint 工具链，风险较低
- `undici` 位于 `expo -> @expo/cli` 链路，本 PR 已补充 Expo CLI 冒烟验证，但仍未对所有 Expo CLI 子命令做穷举覆盖
- 因此本 PR 的定位是“先清除当前高危告警并验证前端主回归与关键 Expo CLI 路径”，而不是“完整验证全部 Expo CLI 子命令路径”

## 验证

- `cd frontend && npm install`
- `cd frontend && npm audit --json`
- `cd frontend && npm audit --omit=dev --json`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --maxWorkers=25%`
- `cd frontend && npx expo --version`
- `cd frontend && npx expo config --json`
- `cd frontend && npx expo export --platform web --output-dir <tmpdir> --clear`
