### PR TITLE
feat(a2a): frontload shared session query contract diagnostics (#468)

### DIFF
--- a/backend/app/integrations/a2a_extensions/session_query_diagnostics.py
+++ b/backend/app/integrations/a2a_extensions/session_query_diagnostics.py
@@ -1,0 +1,110 @@
+"""Shared session query diagnostics for card validation and agent onboarding."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a2a.types import AgentCard
+
+from app.integrations.a2a_extensions.contract_utils import as_dict
+from app.integrations.a2a_extensions.errors import A2AExtensionContractError
+from app.integrations.a2a_extensions.session_query import resolve_session_query
+from app.integrations.a2a_extensions.shared_contract import (
+    LEGACY_SHARED_SESSION_QUERY_URI,
+    SUPPORTED_SESSION_QUERY_URIS,
+)
+from app.schemas.a2a_agent_card import SharedSessionQueryDiagnostic
+
+
+def _find_declared_extension(card: AgentCard) -> tuple[Any | None, str | None]:
+    capabilities = getattr(card, "capabilities", None)
+    extensions = getattr(capabilities, "extensions", None) if capabilities else None
+    if not extensions:
+        return None, None
+
+    hinted = None
+    for candidate in extensions:
+        uri = str(getattr(candidate, "uri", "") or "").strip()
+        if uri in SUPPORTED_SESSION_QUERY_URIS:
+            return candidate, uri
+        if hinted is None and "session-query" in uri:
+            hinted = candidate, uri
+    return hinted if hinted is not None else (None, None)
+
+
+def diagnose_session_query(card: AgentCard) -> SharedSessionQueryDiagnostic:
+    ext, uri = _find_declared_extension(card)
+    if ext is None:
+        return SharedSessionQueryDiagnostic(
+            declared=False,
+            status="unsupported",
+            error="Shared session query extension not declared",
+        )
+
+    if uri not in SUPPORTED_SESSION_QUERY_URIS:
+        return SharedSessionQueryDiagnostic(
+            declared=True,
+            status="unsupported",
+            uri=uri,
+            error="Shared session query extension URI is not supported by Hub",
+        )
+
+    params = as_dict(getattr(ext, "params", None))
+    methods = as_dict(params.get("methods"))
+    raw_pagination = as_dict(params.get("pagination"))
+    result_envelope = params.get("result_envelope")
+    uses_legacy_uri = uri == LEGACY_SHARED_SESSION_QUERY_URI
+    uses_legacy_contract_fields = bool(
+        raw_pagination.get("mode") == "limit"
+        and (
+            "default_size" in raw_pagination
+            or "max_size" in raw_pagination
+            or "page" in raw_pagination.get("params", [])
+        )
+    )
+
+    try:
+        resolved = resolve_session_query(card)
+    except A2AExtensionContractError as exc:
+        return SharedSessionQueryDiagnostic(
+            declared=True,
+            status="invalid",
+            uri=uri,
+            provider=str(params.get("provider") or "").strip().lower() or None,
+            methods=sorted(
+                key
+                for key, value in methods.items()
+                if isinstance(value, str) and value.strip()
+            ),
+            pagination_mode=(
+                str(raw_pagination.get("mode")).strip() if raw_pagination else None
+            ),
+            pagination_params=[
+                item.strip()
+                for item in raw_pagination.get("params", [])
+                if isinstance(item, str) and item.strip()
+            ],
+            result_envelope_declared=result_envelope is not None,
+            uses_legacy_uri=uses_legacy_uri,
+            uses_legacy_contract_fields=uses_legacy_contract_fields,
+            error=str(exc),
+        )
+
+    return SharedSessionQueryDiagnostic(
+        declared=True,
+        status=(
+            "legacy" if uses_legacy_uri or uses_legacy_contract_fields else "canonical"
+        ),
+        uri=resolved.uri,
+        provider=resolved.provider,
+        methods=sorted(key for key, value in resolved.methods.items() if value),
+        pagination_mode=resolved.pagination.mode,
+        pagination_params=list(resolved.pagination.params),
+        result_envelope_declared=resolved.result_envelope is not None,
+        jsonrpc_interface_fallback_used=resolved.jsonrpc.fallback_used,
+        uses_legacy_uri=uses_legacy_uri,
+        uses_legacy_contract_fields=uses_legacy_contract_fields,
+    )
+
+
+__all__ = ["diagnose_session_query"]

--- a/backend/app/schemas/a2a_agent_card.py
+++ b/backend/app/schemas/a2a_agent_card.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import AnyHttpUrl, BaseModel, Field
 
@@ -22,6 +22,29 @@ class A2AAgentCardProxyRequest(BaseModel):
     extra_headers: Dict[str, str] = Field(default_factory=dict)
 
 
+class SharedSessionQueryDiagnostic(BaseModel):
+    declared: bool = Field(
+        ..., description="Whether the card declares a shared session query extension"
+    )
+    status: Literal["canonical", "legacy", "unsupported", "invalid"] = Field(
+        ...,
+        description="Hub compatibility classification for the declared contract",
+    )
+    uri: Optional[str] = Field(default=None)
+    provider: Optional[str] = Field(default=None)
+    methods: List[str] = Field(default_factory=list)
+    pagination_mode: Optional[str] = Field(default=None)
+    pagination_params: List[str] = Field(default_factory=list)
+    result_envelope_declared: Optional[bool] = Field(default=None)
+    jsonrpc_interface_fallback_used: Optional[bool] = Field(default=None)
+    uses_legacy_uri: bool = Field(default=False)
+    uses_legacy_contract_fields: bool = Field(default=False)
+    error: Optional[str] = Field(
+        default=None,
+        description="Structured validation error when the contract is invalid",
+    )
+
+
 class A2AAgentCardValidationResponse(BaseModel):
     success: bool = Field(..., description="Whether the card validation succeeded")
     message: str = Field(..., description="Human-readable validation result")
@@ -34,6 +57,14 @@ class A2AAgentCardValidationResponse(BaseModel):
     validation_errors: Optional[List[str]] = Field(
         default=None, description="Detailed validation errors (only in debug mode)"
     )
+    shared_session_query: Optional[SharedSessionQueryDiagnostic] = Field(
+        default=None,
+        description="接入期 shared session query extension 兼容诊断结果",
+    )
 
 
-__all__ = ["A2AAgentCardProxyRequest", "A2AAgentCardValidationResponse"]
+__all__ = [
+    "A2AAgentCardProxyRequest",
+    "A2AAgentCardValidationResponse",
+    "SharedSessionQueryDiagnostic",
+]

--- a/backend/app/services/a2a_agent_card_validation.py
+++ b/backend/app/services/a2a_agent_card_validation.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from a2a.types import AgentCard
+
 import app.core.config
 from app.integrations.a2a_client.errors import (
     A2AAgentUnavailableError,
@@ -14,6 +16,9 @@ from app.integrations.a2a_client.errors import (
 )
 from app.integrations.a2a_client.validators import (
     validate_agent_card as validate_agent_card_payload,
+)
+from app.integrations.a2a_extensions.session_query_diagnostics import (
+    diagnose_session_query,
 )
 from app.schemas.a2a_agent_card import A2AAgentCardValidationResponse
 
@@ -49,10 +54,27 @@ async def fetch_and_validate_agent_card(
 
     card_payload = card.model_dump(exclude_none=True)
     validation_errors = validate_agent_card_payload(card_payload)
-    success = not validation_errors
-    message = (
-        "Agent card validated" if success else "Agent card validation issues detected"
+    diagnostics_card: AgentCard | None = None
+    try:
+        diagnostics_card = AgentCard.model_validate(card_payload)
+    except Exception:  # noqa: BLE001
+        diagnostics_card = None
+
+    session_query = (
+        diagnose_session_query(diagnostics_card)
+        if diagnostics_card is not None
+        else None
     )
+    if session_query and session_query.status == "invalid" and session_query.error:
+        validation_errors.append(session_query.error)
+
+    success = not validation_errors
+    if success:
+        message = "Agent card validated"
+    elif session_query and session_query.status == "invalid" and session_query.error:
+        message = f"Shared session query contract is invalid: {session_query.error}"
+    else:
+        message = "Agent card validation issues detected"
 
     response_kwargs: dict[str, Any] = {
         "success": success,
@@ -60,6 +82,7 @@ async def fetch_and_validate_agent_card(
         "card_name": card_payload.get("name"),
         "card_description": card_payload.get("description"),
         "card": card_payload,
+        "shared_session_query": session_query,
     }
     if app.core.config.settings.debug:
         response_kwargs["validation_errors"] = validation_errors

--- a/backend/tests/test_hub_a2a_extensions_and_validate_routes.py
+++ b/backend/tests/test_hub_a2a_extensions_and_validate_routes.py
@@ -50,12 +50,13 @@ class _FakeCard:
 class _FakeGateway:
     def __init__(self) -> None:
         self.card_calls: list[Dict[str, Any]] = []
+        self.card_payload = _valid_card_payload()
 
     async def fetch_agent_card_detail(self, *, resolved, raise_on_failure: bool):
         self.card_calls.append(
             {"resolved": resolved, "raise_on_failure": raise_on_failure}
         )
-        return _FakeCard(_valid_card_payload())
+        return _FakeCard(self.card_payload)
 
 
 class _FakeA2AService:
@@ -567,6 +568,61 @@ async def test_hub_card_validate_success_for_allowlisted_user(
     assert len(fake_gateway.card_calls) == 1
     resolved = fake_gateway.card_calls[0]["resolved"]
     assert resolved.headers["Authorization"].endswith("secret-token-validate")
+
+
+@pytest.mark.asyncio
+async def test_hub_card_validate_reports_shared_session_query_diagnostics(
+    async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "a2a_proxy_allowed_hosts", ["example.com"])
+
+    agent_id, user = await _create_allowlisted_hub_agent(
+        async_session_maker=async_session_maker,
+        async_db_session=async_db_session,
+        admin_email="admin_validate_diag@example.com",
+        user_email="alice_validate_diag@example.com",
+        token="secret-token-validate-diag",
+    )
+
+    fake_gateway = _FakeGateway()
+    fake_gateway.card_payload["capabilities"]["extensions"] = [
+        {
+            "uri": "urn:shared-a2a:session-query:v1",
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "shared.sessions.list",
+                    "get_session_messages": "shared.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "page_size",
+                    "default_size": 20,
+                    "max_size": 100,
+                },
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+    monkeypatch.setattr(
+        hub_router, "get_a2a_service", lambda: _FakeA2AService(fake_gateway)
+    )
+
+    async with create_test_client(
+        hub_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as user_client:
+        resp = await user_client.post(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/card:validate"
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert payload["shared_session_query"]["declared"] is True
+    assert payload["shared_session_query"]["status"] == "legacy"
+    assert payload["shared_session_query"]["uses_legacy_uri"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_session_query_diagnostics.py
+++ b/backend/tests/test_session_query_diagnostics.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from a2a.types import AgentCard
+
+from app.integrations.a2a_extensions.session_query_diagnostics import (
+    diagnose_session_query,
+)
+from app.integrations.a2a_extensions.shared_contract import (
+    LEGACY_SHARED_SESSION_QUERY_URI,
+    SHARED_SESSION_QUERY_URI,
+)
+
+
+def _base_card_payload() -> dict:
+    return {
+        "name": "example",
+        "description": "example",
+        "url": "https://example.com",
+        "version": "1.0",
+        "capabilities": {"extensions": []},
+        "defaultInputModes": [],
+        "defaultOutputModes": [],
+        "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+    }
+
+
+def test_diagnose_session_query_returns_canonical_status() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": SHARED_SESSION_QUERY_URI,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "shared.sessions.list",
+                    "get_session_messages": "shared.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "page_size",
+                    "default_size": 20,
+                    "max_size": 100,
+                },
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+
+    diagnostic = diagnose_session_query(AgentCard.model_validate(payload))
+
+    assert diagnostic.declared is True
+    assert diagnostic.status == "canonical"
+    assert diagnostic.uses_legacy_uri is False
+    assert diagnostic.uses_legacy_contract_fields is False
+    assert diagnostic.pagination_mode == "page_size"
+
+
+def test_diagnose_session_query_returns_legacy_status_for_legacy_uri() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": LEGACY_SHARED_SESSION_QUERY_URI,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "shared.sessions.list",
+                    "get_session_messages": "shared.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "page_size",
+                    "default_size": 20,
+                    "max_size": 100,
+                },
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+
+    diagnostic = diagnose_session_query(AgentCard.model_validate(payload))
+
+    assert diagnostic.declared is True
+    assert diagnostic.status == "legacy"
+    assert diagnostic.uses_legacy_uri is True
+
+
+def test_diagnose_session_query_returns_legacy_status_for_legacy_limit_fields() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": SHARED_SESSION_QUERY_URI,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "shared.sessions.list",
+                    "get_session_messages": "shared.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "limit",
+                    "default_size": 20,
+                    "max_size": 100,
+                },
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+
+    diagnostic = diagnose_session_query(AgentCard.model_validate(payload))
+
+    assert diagnostic.declared is True
+    assert diagnostic.status == "legacy"
+    assert diagnostic.uses_legacy_contract_fields is True
+    assert diagnostic.pagination_mode == "limit"
+
+
+def test_diagnose_session_query_returns_unsupported_when_not_declared() -> None:
+    diagnostic = diagnose_session_query(AgentCard.model_validate(_base_card_payload()))
+
+    assert diagnostic.declared is False
+    assert diagnostic.status == "unsupported"
+
+
+def test_diagnose_session_query_returns_invalid_for_bad_contract() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": SHARED_SESSION_QUERY_URI,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "shared.sessions.list",
+                    "get_session_messages": "shared.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "page_size",
+                    "default_size": 20,
+                },
+            },
+        }
+    ]
+
+    diagnostic = diagnose_session_query(AgentCard.model_validate(payload))
+
+    assert diagnostic.declared is True
+    assert diagnostic.status == "invalid"
+    assert diagnostic.error is not None
+    assert "pagination.max_size" in diagnostic.error

--- a/backend/tests/test_validation_errors_debug_mode.py
+++ b/backend/tests/test_validation_errors_debug_mode.py
@@ -35,6 +35,58 @@ async def test_fetch_and_validate_agent_card_validation_errors_gated(monkeypatch
     assert resp_debug.validation_errors == ["bad-card"]
 
 
+@pytest.mark.asyncio
+async def test_fetch_and_validate_agent_card_exposes_invalid_session_query_contract() -> (
+    None
+):
+    class _ExtensionCard:
+        def model_dump(self, **kwargs):
+            return {
+                "name": "dummy",
+                "description": "dummy",
+                "url": "https://example.com",
+                "version": "1.0",
+                "capabilities": {
+                    "extensions": [
+                        {
+                            "uri": "urn:opencode-a2a:session-query/v1",
+                            "params": {
+                                "provider": "opencode",
+                                "methods": {
+                                    "list_sessions": "shared.sessions.list",
+                                    "get_session_messages": (
+                                        "shared.sessions.messages.list"
+                                    ),
+                                },
+                                "pagination": {
+                                    "mode": "page_size",
+                                    "default_size": 20,
+                                },
+                            },
+                        }
+                    ]
+                },
+                "defaultInputModes": [],
+                "defaultOutputModes": [],
+                "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+            }
+
+    class _ExtensionGateway:
+        async def fetch_agent_card_detail(self, **kwargs):
+            from a2a.types import AgentCard
+
+            return AgentCard.model_validate(_ExtensionCard().model_dump())
+
+    resp = await fetch_and_validate_agent_card(
+        gateway=_ExtensionGateway(), resolved=object()
+    )
+
+    assert resp.success is False
+    assert resp.shared_session_query is not None
+    assert resp.shared_session_query.status == "invalid"
+    assert "Shared session query contract is invalid" in resp.message
+
+
 def test_serialize_stream_event_validation_errors_gated(monkeypatch):
     class _DummyEvent:
         def model_dump(self, **kwargs):


### PR DESCRIPTION
## 背景
`#467` 已明确：shared session query extension 的 contract drift 不应主要在运行时首次 query 时才暴露，而应尽量前移到 `card 校验 / agent 接入` 阶段。

当前主干已经具备 runtime strict parser，但 card validate 路径仍只做通用 Agent Card 校验，缺少 shared session query 的接入期诊断。

本 PR 聚焦将这部分 contract 识别前移到接入阶段，并保持与现有 runtime 解析器同构，避免再维护第二套规则。

## 改动说明
### 1. 接入期 diagnostics
- 新增 `backend/app/integrations/a2a_extensions/session_query_diagnostics.py`
- 复用现有 `resolve_session_query()` 作为 shared session query contract 的权威解析入口
- 在接入期输出结构化诊断结果，区分：
  - `canonical`
  - `legacy`
  - `unsupported`
  - `invalid`

### 2. card validate 响应扩展
- 扩展 `A2AAgentCardValidationResponse`，新增 `shared_session_query` 字段
- `card:validate` 现在会返回 shared session query 的结构化诊断，而不是只依赖模糊 message
- 当 extension 已声明但 contract 非法时，validate 会在接入阶段直接失败并给出明确错误信息

### 3. 测试覆盖
- 新增 shared session query diagnostics 单测
- 补充 card validate 服务层测试
- 补充 hub `card:validate` 路由测试，覆盖 legacy variant 的接入期识别

## 审查结论
### 1. 需求匹配
- 本 PR 已完整覆盖 `#468` 当前收敛后的目标：将 shared session query contract 的识别前移到接入期，并输出稳定的结构化 diagnostics。
- 实现保持了与现有 runtime strict parser 的同构，没有复制第二套 contract 规则，符合当前主干的最佳实践。

### 2. 结构合理性
- diagnostics 逻辑被收口在独立 helper 中，业务路由层没有被具体 contract 细节污染。
- `card:validate` 响应通过结构化字段暴露诊断结果，比仅返回 message 更适合作为后续接入治理的稳定接口。

### 3. 范围与后续
- 本 PR 完成的是 **接入期识别与报告**。
- “将 diagnostics 接入 runtime parser / adapter 选择链路”的更强后续目标，已拆分到 `#497`。
- third-party legacy variant 的 Hub 侧显式 adapter 继续由 `#469` 跟进。

### 4. Issue 关系判断
- `Closes #468`：准确。因为 `#468` 已明确收敛为接入期 diagnostics，本 PR 已完成该目标。
- `Related #467`：准确。`#468` 的实现边界受总领 issue 约束。
- `Related #469`：准确。当前 PR 为后续 Hub 侧 compatibility adapter 提供了接入期识别基础，但不应宣称已完成该 issue。
- `Related #497`：准确。该 issue 承接“diagnostics 进入 runtime 选择链路”的后续工作。
- `Follow-up to #18`：可以保留，语义上成立。

## 范围说明
- 本 PR 只实现 **接入期识别与报告**
- runtime parser / adapter 选择链路后续由 `#497` 跟进
- third-party legacy variant 的 Hub 侧显式 adapter 后续由 `#469` 跟进

## 验证
- `cd backend && uv run pre-commit run --files app/schemas/a2a_agent_card.py app/integrations/a2a_extensions/session_query_diagnostics.py app/services/a2a_agent_card_validation.py tests/test_session_query_diagnostics.py tests/test_validation_errors_debug_mode.py tests/test_hub_a2a_extensions_and_validate_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_session_query_diagnostics.py tests/test_validation_errors_debug_mode.py tests/test_hub_a2a_extensions_and_validate_routes.py`
- 结果：`39` 个测试通过

## 关联
- Closes #468
- Related #467
- Related #469
- Related #497
- Follow-up to #18
