### PR TITLE
fix(a2a): add messageId to pascal fallback payload (#503)

### DIFF
--- a/backend/app/integrations/a2a_client/selection.py
+++ b/backend/app/integrations/a2a_client/selection.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections.abc import Iterable
 from typing import Any
+from uuid import uuid4
 
 from a2a.types import AgentCard
 
@@ -67,6 +68,7 @@ def build_peer_descriptor(
 
 def build_pascal_message_payload(request: A2AMessageRequest) -> dict[str, Any]:
     payload: dict[str, Any] = {
+        "messageId": str(uuid4()),
         "role": "user",
         "parts": [{"type": "text", "text": request.query}],
     }

--- a/backend/tests/test_a2a_client.py
+++ b/backend/tests/test_a2a_client.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 from a2a.client.errors import A2AClientHTTPError
 from a2a.types import Message, Role, TextPart
@@ -1002,6 +1004,122 @@ async def test_call_agent_falls_back_to_pascal_jsonrpc_on_method_not_found() -> 
     a2a_client._discard_adapter.assert_awaited_once()
     assert a2a_client._discard_adapter.await_args.args == (client_module.SDK_DIALECT,)
     assert a2a_client._discard_adapter.await_args.kwargs["expected_adapter"] is not None
+
+
+@pytest.mark.asyncio
+async def test_call_agent_pascal_fallback_includes_message_id_for_http_json_preferred_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client_module.global_dialect_cache._entries.clear()
+    captured: dict[str, object] = {}
+
+    class FakeResolver:
+        base_url = "http://example-agent.internal:24020"
+        agent_card_path = ".well-known/agent-card.json"
+
+        def __init__(self, card_payload: SimpleNamespace) -> None:
+            self._card_payload = card_payload
+
+        async def get_agent_card(self, **_kwargs):
+            return self._card_payload
+
+    card = SimpleNamespace(
+        name="Hybrid peer",
+        preferred_transport="HTTP+JSON",
+        url="http://example-agent.internal:24020/v1",
+        additional_interfaces=[
+            SimpleNamespace(
+                transport="JSONRPC",
+                url="http://example-agent.internal:24020/jsonrpc",
+            )
+        ],
+        capabilities=SimpleNamespace(streaming=False),
+        protocol_version="1.0",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": captured["body"]["id"],
+                "result": {"parts": [{"text": "pascal-result"}]},
+            },
+        )
+
+    def fake_validate_outbound_http_url(
+        url: str,
+        *,
+        allowed_hosts,
+        purpose: str = "outbound HTTP request",
+    ) -> str:
+        _ = allowed_hosts, purpose
+        return url
+
+    class FakeSlashAdapter:
+        def __init__(self, *_args, **_kwargs) -> None:
+            return None
+
+        async def send_message(self, _request):
+            raise A2APeerProtocolError(
+                "Unknown method: message/send",
+                error_code="method_not_found",
+                rpc_code=-32601,
+            )
+
+        async def retire(self) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        client_module,
+        "validate_outbound_http_url",
+        fake_validate_outbound_http_url,
+    )
+    monkeypatch.setattr(
+        client_module.a2a_proxy_service,
+        "get_effective_allowed_hosts_sync",
+        lambda: ["example-agent.internal:24020"],
+    )
+    monkeypatch.setattr(client_module, "SDKA2AAdapter", FakeSlashAdapter)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        a2a_client = A2AClient(
+            "http://example-agent.internal:24020",
+            use_client_preference=True,
+        )
+        a2a_client._get_http_client = AsyncMock(return_value=http_client)
+        a2a_client._build_card_resolver = Mock(return_value=FakeResolver(card))
+
+        result = await a2a_client.call_agent(
+            "hello",
+            context_id="ctx-1",
+            metadata={"trace_id": "trace-1"},
+        )
+
+    assert result["success"] is True
+    assert result["content"] == "pascal-result"
+    assert a2a_client._peer_descriptor is not None
+    assert a2a_client._peer_descriptor.selected_transport == "JSONRPC"
+    assert a2a_client._peer_descriptor.selected_url == (
+        "http://example-agent.internal:24020/jsonrpc"
+    )
+    assert captured["method"] == "POST"
+    assert captured["url"] == "http://example-agent.internal:24020/jsonrpc"
+    assert captured["body"]["method"] == "SendMessage"
+    message = captured["body"]["params"]["message"]
+    assert isinstance(message["messageId"], str)
+    assert message["messageId"]
+    assert message["role"] == "user"
+    assert message["parts"] == [{"type": "text", "text": "hello"}]
+    assert message["contextId"] == "ctx-1"
+    assert message["metadata"] == {"trace_id": "trace-1"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

本 PR 聚焦修复 Hub 在 JSON-RPC Pascal fallback 路径上的消息负载缺口。

当前生产默认配置会优先按客户端顺序选择 `JSONRPC` binding；当上游 Agent card 同时暴露 `preferredTransport=HTTP+JSON` 与 `additionalInterfaces=JSONRPC` 时，Hub 仍可能先走 JSON-RPC。若 slash 风格 `message/send` 不兼容，Hub 会 fallback 到 Pascal JSON-RPC (`SendMessage`)。

此前该 fallback 负载缺少 `params.message.messageId`，会导致要求严格 JSON-RPC 消息模型的上游返回 `-32602 Invalid parameters`。

## 改动

### A2A Client
- 在 [`backend/app/integrations/a2a_client/selection.py`](backend/app/integrations/a2a_client/selection.py) 的 Pascal JSON-RPC 消息构造里补齐 `messageId`
- 保持现有 `role=user`、`parts`、`contextId`、`metadata` 语义不变

### 测试
- 在 [`backend/tests/test_a2a_client.py`](backend/tests/test_a2a_client.py) 新增回归测试，覆盖：
  - `preferredTransport=HTTP+JSON`
  - `additionalInterfaces=JSONRPC`
  - `use_client_preference=true`
  - Hub 选到 JSON-RPC 后先失败于 slash 风格，再 fallback 到 Pascal `SendMessage`
  - fallback 请求负载包含合法 `messageId`

## 验证

已执行 backend scoped 低负载校验：

```bash
cd backend && uv run pre-commit run --files app/integrations/a2a_client/selection.py tests/test_a2a_client.py --config ../.pre-commit-config.yaml
cd backend && uv run pytest tests/test_a2a_client.py
```

结果：`38 passed`

## Issues

Closes #503
