### PR TITLE
fix(a2a): own jsonrpc slash-to-pascal streaming fallback (#505)

### DIFF
--- a/backend/app/integrations/a2a_client/adapters/__init__.py
+++ b/backend/app/integrations/a2a_client/adapters/__init__.py
@@ -5,6 +5,10 @@ from app.integrations.a2a_client.adapters.jsonrpc_pascal import (
     JSONRPC_PASCAL_DIALECT,
     JsonRpcPascalAdapter,
 )
+from app.integrations.a2a_client.adapters.jsonrpc_slash import (
+    JSONRPC_SLASH_DIALECT,
+    JsonRpcSlashAdapter,
+)
 from app.integrations.a2a_client.adapters.sdk import (
     SDK_DIALECT,
     SDKA2AAdapter,
@@ -13,7 +17,9 @@ from app.integrations.a2a_client.adapters.sdk import (
 __all__ = [
     "A2AAdapter",
     "JSONRPC_PASCAL_DIALECT",
+    "JSONRPC_SLASH_DIALECT",
     "JsonRpcPascalAdapter",
+    "JsonRpcSlashAdapter",
     "SDKA2AAdapter",
     "SDK_DIALECT",
 ]

--- a/backend/app/integrations/a2a_client/adapters/jsonrpc_common.py
+++ b/backend/app/integrations/a2a_client/adapters/jsonrpc_common.py
@@ -1,0 +1,102 @@
+"""Shared helpers for Hub-owned JSON-RPC adapters."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from uuid import uuid4
+
+from a2a.client import ClientCallInterceptor
+
+from app.integrations.a2a_client.errors import A2APeerProtocolError
+
+JSONRPC_METHOD_NOT_FOUND_CODE = -32601
+
+
+def build_jsonrpc_payload(*, method: str, params: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": str(uuid4()),
+        "method": method,
+        "params": params,
+    }
+
+
+async def apply_jsonrpc_interceptors(
+    *,
+    interceptors: list[ClientCallInterceptor],
+    method_name: str,
+    request_payload: dict[str, Any],
+    http_kwargs: dict[str, Any] | None,
+    agent_card: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    final_payload = request_payload
+    final_http_kwargs = dict(http_kwargs or {})
+    for interceptor in interceptors:
+        final_payload, final_http_kwargs = await interceptor.intercept(
+            method_name,
+            final_payload,
+            final_http_kwargs,
+            agent_card,
+            None,
+        )
+    return final_payload, final_http_kwargs
+
+
+def normalize_jsonrpc_error_code(*, code: Any, message: str) -> str:
+    if code == JSONRPC_METHOD_NOT_FOUND_CODE:
+        return "method_not_found"
+    candidate = str(message).strip().replace("-", "_").replace(" ", "_").lower()
+    return candidate or "peer_protocol_error"
+
+
+def build_protocol_error_from_jsonrpc_error(
+    error: dict[str, Any],
+    *,
+    fallback_message: str,
+    http_status: int | None,
+) -> A2APeerProtocolError:
+    code = error.get("code")
+    message = error.get("message") or fallback_message
+    return A2APeerProtocolError(
+        message=str(message),
+        error_code=normalize_jsonrpc_error_code(code=code, message=str(message)),
+        rpc_code=code if isinstance(code, int) else None,
+        data=error.get("data"),
+        http_status=http_status,
+    )
+
+
+def parse_jsonrpc_error_payload(
+    payload: Any,
+    *,
+    fallback_message: str,
+    http_status: int | None,
+) -> A2APeerProtocolError | None:
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    return build_protocol_error_from_jsonrpc_error(
+        error,
+        fallback_message=fallback_message,
+        http_status=http_status,
+    )
+
+
+def parse_jsonrpc_error_bytes(
+    raw_body: bytes,
+    *,
+    fallback_message: str,
+    http_status: int | None,
+) -> A2APeerProtocolError | None:
+    try:
+        payload = json.loads(raw_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return parse_jsonrpc_error_payload(
+        payload,
+        fallback_message=fallback_message,
+        http_status=http_status,
+    )

--- a/backend/app/integrations/a2a_client/adapters/jsonrpc_pascal.py
+++ b/backend/app/integrations/a2a_client/adapters/jsonrpc_pascal.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import json
 from collections.abc import AsyncIterator
 from typing import Any
-from uuid import uuid4
 
 import httpx
+from a2a.client import ClientCallInterceptor
 from httpx_sse import aconnect_sse
 
 from app.integrations.a2a_client.adapters.base import A2AAdapter
+from app.integrations.a2a_client.adapters.jsonrpc_common import (
+    apply_jsonrpc_interceptors,
+    build_jsonrpc_payload,
+    parse_jsonrpc_error_bytes,
+    parse_jsonrpc_error_payload,
+)
 from app.integrations.a2a_client.errors import (
     A2APeerProtocolError,
     A2AUnsupportedOperationError,
@@ -45,11 +51,13 @@ class JsonRpcPascalAdapter(A2AAdapter):
         http_client: httpx.AsyncClient,
         headers: dict[str, str] | None = None,
         timeout: httpx.Timeout | None = None,
+        interceptors: list[ClientCallInterceptor] | None = None,
     ) -> None:
         super().__init__(descriptor)
         self._http_client = http_client
         self._headers = dict(headers or {})
         self._timeout = timeout
+        self._interceptors = list(interceptors or [])
 
     @property
     def dialect(self) -> str:
@@ -96,20 +104,21 @@ class JsonRpcPascalAdapter(A2AAdapter):
         return None
 
     async def _send_rpc(self, method: str, *, params: dict[str, Any]) -> Any:
-        payload = {
-            "jsonrpc": "2.0",
-            "id": str(uuid4()),
-            "method": method,
-            "params": params,
-        }
+        payload = build_jsonrpc_payload(method=method, params=params)
         request_headers = {"Content-Type": "application/json"}
         request_headers.update(self._headers)
+        payload, http_kwargs = await apply_jsonrpc_interceptors(
+            interceptors=self._interceptors,
+            method_name=method,
+            request_payload=payload,
+            http_kwargs={"headers": request_headers, "timeout": self._timeout},
+            agent_card=self.descriptor.card,
+        )
         try:
             response = await self._http_client.post(
                 self.descriptor.selected_url,
                 json=payload,
-                headers=request_headers,
-                timeout=self._timeout,
+                **http_kwargs,
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -133,19 +142,13 @@ class JsonRpcPascalAdapter(A2AAdapter):
                 http_status=response.status_code,
             ) from exc
 
-        if isinstance(data, dict) and isinstance(data.get("error"), dict):
-            error = data["error"]
-            code = error.get("code")
-            message = error.get("message") or f"JSON-RPC Error {error}"
-            raise A2APeerProtocolError(
-                message=message,
-                error_code=(
-                    "method_not_found" if code == -32601 else "peer_protocol_error"
-                ),
-                rpc_code=code if isinstance(code, int) else None,
-                data=error.get("data"),
-                http_status=response.status_code,
-            )
+        protocol_error = parse_jsonrpc_error_payload(
+            data,
+            fallback_message="Invalid JSON-RPC response",
+            http_status=response.status_code,
+        )
+        if protocol_error is not None:
+            raise protocol_error
 
         if isinstance(data, dict):
             return data.get("result")
@@ -157,22 +160,23 @@ class JsonRpcPascalAdapter(A2AAdapter):
         *,
         params: dict[str, Any],
     ) -> AsyncIterator[dict[str, Any]]:
-        payload = {
-            "jsonrpc": "2.0",
-            "id": str(uuid4()),
-            "method": method,
-            "params": params,
-        }
+        payload = build_jsonrpc_payload(method=method, params=params)
         request_headers = {"Content-Type": "application/json"}
         request_headers.update(self._headers)
+        payload, http_kwargs = await apply_jsonrpc_interceptors(
+            interceptors=self._interceptors,
+            method_name=method,
+            request_payload=payload,
+            http_kwargs={"headers": request_headers, "timeout": self._timeout},
+            agent_card=self.descriptor.card,
+        )
         try:
             async with aconnect_sse(
                 self._http_client,
                 "POST",
                 self.descriptor.selected_url,
                 json=payload,
-                headers=request_headers,
-                timeout=self._timeout,
+                **http_kwargs,
             ) as event_source:
                 response = event_source.response
                 try:
@@ -221,23 +225,9 @@ class JsonRpcPascalAdapter(A2AAdapter):
         except httpx.RequestError:
             return None
 
-        try:
-            data = json.loads(raw_body.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            return None
-
-        if not isinstance(data, dict) or not isinstance(data.get("error"), dict):
-            return None
-        error = data["error"]
-        code = error.get("code")
-        message = error.get("message") or f"JSON-RPC Error {error}"
-        return A2APeerProtocolError(
-            message=str(message),
-            error_code=(
-                "method_not_found" if code == -32601 else "peer_protocol_error"
-            ),
-            rpc_code=code if isinstance(code, int) else None,
-            data=error.get("data"),
+        return parse_jsonrpc_error_bytes(
+            raw_body,
+            fallback_message="Invalid JSON-RPC stream response",
             http_status=response.status_code,
         )
 

--- a/backend/app/integrations/a2a_client/adapters/jsonrpc_slash.py
+++ b/backend/app/integrations/a2a_client/adapters/jsonrpc_slash.py
@@ -1,0 +1,278 @@
+"""Adapter for slash-style JSON-RPC A2A peers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from uuid import uuid4
+
+import httpx
+from a2a.client import ClientCallInterceptor
+from a2a.types import (
+    CancelTaskRequest,
+    CancelTaskResponse,
+    MessageSendConfiguration,
+    MessageSendParams,
+    SendMessageRequest,
+    SendMessageResponse,
+    SendStreamingMessageRequest,
+    SendStreamingMessageResponse,
+    TaskIdParams,
+)
+from httpx_sse import aconnect_sse
+from pydantic import ValidationError
+
+from app.integrations.a2a_client.adapters.base import A2AAdapter
+from app.integrations.a2a_client.adapters.jsonrpc_common import (
+    apply_jsonrpc_interceptors,
+    parse_jsonrpc_error_bytes,
+    parse_jsonrpc_error_payload,
+)
+from app.integrations.a2a_client.errors import (
+    A2APeerProtocolError,
+    A2AUnsupportedOperationError,
+)
+from app.integrations.a2a_client.models import A2AMessageRequest, A2APeerDescriptor
+from app.integrations.a2a_client.selection import build_a2a_message
+
+JSONRPC_SLASH_DIALECT = "jsonrpc_slash"
+
+_METHOD_SEND_MESSAGE = "message/send"
+_METHOD_SEND_STREAMING_MESSAGE = "message/stream"
+_METHOD_CANCEL_TASK = "tasks/cancel"
+
+
+class JsonRpcSlashAdapter(A2AAdapter):
+    """Hub-owned slash-style JSON-RPC adapter that preserves single-shot semantics."""
+
+    def __init__(
+        self,
+        descriptor: A2APeerDescriptor,
+        *,
+        http_client: httpx.AsyncClient,
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        interceptors: list[ClientCallInterceptor] | None = None,
+    ) -> None:
+        super().__init__(descriptor)
+        self._http_client = http_client
+        self._headers = dict(headers or {})
+        self._timeout = timeout
+        self._interceptors = list(interceptors or [])
+
+    @property
+    def dialect(self) -> str:
+        return JSONRPC_SLASH_DIALECT
+
+    async def send_message(self, request: A2AMessageRequest) -> Any:
+        params = MessageSendParams(
+            message=build_a2a_message(request),
+            configuration=MessageSendConfiguration(
+                accepted_output_modes=["text/plain"],
+                blocking=True,
+            ),
+        )
+        rpc_request = SendMessageRequest(params=params, id=str(uuid4()))
+        return await self._send_rpc(
+            method=_METHOD_SEND_MESSAGE,
+            payload=rpc_request.model_dump(mode="json", exclude_none=True),
+            response_model=SendMessageResponse,
+        )
+
+    async def stream_message(self, request: A2AMessageRequest) -> AsyncIterator[Any]:
+        if not self.descriptor.supports_streaming:
+            yield await self.send_message(request)
+            return
+        params = MessageSendParams(
+            message=build_a2a_message(request),
+            configuration=MessageSendConfiguration(
+                accepted_output_modes=["text/plain"],
+                blocking=True,
+            ),
+        )
+        rpc_request = SendStreamingMessageRequest(
+            params=params,
+            id=str(uuid4()),
+        )
+        async for payload in self._send_rpc_stream(
+            method=_METHOD_SEND_STREAMING_MESSAGE,
+            payload=rpc_request.model_dump(mode="json", exclude_none=True),
+        ):
+            yield payload
+
+    async def cancel_task(
+        self,
+        task_id: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        params = TaskIdParams(id=task_id, metadata=metadata)
+        rpc_request = CancelTaskRequest(
+            params=params,
+            id=str(uuid4()),
+        )
+        try:
+            return await self._send_rpc(
+                method=_METHOD_CANCEL_TASK,
+                payload=rpc_request.model_dump(mode="json", exclude_none=True),
+                response_model=CancelTaskResponse,
+            )
+        except A2APeerProtocolError as exc:
+            if exc.rpc_code == -32601:
+                raise A2AUnsupportedOperationError(str(exc)) from exc
+            raise
+
+    async def close(self) -> None:
+        return None
+
+    async def _send_rpc(
+        self, *, method: str, payload: dict[str, Any], response_model
+    ) -> Any:
+        request_headers = {"Content-Type": "application/json"}
+        request_headers.update(self._headers)
+        final_payload, http_kwargs = await apply_jsonrpc_interceptors(
+            interceptors=self._interceptors,
+            method_name=method,
+            request_payload=payload,
+            http_kwargs={"headers": request_headers, "timeout": self._timeout},
+            agent_card=self.descriptor.card,
+        )
+        try:
+            response = await self._http_client.post(
+                self.descriptor.selected_url,
+                json=final_payload,
+                **http_kwargs,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise A2APeerProtocolError(
+                message=str(exc),
+                error_code=f"http_{exc.response.status_code}",
+                http_status=exc.response.status_code,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise A2APeerProtocolError(
+                message=str(exc),
+                error_code="peer_request_error",
+            ) from exc
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:
+            raise A2APeerProtocolError(
+                message=str(exc),
+                error_code="invalid_json_response",
+                http_status=response.status_code,
+            ) from exc
+
+        protocol_error = parse_jsonrpc_error_payload(
+            data,
+            fallback_message="Invalid JSON-RPC response",
+            http_status=response.status_code,
+        )
+        if protocol_error is not None:
+            raise protocol_error
+
+        try:
+            parsed = response_model.model_validate(data)
+        except ValidationError as exc:
+            raise A2APeerProtocolError(
+                message=str(exc),
+                error_code="invalid_json_response",
+                http_status=response.status_code,
+            ) from exc
+        return parsed.root.result
+
+    async def _send_rpc_stream(
+        self,
+        *,
+        method: str,
+        payload: dict[str, Any],
+    ) -> AsyncIterator[Any]:
+        request_headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "Cache-Control": "no-store",
+        }
+        request_headers.update(self._headers)
+        final_payload, http_kwargs = await apply_jsonrpc_interceptors(
+            interceptors=self._interceptors,
+            method_name=method,
+            request_payload=payload,
+            http_kwargs={"headers": request_headers, "timeout": self._timeout},
+            agent_card=self.descriptor.card,
+        )
+        try:
+            async with aconnect_sse(
+                self._http_client,
+                "POST",
+                self.descriptor.selected_url,
+                json=final_payload,
+                **http_kwargs,
+            ) as event_source:
+                response = event_source.response
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raise A2APeerProtocolError(
+                        message=str(exc),
+                        error_code=f"http_{exc.response.status_code}",
+                        http_status=exc.response.status_code,
+                    ) from exc
+
+                content_type = response.headers.get("content-type", "").partition(";")[
+                    0
+                ]
+                if "text/event-stream" not in content_type:
+                    raw_body = await response.aread()
+                    protocol_error = parse_jsonrpc_error_bytes(
+                        raw_body,
+                        fallback_message=(
+                            "Expected response header Content-Type to contain "
+                            f"'text/event-stream', got {content_type!r}"
+                        ),
+                        http_status=response.status_code,
+                    )
+                    if protocol_error is not None:
+                        raise protocol_error
+                    raise A2APeerProtocolError(
+                        message=(
+                            "Expected response header Content-Type to contain "
+                            f"'text/event-stream', got {content_type!r}"
+                        ),
+                        error_code="invalid_stream_response",
+                        http_status=response.status_code,
+                    )
+
+                async for sse in event_source.aiter_sse():
+                    try:
+                        data = json.loads(sse.data)
+                    except json.JSONDecodeError as exc:
+                        raise A2APeerProtocolError(
+                            message=str(exc),
+                            error_code="invalid_json_response",
+                        ) from exc
+
+                    protocol_error = parse_jsonrpc_error_payload(
+                        data,
+                        fallback_message="Invalid JSON-RPC stream event",
+                        http_status=response.status_code,
+                    )
+                    if protocol_error is not None:
+                        raise protocol_error
+
+                    try:
+                        parsed = SendStreamingMessageResponse.model_validate(data)
+                    except ValidationError as exc:
+                        raise A2APeerProtocolError(
+                            message=str(exc),
+                            error_code="invalid_json_response",
+                            http_status=response.status_code,
+                        ) from exc
+                    yield parsed.root.result
+        except httpx.RequestError as exc:
+            raise A2APeerProtocolError(
+                message=str(exc),
+                error_code="peer_request_error",
+            ) from exc

--- a/backend/app/integrations/a2a_client/adapters/sdk.py
+++ b/backend/app/integrations/a2a_client/adapters/sdk.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any
-from uuid import uuid4
 
 import httpx
 from a2a.client import (
@@ -18,18 +16,8 @@ from a2a.client import (
     ClientFactory,
     Consumer,
 )
-from a2a.client.errors import A2AClientHTTPError, A2AClientJSONRPCError
-from a2a.types import (
-    Message,
-    MessageSendConfiguration,
-    MessageSendParams,
-    Part,
-    Role,
-    SendStreamingMessageRequest,
-    TaskIdParams,
-    TextPart,
-    TransportProtocol,
-)
+from a2a.client.errors import A2AClientJSONRPCError
+from a2a.types import TaskIdParams, TransportProtocol
 
 from app.integrations.a2a_client.adapters.base import A2AAdapter
 from app.integrations.a2a_client.errors import A2APeerProtocolError
@@ -41,6 +29,7 @@ from app.integrations.a2a_client.http_clients import (
 )
 from app.integrations.a2a_client.lifecycle import AdapterLifecycleSnapshot
 from app.integrations.a2a_client.models import A2AMessageRequest, A2APeerDescriptor
+from app.integrations.a2a_client.selection import build_a2a_message
 from app.utils.async_cleanup import await_cancel_safe
 
 SDK_DIALECT = "sdk"
@@ -126,7 +115,7 @@ class SDKA2AAdapter(A2AAdapter):
             client = await self._get_client(streaming=False)
             try:
                 final_payload: Any = None
-                async for payload in client.send_message(self._build_message(request)):
+                async for payload in client.send_message(build_a2a_message(request)):
                     final_payload = payload
                 return final_payload
             except A2AClientJSONRPCError as exc:
@@ -136,18 +125,10 @@ class SDKA2AAdapter(A2AAdapter):
         async with self._operation_usage(), self._transport_usage():
             client = await self._get_client(streaming=True)
             try:
-                async for payload in client.send_message(self._build_message(request)):
+                async for payload in client.send_message(build_a2a_message(request)):
                     yield payload
             except A2AClientJSONRPCError as exc:
                 raise _map_protocol_error(exc) from exc
-            except A2AClientHTTPError as exc:
-                protocol_error = await self._probe_streaming_protocol_error(
-                    request=request,
-                    exc=exc,
-                )
-                if protocol_error is not None:
-                    raise protocol_error from exc
-                raise
 
     async def cancel_task(
         self,
@@ -241,75 +222,6 @@ class SDKA2AAdapter(A2AAdapter):
             self._clients[streaming] = _SDKClientEntry(config=config, client=client)
             return client
 
-    async def _apply_interceptors(
-        self,
-        method_name: str,
-        request_payload: dict[str, Any],
-        http_kwargs: dict[str, Any] | None = None,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        final_payload = request_payload
-        final_http_kwargs = dict(http_kwargs or {})
-        for interceptor in self._interceptors:
-            final_payload, final_http_kwargs = await interceptor.intercept(
-                method_name,
-                final_payload,
-                final_http_kwargs,
-                self.descriptor.card,
-                None,
-            )
-        return final_payload, final_http_kwargs
-
-    async def _probe_streaming_protocol_error(
-        self,
-        *,
-        request: A2AMessageRequest,
-        exc: A2AClientHTTPError,
-    ) -> A2APeerProtocolError | None:
-        if self.descriptor.selected_transport.upper() != "JSONRPC":
-            return None
-
-        message = getattr(exc, "message", str(exc)).lower()
-        if "text/event-stream" not in message and "invalid sse response" not in message:
-            return None
-
-        params = MessageSendParams(
-            message=self._build_message(request),
-            configuration=MessageSendConfiguration(
-                accepted_output_modes=["text/plain"],
-                blocking=True,
-            ),
-        )
-        rpc_request = SendStreamingMessageRequest(
-            params=params,
-            id=str(uuid4()),
-        )
-        payload, http_kwargs = await self._apply_interceptors(
-            "message/stream",
-            rpc_request.model_dump(mode="json", exclude_none=True),
-            {
-                "headers": {
-                    "Content-Type": "application/json",
-                    "Accept": "text/event-stream",
-                    "Cache-Control": "no-store",
-                },
-                "timeout": self._transport_http_client.timeout.as_dict().get(
-                    "read", None
-                ),
-            },
-        )
-        try:
-            response = await self._transport_http_client.post(
-                self.descriptor.selected_url,
-                json=payload,
-                **http_kwargs,
-            )
-        except httpx.RequestError:
-            return None
-        return _parse_jsonrpc_error_response(
-            response=response,
-            invalid_stream_error_message=getattr(exc, "message", str(exc)),
-        )
-
     def _transport_usage(self):
         return use_shared_sdk_transport_http_client(self._shared_transport_lease)
 
@@ -338,20 +250,6 @@ class SDKA2AAdapter(A2AAdapter):
         if should_finalize:
             await self._finalize_clients()
 
-    def _build_message(self, request: A2AMessageRequest) -> Message:
-        raw_role = (
-            getattr(Role, "USER", None) or getattr(Role, "user", None) or Role("user")
-        )
-        resolved_context_id = request.context_id or str(uuid4())
-        parts: list[Part] = [TextPart(text=request.query)]
-        return Message(
-            message_id=str(uuid4()),
-            role=raw_role,
-            parts=parts,
-            context_id=resolved_context_id,
-            metadata=request.metadata or None,
-        )
-
 
 def _map_protocol_error(exc: A2AClientJSONRPCError) -> A2APeerProtocolError:
     error = getattr(exc, "error", None)
@@ -371,30 +269,3 @@ def _normalize_protocol_error_code(*, code: Any, message: str) -> str:
         return "method_not_found"
     candidate = str(message).strip().replace("-", "_").replace(" ", "_").lower()
     return candidate or "peer_protocol_error"
-
-
-def _parse_jsonrpc_error_response(
-    *,
-    response: httpx.Response,
-    invalid_stream_error_message: str,
-) -> A2APeerProtocolError | None:
-    try:
-        data = response.json()
-    except json.JSONDecodeError:
-        return None
-
-    if not isinstance(data, dict):
-        return None
-    error = data.get("error")
-    if not isinstance(error, dict):
-        return None
-
-    code = error.get("code")
-    message = error.get("message") or invalid_stream_error_message
-    return A2APeerProtocolError(
-        message=str(message),
-        error_code=("method_not_found" if code == -32601 else "peer_protocol_error"),
-        rpc_code=code if isinstance(code, int) else None,
-        data=error.get("data"),
-        http_status=response.status_code,
-    )

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -29,8 +29,10 @@ from app.core.http_client import get_global_http_client
 from app.core.logging import get_logger
 from app.integrations.a2a_client.adapters import (
     JSONRPC_PASCAL_DIALECT,
+    JSONRPC_SLASH_DIALECT,
     SDK_DIALECT,
     JsonRpcPascalAdapter,
+    JsonRpcSlashAdapter,
     SDKA2AAdapter,
 )
 from app.integrations.a2a_client.adapters.sdk import SDKA2AAdapterRetiredError
@@ -783,12 +785,19 @@ class A2AClient:
                     use_client_preference=self._use_client_preference,
                     supported_transports=list(self._supported_transports),
                 )
+            elif dialect == JSONRPC_SLASH_DIALECT:
+                adapter = JsonRpcSlashAdapter(
+                    descriptor,
+                    http_client=httpx_client,
+                    timeout=self._timeout,
+                    interceptors=list(self._interceptors),
+                )
             elif dialect == JSONRPC_PASCAL_DIALECT:
                 adapter = JsonRpcPascalAdapter(
                     descriptor,
                     http_client=httpx_client,
-                    headers=self._default_headers,
                     timeout=self._timeout,
+                    interceptors=list(self._interceptors),
                 )
             else:
                 raise A2AUnsupportedBindingError(
@@ -856,13 +865,14 @@ class A2AClient:
     async def _get_preferred_dialects(self, descriptor) -> list[str]:
         if normalize_transport_label(descriptor.selected_transport) != "JSONRPC":
             return [SDK_DIALECT]
+        choices = [JSONRPC_SLASH_DIALECT, JSONRPC_PASCAL_DIALECT]
         cached = global_dialect_cache.get(
             agent_url=descriptor.agent_url,
             card_fingerprint=descriptor.card_fingerprint,
         )
-        if cached:
-            return [cached]
-        return [SDK_DIALECT, JSONRPC_PASCAL_DIALECT]
+        if cached in choices:
+            return [cached, *[dialect for dialect in choices if dialect != cached]]
+        return choices
 
     @staticmethod
     def _should_try_alternate_dialect(
@@ -873,7 +883,7 @@ class A2AClient:
     ) -> bool:
         if normalize_transport_label(descriptor.selected_transport) != "JSONRPC":
             return False
-        if dialect != SDK_DIALECT:
+        if dialect != JSONRPC_SLASH_DIALECT:
             return False
         if isinstance(exc, A2APeerProtocolError):
             return exc.error_code == "method_not_found" or exc.code == -32601

--- a/backend/app/integrations/a2a_client/selection.py
+++ b/backend/app/integrations/a2a_client/selection.py
@@ -8,7 +8,7 @@ from collections.abc import Iterable
 from typing import Any
 from uuid import uuid4
 
-from a2a.types import AgentCard
+from a2a.types import AgentCard, Message, Part, Role, TextPart
 
 from app.integrations.a2a_client.models import (
     A2AInterfaceDescriptor,
@@ -79,6 +79,21 @@ def build_pascal_message_payload(request: A2AMessageRequest) -> dict[str, Any]:
     return payload
 
 
+def build_a2a_message(request: A2AMessageRequest) -> Message:
+    raw_role = (
+        getattr(Role, "USER", None) or getattr(Role, "user", None) or Role("user")
+    )
+    resolved_context_id = request.context_id or str(uuid4())
+    parts: list[Part] = [TextPart(text=request.query)]
+    return Message(
+        message_id=str(uuid4()),
+        role=raw_role,
+        parts=parts,
+        context_id=resolved_context_id,
+        metadata=request.metadata or None,
+    )
+
+
 def _collect_interfaces(card: AgentCard) -> Iterable[A2AInterfaceDescriptor]:
     protocol_version = getattr(card, "protocol_version", None)
     preferred_transport = normalize_transport_label(
@@ -109,6 +124,7 @@ def _collect_interfaces(card: AgentCard) -> Iterable[A2AInterfaceDescriptor]:
 __all__ = [
     "A2AMessageRequest",
     "A2APeerDescriptor",
+    "build_a2a_message",
     "build_pascal_message_payload",
     "build_peer_descriptor",
     "normalize_transport_label",

--- a/backend/tests/test_a2a_client.py
+++ b/backend/tests/test_a2a_client.py
@@ -1002,7 +1002,9 @@ async def test_call_agent_falls_back_to_pascal_jsonrpc_on_method_not_found() -> 
     assert result["success"] is True
     assert result["content"] == "pascal-result"
     a2a_client._discard_adapter.assert_awaited_once()
-    assert a2a_client._discard_adapter.await_args.args == (client_module.SDK_DIALECT,)
+    assert a2a_client._discard_adapter.await_args.args == (
+        client_module.JSONRPC_SLASH_DIALECT,
+    )
     assert a2a_client._discard_adapter.await_args.kwargs["expected_adapter"] is not None
 
 
@@ -1086,7 +1088,7 @@ async def test_call_agent_pascal_fallback_includes_message_id_for_http_json_pref
         "get_effective_allowed_hosts_sync",
         lambda: ["example-agent.internal:24020"],
     )
-    monkeypatch.setattr(client_module, "SDKA2AAdapter", FakeSlashAdapter)
+    monkeypatch.setattr(client_module, "JsonRpcSlashAdapter", FakeSlashAdapter)
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as http_client:
@@ -1123,23 +1125,30 @@ async def test_call_agent_pascal_fallback_includes_message_id_for_http_json_pref
 
 
 @pytest.mark.asyncio
-async def test_sdk_stream_message_probes_application_json_method_not_found() -> None:
-    captured: dict[str, object] = {}
+async def test_jsonrpc_slash_stream_message_maps_application_json_method_not_found_without_replaying() -> (
+    None
+):
+    captured_requests: list[dict[str, object]] = []
     descriptor = SimpleNamespace(
         selected_transport="JSONRPC",
         selected_url="http://example-agent.internal:24020/jsonrpc",
+        supports_streaming=True,
         card=Mock(),
     )
 
     def handler(request: httpx.Request) -> httpx.Response:
-        captured["method"] = request.method
-        captured["url"] = str(request.url)
-        captured["body"] = json.loads(request.content.decode("utf-8"))
+        captured_requests.append(
+            {
+                "method": request.method,
+                "url": str(request.url),
+                "body": json.loads(request.content.decode("utf-8")),
+            }
+        )
         return httpx.Response(
             200,
             json={
                 "jsonrpc": "2.0",
-                "id": captured["body"]["id"],
+                "id": captured_requests[-1]["body"]["id"],
                 "error": {
                     "code": -32601,
                     "message": "Unknown method: message/stream",
@@ -1147,22 +1156,12 @@ async def test_sdk_stream_message_probes_application_json_method_not_found() -> 
             },
         )
 
-    class FakeStreamingClient:
-        async def send_message(self, _message):
-            raise A2AClientHTTPError(
-                400,
-                "Invalid SSE response or protocol error: Expected response header "
-                "Content-Type to contain 'text/event-stream', got 'application/json'",
-            )
-            yield  # pragma: no cover
-
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as http_client:
-        adapter = SDKA2AAdapter(
+        adapter = client_module.JsonRpcSlashAdapter(
             descriptor,
-            transport_http_client=http_client,
+            http_client=http_client,
         )
-        adapter._get_client = AsyncMock(return_value=FakeStreamingClient())
 
         with pytest.raises(
             A2APeerProtocolError,
@@ -1178,9 +1177,10 @@ async def test_sdk_stream_message_probes_application_json_method_not_found() -> 
 
     assert exc_info.value.error_code == "method_not_found"
     assert exc_info.value.code == -32601
-    assert captured["method"] == "POST"
-    assert captured["url"] == "http://example-agent.internal:24020/jsonrpc"
-    assert captured["body"]["method"] == "message/stream"
+    assert len(captured_requests) == 1
+    assert captured_requests[0]["method"] == "POST"
+    assert captured_requests[0]["url"] == "http://example-agent.internal:24020/jsonrpc"
+    assert captured_requests[0]["body"]["method"] == "message/stream"
 
 
 @pytest.mark.asyncio
@@ -1188,7 +1188,7 @@ async def test_stream_agent_falls_back_to_pascal_jsonrpc_streaming_for_http_json
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client_module.global_dialect_cache._entries.clear()
-    captured: dict[str, object] = {}
+    captured_requests: list[dict[str, object]] = []
 
     class FakeResolver:
         base_url = "http://example-agent.internal:24020"
@@ -1215,9 +1215,26 @@ async def test_stream_agent_falls_back_to_pascal_jsonrpc_streaming_for_http_json
     )
 
     def handler(request: httpx.Request) -> httpx.Response:
-        captured["method"] = request.method
-        captured["url"] = str(request.url)
-        captured["body"] = json.loads(request.content.decode("utf-8"))
+        body = json.loads(request.content.decode("utf-8"))
+        captured_requests.append(
+            {
+                "method": request.method,
+                "url": str(request.url),
+                "body": body,
+            }
+        )
+        if body["method"] == "message/stream":
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "error": {
+                        "code": -32601,
+                        "message": "Unknown method: message/stream",
+                    },
+                },
+            )
         stream_body = (
             "event: TaskArtifactUpdateEvent\n"
             'data: {"taskId":"task-1","contextId":"ctx-1","artifact":{"parts":[{"type":"text","text":"hello"}]}}\n\n'
@@ -1239,24 +1256,6 @@ async def test_stream_agent_falls_back_to_pascal_jsonrpc_streaming_for_http_json
         _ = allowed_hosts, purpose
         return url
 
-    class FakeSlashAdapter:
-        def __init__(self, *_args, **_kwargs) -> None:
-            return None
-
-        async def stream_message(self, _request):
-            raise A2APeerProtocolError(
-                "Unknown method: message/stream",
-                error_code="method_not_found",
-                rpc_code=-32601,
-            )
-            yield  # pragma: no cover
-
-        async def retire(self) -> None:
-            return None
-
-        async def close(self) -> None:
-            return None
-
     monkeypatch.setattr(
         client_module,
         "validate_outbound_http_url",
@@ -1267,7 +1266,6 @@ async def test_stream_agent_falls_back_to_pascal_jsonrpc_streaming_for_http_json
         "get_effective_allowed_hosts_sync",
         lambda: ["example-agent.internal:24020"],
     )
-    monkeypatch.setattr(client_module, "SDKA2AAdapter", FakeSlashAdapter)
 
     transport = httpx.MockTransport(handler)
     async with httpx.AsyncClient(transport=transport) as http_client:
@@ -1291,10 +1289,16 @@ async def test_stream_agent_falls_back_to_pascal_jsonrpc_streaming_for_http_json
     assert a2a_client._peer_descriptor.selected_url == (
         "http://example-agent.internal:24020/jsonrpc"
     )
-    assert captured["method"] == "POST"
-    assert captured["url"] == "http://example-agent.internal:24020/jsonrpc"
-    assert captured["body"]["method"] == "SendStreamingMessage"
-    assert captured["body"]["params"]["message"]["messageId"]
+    assert [item["body"]["method"] for item in captured_requests] == [
+        "message/stream",
+        "SendStreamingMessage",
+    ]
+    assert all(
+        item["method"] == "POST"
+        and item["url"] == "http://example-agent.internal:24020/jsonrpc"
+        for item in captured_requests
+    )
+    assert captured_requests[1]["body"]["params"]["message"]["messageId"]
     assert events[0]["kind"] == "artifact-update"
     assert events[0]["artifact"]["metadata"]["block_type"] == "text"
     assert events[0]["artifact"]["parts"] == [
@@ -1311,8 +1315,8 @@ async def test_call_agent_retries_sdk_dialect_after_transport_reset() -> None:
 
     card = SimpleNamespace(
         name="SDK peer",
-        preferred_transport="JSONRPC",
-        url="http://example-agent.internal:24020/",
+        preferred_transport="HTTP+JSON",
+        url="http://example-agent.internal:24020/v1",
         additional_interfaces=[],
         capabilities=SimpleNamespace(streaming=False),
         protocol_version="1.0",
@@ -1320,8 +1324,8 @@ async def test_call_agent_retries_sdk_dialect_after_transport_reset() -> None:
     descriptor = client_module.build_peer_descriptor(
         agent_url="http://example-agent.internal:24020",
         card=card,
-        selected_transport="JSONRPC",
-        selected_url="http://example-agent.internal:24020/",
+        selected_transport="HTTP+JSON",
+        selected_url="http://example-agent.internal:24020/v1",
     )
 
     class ResettingSdkAdapter(sdk_module.SDKA2AAdapter):
@@ -1374,8 +1378,8 @@ async def test_call_agent_retries_retired_sdk_adapter_without_transport_invalida
 
     card = SimpleNamespace(
         name="SDK peer",
-        preferred_transport="JSONRPC",
-        url="http://example-agent.internal:24020/",
+        preferred_transport="HTTP+JSON",
+        url="http://example-agent.internal:24020/v1",
         additional_interfaces=[],
         capabilities=SimpleNamespace(streaming=False),
         protocol_version="1.0",
@@ -1383,8 +1387,8 @@ async def test_call_agent_retries_retired_sdk_adapter_without_transport_invalida
     descriptor = client_module.build_peer_descriptor(
         agent_url="http://example-agent.internal:24020",
         card=card,
-        selected_transport="JSONRPC",
-        selected_url="http://example-agent.internal:24020/",
+        selected_transport="HTTP+JSON",
+        selected_url="http://example-agent.internal:24020/v1",
     )
 
     class RetiredSdkAdapter(sdk_module.SDKA2AAdapter):


### PR DESCRIPTION
## 背景

`#505` 需要修复一类新的 JSON-RPC 流式兼容问题：当下游只支持 PascalCase `SendStreamingMessage`，而不支持 slash-style `message/stream` 时，Hub 当前会先走 slash 风格并收到 `200 + application/json + -32601`。

本 PR 最初先补了 Pascal streaming fallback；随后进一步把 `JSONRPC` binding 下的 slash 路径也收回到 Hub 自己控制，去掉 SDK 流式失败后的二次 probe，请求语义改为：基于**原始响应**直接识别 method-not-found，再 fallback 到 PascalCase。

Closes #505
Related #494

## 相关提交
- `126f61f` `fix(a2a): add pascal streaming fallback (#505)`
- `09212eb` `refactor(a2a): own jsonrpc slash fallback path (#505)`

## 改动

### JSON-RPC 适配层
- 新增 `backend/app/integrations/a2a_client/adapters/jsonrpc_common.py`
  - 收口 JSON-RPC payload、interceptor 应用、error payload 解析等共享逻辑。
- 新增 `backend/app/integrations/a2a_client/adapters/jsonrpc_slash.py`
  - 在 Hub 内直接实现 slash-style JSON-RPC 的 `message/send`、`message/stream`、`tasks/cancel`。
  - 流式路径直接检查**同一次原始响应**的 `Content-Type` 与 JSON-RPC error，不再补发第二次 slash 请求。
- 更新 `backend/app/integrations/a2a_client/adapters/jsonrpc_pascal.py`
  - 复用共享 helper，并接入 interceptor 应用逻辑。

### Client 选择逻辑
- 更新 `backend/app/integrations/a2a_client/client.py`
  - `JSONRPC` transport 下的 dialect 顺序改为 `jsonrpc_slash -> jsonrpc_pascal`。
  - 只在 `jsonrpc_slash` 返回 method-not-found 时再 fallback 到 `jsonrpc_pascal`。
- 更新 `backend/app/integrations/a2a_client/selection.py`
  - 抽出共享的 A2A `Message` 构造，避免 SDK/slash 两条路径各自生成。

### SDK 路径收口
- 更新 `backend/app/integrations/a2a_client/adapters/sdk.py`
  - 删除 JSON-RPC streaming invalid-SSE 后的二次 probe 逻辑。
  - SDK adapter 继续承担非 JSONRPC transport 的路径，不再负责当前这条 JSONRPC fallback 修复。

### 测试
- 更新 `backend/tests/test_a2a_client.py`
  - 新增 slash adapter 在 `200 + application/json + -32601` 下直接识别 method-not-found 的单测，并断言 slash 失败路径只发生一次请求。
  - 更新端到端回归，覆盖：`preferred HTTP+JSON + additional JSONRPC`、先打 `message/stream`、再 fallback 到 `SendStreamingMessage`，且总请求数为两次。
  - 调整 SDK reset 相关测试，使其继续覆盖 `HTTP+JSON` 路径上的 SDK lifecycle 行为。

## 审查结论
- 未发现当前阻塞性代码问题。
- 这组改动已经比较优雅、稳健地实现了 `#505` 想解决的核心目标：既补上 PascalCase `SendStreamingMessage` fallback，又去掉了原先 SDK 流式失败后的二次探测请求，避免重复 POST 和 probe/原请求不一致的问题。
- 现有改动边界也比较干净：`JSONRPC` binding 由 Hub 自己的 slash/pascal 双 adapter 承担，`HTTP+JSON` transport 仍保留现有 SDK 路径，没有把 REST binding 重写混进当前 bugfix。
- 低风险残余主要在后续策略层，而不在本 PR：目前仍是“slash 失败后 fallback 到 pascal”的运行时选择；“基于 card 声明优先选择 dialect，而不是先试错”仍应后续独立推进。

## 关系说明
- `Closes #505`：准确。本 PR 已完成 issue 里定义的 Pascal JSON-RPC streaming fallback 与 slash streaming method-not-found 识别。
- `Related #494`：准确。当前 PR 已补充关键互操作回归，但没有完成完整 multi-binding / multi-dialect 测试矩阵，因此保持 `Related` 更合适。

## 验证
- `cd backend && uv run pre-commit run --files app/integrations/a2a_client/selection.py app/integrations/a2a_client/adapters/jsonrpc_common.py app/integrations/a2a_client/adapters/jsonrpc_slash.py app/integrations/a2a_client/adapters/jsonrpc_pascal.py app/integrations/a2a_client/adapters/sdk.py app/integrations/a2a_client/adapters/__init__.py app/integrations/a2a_client/client.py tests/test_a2a_client.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_a2a_client.py`
- `cd backend && uv run pytest tests/test_a2a_websocket.py tests/test_hub_a2a_websocket.py`

结果：`40 passed`，`8 passed`。

## 范围说明
- 本 PR 聚焦修复 `JSONRPC` binding 下的 slash/pascal streaming fallback。
- 本 PR 不处理“基于 card 声明优先选择 dialect，而不是先试错再 fallback”的更长期策略问题。
