### PR TITLE
fix(frontend): render scheduled history rows in a single line by default (#502)

### DIFF
--- a/frontend/components/scheduled/ScheduledJobCard.tsx
+++ b/frontend/components/scheduled/ScheduledJobCard.tsx
@@ -293,44 +293,49 @@ export function ScheduledJobCard({
               </Text>
             ) : (
               <>
-                {executions.map((execution) => (
-                  <View
-                    key={execution.id}
-                    className="mb-2 rounded-xl bg-black/20 p-3"
-                  >
-                    <View className="flex-row items-center justify-between">
-                      <Text className="text-[10px] font-medium text-slate-500">
-                        {formatLocalDateTime(
-                          execution.finished_at ??
-                            execution.started_at ??
-                            execution.scheduled_for,
-                          timeZone,
-                        )}
-                      </Text>
-                      <View className="rounded px-1 py-0.5 bg-black/20">
-                        <Text
-                          className={`text-[9px] font-bold ${executionStatusColor[execution.status]}`}
-                        >
-                          {execution.status.toUpperCase()}
-                        </Text>
+                {executions.map((execution) => {
+                  const errorMessage = execution.error_message?.trim();
+
+                  return (
+                    <View
+                      key={execution.id}
+                      className="mb-2 rounded-xl bg-black/20 p-3"
+                    >
+                      <View className="flex-row items-center justify-between gap-3">
+                        <View className="min-w-0 flex-1 flex-row items-center gap-2">
+                          <View className="rounded bg-black/20 px-1 py-0.5">
+                            <Text
+                              className={`text-[9px] font-bold ${executionStatusColor[execution.status]}`}
+                            >
+                              {execution.status.toUpperCase()}
+                            </Text>
+                          </View>
+                          <Text className="flex-1 text-[10px] font-medium text-slate-500">
+                            {formatLocalDateTime(
+                              execution.finished_at ??
+                                execution.started_at ??
+                                execution.scheduled_for,
+                              timeZone,
+                            )}
+                          </Text>
+                        </View>
+                        {execution.conversation_id ? (
+                          <Button
+                            label="Open Session"
+                            size="xs"
+                            variant="secondary"
+                            onPress={() => openExecutionSession(execution)}
+                          />
+                        ) : null}
                       </View>
+                      {errorMessage ? (
+                        <Text className="mt-2 text-[11px] font-normal leading-4 text-red-400/80">
+                          {errorMessage}
+                        </Text>
+                      ) : null}
                     </View>
-                    {execution.error_message ? (
-                      <Text className="mt-2 text-[11px] font-normal text-red-400/80">
-                        {execution.error_message}
-                      </Text>
-                    ) : null}
-                    {execution.conversation_id ? (
-                      <Button
-                        className="mt-3 self-start"
-                        label="Open Session"
-                        size="xs"
-                        variant="secondary"
-                        onPress={() => openExecutionSession(execution)}
-                      />
-                    ) : null}
-                  </View>
-                ))}
+                  );
+                })}
 
                 {executionsHasMore ? (
                   <Button

--- a/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
+++ b/frontend/components/scheduled/__tests__/ScheduledJobCard.test.tsx
@@ -200,6 +200,71 @@ describe("ScheduledJobCard visuals", () => {
 
     expect(getByText(/Every 15 min/)).toBeTruthy();
   });
+
+  it("renders execution history as a single main row when no error summary exists", () => {
+    const job = {
+      id: "7a",
+      name: "History Job",
+      enabled: true,
+      last_run_status: "success" as const,
+      next_run_at_utc: "2026-02-23T10:00:00Z",
+      schedule_timezone: "UTC",
+    };
+    const execution = {
+      id: "execution-1",
+      status: "success" as const,
+      scheduled_for: "2026-02-23T10:00:00Z",
+      conversation_id: "conversation-1",
+    };
+    let root: any;
+
+    act(() => {
+      root = create(
+        <ScheduledJobCard
+          {...defaultProps}
+          job={job as any}
+          executions={[execution] as any}
+          executionsOpen
+        />,
+      );
+    });
+
+    expect(JSON.stringify(root.toJSON())).toContain("SUCCESS");
+    expect(JSON.stringify(root.toJSON())).toContain("Open Session");
+    expect(JSON.stringify(root.toJSON())).not.toContain("upstream timeout");
+  });
+
+  it("renders execution error summary only when it exists", () => {
+    const job = {
+      id: "7b",
+      name: "History Job",
+      enabled: true,
+      last_run_status: "failed" as const,
+      next_run_at_utc: "2026-02-23T10:00:00Z",
+      schedule_timezone: "UTC",
+    };
+    const errorMessage = "upstream timeout";
+    const { getByText } = render(
+      <ScheduledJobCard
+        {...defaultProps}
+        job={job as any}
+        executions={
+          [
+            {
+              id: "execution-2",
+              status: "failed" as const,
+              scheduled_for: "2026-02-23T10:00:00Z",
+              error_message: ` ${errorMessage} `,
+            },
+          ] as any
+        }
+        executionsOpen
+      />,
+    );
+
+    expect(getByText("FAILED")).toBeTruthy();
+    expect(getByText(errorMessage)).toBeTruthy();
+  });
 });
 
 jest.mock("@/lib/confirm", () => ({


### PR DESCRIPTION
## 关联 Issue
- Closes #502

## 变更概览
本 PR 聚焦优化 scheduled jobs 页面中的 execution history 展示密度：默认将每条执行记录收拢为单行主信息，仅在存在错误摘要时追加错误信息行。

## 模块说明
### frontend/components/scheduled
- 调整 `ScheduledJobCard` 中 execution history 的布局顺序，将主结构改为单行展示：状态、执行时间、`Open Session` 操作。
- 仅当 `execution.error_message` 去除首尾空白后仍有内容时，才渲染错误摘要副行，避免正常记录占用额外垂直空间。
- 保持已有会话跳转逻辑不变；存在 `conversation_id` 时仍可打开对应会话。

### frontend/components/scheduled/__tests__
- 为 `ScheduledJobCard` 补充执行历史渲染测试，覆盖“无错误摘要时仅展示主行”和“存在错误摘要时展示错误文本”两个场景。

### 文档
- 本 PR 未引入仓库文档文件变更。

## 关联关系校对
- 当前 PR 仅包含与 `#502` 直接相关的前端展示与测试改动，使用 `Closes #502` 是准确的。
- 未发现需要追加 `Related` 或额外关闭其他 issue 的情况。

## 验证结果
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/scheduled/ScheduledJobCard.tsx components/scheduled/__tests__/ScheduledJobCard.test.tsx --maxWorkers=25%`

以上命令均已通过。
