### PR TITLE
tests(backend): lock schedule recovery timeout boundaries (#375)

### DIFF
--- a/backend/tests/test_a2a_schedule_job.py
+++ b/backend/tests/test_a2a_schedule_job.py
@@ -21,6 +21,7 @@ from app.db.models.conversation_thread import ConversationThread
 from app.db.models.user import User
 from app.db.transaction import commit_safely as real_commit_safely
 from app.services.a2a_schedule_job import (
+    _derive_recovery_timeouts,
     _execute_claimed_task,
     _refresh_ops_metrics,
     _schedule_run_heartbeat_loop,
@@ -1974,6 +1975,28 @@ async def test_dispatch_due_a2a_schedules_reraises_non_connectivity_errors(
         await dispatch_due_a2a_schedules(batch_size=1)
 
 
+async def test_derive_recovery_timeouts_clamps_heartbeat_stale_to_invoke_timeout(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "a2a_schedule_task_invoke_timeout",
+        45.0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings,
+        "a2a_schedule_run_heartbeat_interval_seconds",
+        20.0,
+        raising=False,
+    )
+
+    heartbeat_timeout_seconds, hard_timeout_seconds = _derive_recovery_timeouts()
+
+    assert heartbeat_timeout_seconds == 45
+    assert hard_timeout_seconds == 45
+
+
 async def test_dispatch_due_a2a_schedules_passes_heartbeat_and_hard_timeout(
     async_db_session,  # noqa: ARG001
     monkeypatch,
@@ -2018,6 +2041,54 @@ async def test_dispatch_due_a2a_schedules_passes_heartbeat_and_hard_timeout(
     call_kwargs = recover_mock.await_args.kwargs
     assert call_kwargs["timeout_seconds"] == 60
     assert call_kwargs["hard_timeout_seconds"] == 200
+    assert ensure_workers_mock.await_count == 1
+    assert refresh_metrics_mock.await_count == 1
+
+
+async def test_dispatch_due_a2a_schedules_clamps_stale_timeout_to_invoke_timeout(
+    async_db_session,  # noqa: ARG001
+    monkeypatch,
+) -> None:
+    ensure_workers_mock = AsyncMock()
+    refresh_metrics_mock = AsyncMock()
+    recover_mock = AsyncMock(return_value=0)
+    enqueue_mock = AsyncMock(return_value=0)
+
+    monkeypatch.setattr(
+        settings,
+        "a2a_schedule_task_invoke_timeout",
+        45.0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings,
+        "a2a_schedule_run_heartbeat_interval_seconds",
+        20.0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.a2a_schedule_job._ensure_schedule_workers_started",
+        ensure_workers_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.a2a_schedule_job._refresh_ops_metrics",
+        refresh_metrics_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.a2a_schedule_job.a2a_schedule_service.recover_stale_running_tasks",
+        recover_mock,
+    )
+    monkeypatch.setattr(
+        "app.services.a2a_schedule_job.a2a_schedule_service.enqueue_due_tasks",
+        enqueue_mock,
+    )
+
+    await dispatch_due_a2a_schedules(batch_size=1)
+
+    assert recover_mock.await_count == 1
+    call_kwargs = recover_mock.await_args.kwargs
+    assert call_kwargs["timeout_seconds"] == 45
+    assert call_kwargs["hard_timeout_seconds"] == 45
     assert ensure_workers_mock.await_count == 1
     assert refresh_metrics_mock.await_count == 1
 


### PR DESCRIPTION
## 背景复核
`#375` 原始关注的问题仍然成立：调度恢复与执行超时之间如果边界不清晰，会出现误恢复风险。

但当前主干已经不再使用独立 `run lease` 配置，而是采用更稳妥的双阈值模型：
- worker 周期性更新 `last_heartbeat_at`
- recovery 基于 heartbeat stale timeout 判断失活
- `A2A_SCHEDULE_TASK_INVOKE_TIMEOUT` 作为 hard timeout 上限
- stale timeout 由 `_derive_recovery_timeouts()` 统一派生，且不会大于 invoke timeout

因此，本 PR 不再引入新的 lease 配置项，而是把当前最佳实践固化为明确的回归测试护栏。

## 模块改动
### backend/tests
- 在 `backend/tests/test_a2a_schedule_job.py` 新增直接测试，覆盖 `_derive_recovery_timeouts()` 在需要 clamp 时的行为
- 补充 dispatch -> recovery 参数透传测试，确认当 `heartbeat_interval * 3 > invoke_timeout` 时：
  - `timeout_seconds` 会被 clamp 到 `invoke_timeout`
  - `hard_timeout_seconds` 与 `invoke_timeout` 保持一致

## 文档与 Issue
- 已将 `#375` 的 issue 描述改写为当前代码语义：收敛为“固化调度恢复 timeout 边界契约”
- 无额外落库文档改动；这次变更只补测试护栏，不改运行时代码

## 代码审查结论
- 本 PR 没有引入新的运行时路径，风险较低
- 当前主干实现已经满足 `#375` 的核心稳定性目标；本 PR 的价值在于防止该边界未来回归
- `Related #389` 与 `Related #462` 仍然准确，但不应与本 PR 混做

## 验证
- `cd backend && uv run pre-commit run --files tests/test_a2a_schedule_job.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_a2a_schedule_job.py`
- 结果：`40 passed`

## Issue 关联
Closes #375
Related #389
Related #462
