### PR TITLE
feat(backend): add A2A task query support and interop coverage (#493)

### DIFF
--- a/backend/app/integrations/a2a_client/adapters/base.py
+++ b/backend/app/integrations/a2a_client/adapters/base.py
@@ -34,6 +34,16 @@ class A2AAdapter(ABC):
         """Produce normalized or raw streaming payloads."""
 
     @abstractmethod
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        """Fetch a downstream task snapshot."""
+
+    @abstractmethod
     async def cancel_task(
         self,
         task_id: str,

--- a/backend/app/integrations/a2a_client/adapters/jsonrpc_pascal.py
+++ b/backend/app/integrations/a2a_client/adapters/jsonrpc_pascal.py
@@ -28,6 +28,7 @@ JSONRPC_PASCAL_DIALECT = "jsonrpc_pascal"
 
 _METHOD_SEND_MESSAGE = "SendMessage"
 _METHOD_SEND_STREAMING_MESSAGE = "SendStreamingMessage"
+_METHOD_GET_TASK = "GetTask"
 _METHOD_CANCEL_TASK = "CancelTask"
 _FINAL_STATUS_STATES = {
     "completed",
@@ -84,6 +85,25 @@ class JsonRpcPascalAdapter(A2AAdapter):
         ):
             yield payload
 
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        params: dict[str, Any] = {"id": task_id}
+        if history_length is not None:
+            params["historyLength"] = history_length
+        if metadata:
+            params["metadata"] = metadata
+        try:
+            return await self._send_rpc(_METHOD_GET_TASK, params=params)
+        except A2APeerProtocolError as exc:
+            if exc.code == -32601:
+                raise A2AUnsupportedOperationError(str(exc)) from exc
+            raise
+
     async def cancel_task(
         self,
         task_id: str,
@@ -96,7 +116,7 @@ class JsonRpcPascalAdapter(A2AAdapter):
         try:
             return await self._send_rpc(_METHOD_CANCEL_TASK, params=params)
         except A2APeerProtocolError as exc:
-            if exc.rpc_code == -32601:
+            if exc.code == -32601:
                 raise A2AUnsupportedOperationError(str(exc)) from exc
             raise
 

--- a/backend/app/integrations/a2a_client/adapters/jsonrpc_slash.py
+++ b/backend/app/integrations/a2a_client/adapters/jsonrpc_slash.py
@@ -12,6 +12,8 @@ from a2a.client import ClientCallInterceptor
 from a2a.types import (
     CancelTaskRequest,
     CancelTaskResponse,
+    GetTaskRequest,
+    GetTaskResponse,
     MessageSendConfiguration,
     MessageSendParams,
     SendMessageRequest,
@@ -19,6 +21,7 @@ from a2a.types import (
     SendStreamingMessageRequest,
     SendStreamingMessageResponse,
     TaskIdParams,
+    TaskQueryParams,
 )
 from httpx_sse import aconnect_sse
 from pydantic import ValidationError
@@ -40,6 +43,7 @@ JSONRPC_SLASH_DIALECT = "jsonrpc_slash"
 
 _METHOD_SEND_MESSAGE = "message/send"
 _METHOD_SEND_STREAMING_MESSAGE = "message/stream"
+_METHOD_GET_TASK = "tasks/get"
 _METHOD_CANCEL_TASK = "tasks/cancel"
 
 
@@ -101,6 +105,33 @@ class JsonRpcSlashAdapter(A2AAdapter):
         ):
             yield payload
 
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        params = TaskQueryParams(
+            id=task_id,
+            history_length=history_length,
+            metadata=metadata,
+        )
+        rpc_request = GetTaskRequest(
+            params=params,
+            id=str(uuid4()),
+        )
+        try:
+            return await self._send_rpc(
+                method=_METHOD_GET_TASK,
+                payload=rpc_request.model_dump(mode="json", exclude_none=True),
+                response_model=GetTaskResponse,
+            )
+        except A2APeerProtocolError as exc:
+            if exc.code == -32601:
+                raise A2AUnsupportedOperationError(str(exc)) from exc
+            raise
+
     async def cancel_task(
         self,
         task_id: str,
@@ -119,7 +150,7 @@ class JsonRpcSlashAdapter(A2AAdapter):
                 response_model=CancelTaskResponse,
             )
         except A2APeerProtocolError as exc:
-            if exc.rpc_code == -32601:
+            if exc.code == -32601:
                 raise A2AUnsupportedOperationError(str(exc)) from exc
             raise
 

--- a/backend/app/integrations/a2a_client/adapters/sdk.py
+++ b/backend/app/integrations/a2a_client/adapters/sdk.py
@@ -17,7 +17,7 @@ from a2a.client import (
     Consumer,
 )
 from a2a.client.errors import A2AClientJSONRPCError
-from a2a.types import TaskIdParams, TransportProtocol
+from a2a.types import TaskIdParams, TaskQueryParams, TransportProtocol
 
 from app.integrations.a2a_client.adapters.base import A2AAdapter
 from app.integrations.a2a_client.errors import A2APeerProtocolError
@@ -127,6 +127,26 @@ class SDKA2AAdapter(A2AAdapter):
             try:
                 async for payload in client.send_message(build_a2a_message(request)):
                     yield payload
+            except A2AClientJSONRPCError as exc:
+                raise _map_protocol_error(exc) from exc
+
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        async with self._operation_usage(), self._transport_usage():
+            client = await self._get_client(streaming=False)
+            try:
+                return await client.get_task(
+                    TaskQueryParams(
+                        id=task_id,
+                        history_length=history_length,
+                        metadata=metadata,
+                    )
+                )
             except A2AClientJSONRPCError as exc:
                 raise _map_protocol_error(exc) from exc
 

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -44,6 +44,7 @@ from app.integrations.a2a_client.errors import (
     A2AOutboundNotAllowedError,
     A2APeerProtocolError,
     A2AUnsupportedBindingError,
+    A2AUnsupportedOperationError,
 )
 from app.integrations.a2a_client.http_clients import (
     SharedSDKTransportInvalidatedError,
@@ -358,6 +359,14 @@ class A2AClient:
                     "error": str(exc),
                     "error_code": getattr(exc, "error_code", "cancel_failed"),
                 }
+            except A2AUnsupportedOperationError as exc:
+                return {
+                    "success": False,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                    "error_code": getattr(exc, "error_code", "unsupported_operation"),
+                }
             except Exception as exc:  # noqa: BLE001
                 http_error = _unwrap_httpx_error(exc)
                 if http_error and _should_reset_http_error(http_error):
@@ -373,6 +382,96 @@ class A2AClient:
                     "task_id": normalized_task_id,
                     "error": str(exc),
                     "error_code": "cancel_failed",
+                }
+
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Fetch one upstream A2A task by task id."""
+
+        async with self._request_usage():
+            normalized_task_id = task_id.strip() if isinstance(task_id, str) else ""
+            if not normalized_task_id:
+                return {
+                    "success": False,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "error": "Task id is required.",
+                    "error_code": "invalid_task_id",
+                }
+
+            try:
+                task = await self._get_task_with_fallback(
+                    normalized_task_id,
+                    history_length=history_length,
+                    metadata=metadata,
+                )
+                logger.info(
+                    "Fetched A2A task %s for %s",
+                    normalized_task_id,
+                    redact_url_for_logging(self.agent_url),
+                )
+                return {
+                    "success": True,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "task": task,
+                }
+            except A2AClientHTTPError as exc:
+                status_code = getattr(exc, "status_code", None)
+                error_code = "task_query_failed"
+                if status_code == 404:
+                    error_code = "task_not_found"
+                elif status_code in {400, 405, 409, 501}:
+                    error_code = "unsupported_operation"
+                logger.warning(
+                    "Failed to fetch A2A task %s for %s",
+                    normalized_task_id,
+                    redact_url_for_logging(self.agent_url),
+                    extra={"status_code": status_code},
+                )
+                return {
+                    "success": False,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                    "error_code": error_code,
+                }
+            except A2APeerProtocolError as exc:
+                return {
+                    "success": False,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                    "error_code": getattr(exc, "error_code", "task_query_failed"),
+                }
+            except A2AUnsupportedOperationError as exc:
+                return {
+                    "success": False,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                    "error_code": getattr(exc, "error_code", "unsupported_operation"),
+                }
+            except Exception as exc:  # noqa: BLE001
+                http_error = _unwrap_httpx_error(exc)
+                if http_error and _should_reset_http_error(http_error):
+                    raise A2AClientResetRequiredError(str(http_error)) from exc
+                logger.exception(
+                    "Failed to fetch A2A task %s for %s",
+                    normalized_task_id,
+                    redact_url_for_logging(self.agent_url),
+                )
+                return {
+                    "success": False,
+                    "agent_url": self.agent_url,
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                    "error_code": "task_query_failed",
                 }
 
     async def get_agent_card(self) -> AgentCard:
@@ -668,6 +767,21 @@ class A2AClient:
     ) -> Any:
         return await self._invoke_with_jsonrpc_fallback(
             callback=lambda adapter: adapter.cancel_task(task_id, metadata=metadata)
+        )
+
+    async def _get_task_with_fallback(
+        self,
+        task_id: str,
+        *,
+        history_length: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        return await self._invoke_with_jsonrpc_fallback(
+            callback=lambda adapter: adapter.get_task(
+                task_id,
+                history_length=history_length,
+                metadata=metadata,
+            )
         )
 
     async def _invoke_with_jsonrpc_fallback(self, *, callback) -> Any:

--- a/backend/app/integrations/a2a_client/errors.py
+++ b/backend/app/integrations/a2a_client/errors.py
@@ -26,9 +26,13 @@ class A2AUnsupportedBindingError(A2AAgentUnavailableError):
 class A2AUnsupportedOperationError(A2AAgentUnavailableError):
     """Raised when a peer does not implement an optional operation."""
 
+    error_code = "unsupported_operation"
+
 
 class A2AStreamingNotSupportedError(A2AUnsupportedOperationError):
     """Raised when the selected adapter cannot stream for this peer."""
+
+    error_code = "streaming_not_supported"
 
 
 class A2APeerProtocolError(A2AAgentUnavailableError):

--- a/backend/app/integrations/a2a_client/gateway.py
+++ b/backend/app/integrations/a2a_client/gateway.py
@@ -455,6 +455,173 @@ class A2AGateway:
             "task": result.get("task"),
         }
 
+    async def get_task(
+        self,
+        *,
+        resolved: "ResolvedAgent",
+        task_id: str,
+        history_length: int | None = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        normalized_task_id = task_id.strip() if isinstance(task_id, str) else ""
+        if not normalized_task_id:
+            return {
+                "success": False,
+                "agent_name": resolved.name,
+                "agent_url": resolved.url,
+                "task_id": normalized_task_id,
+                "error": "Task id is required.",
+                "error_code": "invalid_task_id",
+            }
+
+        start_time = time.monotonic()
+        logger.info(
+            "A2A task get",
+            extra={
+                "agent_name": resolved.name,
+                "agent_url": redact_url_for_logging(resolved.url),
+                "task_id": normalized_task_id,
+                "history_length": history_length,
+            },
+        )
+        try:
+            async with self.open_invoke_session(
+                resolved=resolved,
+                policy=AgentResolutionPolicy.CACHED_SHARED,
+            ) as session:
+                result = await session.client.get_task(
+                    normalized_task_id,
+                    history_length=history_length,
+                    metadata=metadata,
+                )
+        except A2AClientResetRequiredError as exc:
+            await self._invalidate_client(resolved)
+            elapsed = time.monotonic() - start_time
+            logger.error(
+                "A2A task get requires client reset",
+                extra={
+                    "agent_name": resolved.name,
+                    "elapsed_seconds": round(elapsed, 3),
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                },
+            )
+            a2a_metrics.record_call(
+                resolved.name,
+                success=False,
+                error_code="client_reset",
+            )
+            return {
+                "success": False,
+                "agent_name": resolved.name,
+                "agent_url": resolved.url,
+                "task_id": normalized_task_id,
+                "error": str(exc),
+                "error_code": "client_reset",
+            }
+        except A2AOutboundNotAllowedError as exc:
+            elapsed = time.monotonic() - start_time
+            logger.error(
+                "A2A task get blocked by allowlist",
+                extra={
+                    "agent_name": resolved.name,
+                    "elapsed_seconds": round(elapsed, 3),
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                },
+            )
+            a2a_metrics.record_call(
+                resolved.name,
+                success=False,
+                error_code="outbound_not_allowed",
+            )
+            return {
+                "success": False,
+                "agent_name": resolved.name,
+                "agent_url": resolved.url,
+                "task_id": normalized_task_id,
+                "error": "Outbound A2A URL is not allowed",
+                "error_code": "outbound_not_allowed",
+            }
+        except A2AAgentUnavailableError as exc:
+            elapsed = time.monotonic() - start_time
+            logger.error(
+                "A2A task get unavailable",
+                extra={
+                    "agent_name": resolved.name,
+                    "elapsed_seconds": round(elapsed, 3),
+                    "task_id": normalized_task_id,
+                    "error": str(exc),
+                },
+            )
+            a2a_metrics.record_call(
+                resolved.name,
+                success=False,
+                error_code="agent_unavailable",
+            )
+            return {
+                "success": False,
+                "agent_name": resolved.name,
+                "agent_url": resolved.url,
+                "task_id": normalized_task_id,
+                "error": str(exc),
+                "error_code": "agent_unavailable",
+            }
+        except Exception as exc:  # noqa: BLE001
+            elapsed = time.monotonic() - start_time
+            logger.error(
+                "A2A task get failed unexpectedly",
+                exc_info=True,
+                extra={
+                    "agent_name": resolved.name,
+                    "elapsed_seconds": round(elapsed, 3),
+                    "task_id": normalized_task_id,
+                },
+            )
+            a2a_metrics.record_call(
+                resolved.name,
+                success=False,
+                error_code="upstream_error",
+            )
+            return {
+                "success": False,
+                "agent_name": resolved.name,
+                "agent_url": resolved.url,
+                "task_id": normalized_task_id,
+                "error": str(exc),
+                "error_code": "upstream_error",
+            }
+
+        elapsed = time.monotonic() - start_time
+        success = bool(result.get("success"))
+        error_code = (
+            None if success else str(result.get("error_code") or "upstream_error")
+        )
+        a2a_metrics.record_call(
+            resolved.name,
+            success=success,
+            error_code=error_code,
+        )
+        logger.info(
+            "A2A task get finished",
+            extra={
+                "agent_name": resolved.name,
+                "success": success,
+                "elapsed_seconds": round(elapsed, 3),
+                "task_id": normalized_task_id,
+                "error_code": error_code,
+            },
+        )
+        return {
+            "success": success,
+            "agent_name": resolved.name,
+            "agent_url": resolved.url,
+            "task_id": normalized_task_id,
+            "error": result.get("error"),
+            "error_code": error_code,
+            "task": result.get("task"),
+        }
+
     async def _watch_pending_invoke(
         self,
         *,

--- a/backend/app/integrations/a2a_client/service.py
+++ b/backend/app/integrations/a2a_client/service.py
@@ -83,6 +83,30 @@ class A2AService:
             metadata=metadata,
         )
 
+    async def get_task(
+        self,
+        *,
+        resolved: ResolvedAgent,
+        task_id: str,
+        history_length: int | None = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        logger.info(
+            "Fetching task via A2A service",
+            extra={
+                "agent_name": resolved.name,
+                "agent_url": redact_url_for_logging(resolved.url),
+                "task_id": task_id,
+                "history_length": history_length,
+            },
+        )
+        return await self.gateway.get_task(
+            resolved=resolved,
+            task_id=task_id,
+            history_length=history_length,
+            metadata=metadata,
+        )
+
 
 _service_instance: Optional[A2AService] = None
 

--- a/backend/tests/test_a2a_client.py
+++ b/backend/tests/test_a2a_client.py
@@ -31,6 +31,7 @@ from app.integrations.a2a_client.invoke_session import (
     AgentResolutionPolicy,
     InvokeSessionOwnership,
 )
+from app.integrations.a2a_client.service import A2AService
 
 
 @pytest.mark.asyncio
@@ -847,3 +848,136 @@ async def test_cancel_task_rejects_blank_task_id() -> None:
 
     assert result["success"] is False
     assert result["error_code"] == "invalid_task_id"
+
+
+@pytest.mark.asyncio
+async def test_get_task_returns_success_for_valid_request() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_task_with_fallback = AsyncMock(return_value={"id": "task-1"})
+
+    result = await a2a_client.get_task(" task-1 ", history_length=3)
+
+    assert result["success"] is True
+    assert result["task_id"] == "task-1"
+    assert result["task"] == {"id": "task-1"}
+    a2a_client._get_task_with_fallback.assert_awaited_once_with(
+        "task-1",
+        history_length=3,
+        metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_task_maps_http_status_error_codes() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_task_with_fallback = AsyncMock(
+        side_effect=A2AClientHTTPError(404, "Task not found")
+    )
+
+    result = await a2a_client.get_task("task-missing")
+
+    assert result["success"] is False
+    assert result["error_code"] == "task_not_found"
+
+
+@pytest.mark.asyncio
+async def test_get_task_maps_unsupported_operation_errors() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_task_with_fallback = AsyncMock(
+        side_effect=client_module.A2AUnsupportedOperationError("GetTask not supported")
+    )
+
+    result = await a2a_client.get_task("task-unsupported")
+
+    assert result["success"] is False
+    assert result["error_code"] == "unsupported_operation"
+
+
+@pytest.mark.asyncio
+async def test_get_task_rejects_blank_task_id() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+
+    result = await a2a_client.get_task("  ")
+
+    assert result["success"] is False
+    assert result["error_code"] == "invalid_task_id"
+
+
+@pytest.mark.asyncio
+async def test_gateway_get_task_returns_success_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = gateway_module.A2AGateway(
+        A2ASettings(
+            default_timeout=10.0,
+            use_client_preference=False,
+            client_idle_timeout=1.0,
+        )
+    )
+    resolved = SimpleNamespace(
+        url="http://example-agent.internal:24020",
+        headers={},
+        name="TestAgent",
+    )
+    session_client = SimpleNamespace(
+        get_task=AsyncMock(
+            return_value={
+                "success": True,
+                "task": {"id": "task-1"},
+                "task_id": "task-1",
+            }
+        )
+    )
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_open_invoke_session(**_kwargs):
+        yield SimpleNamespace(client=session_client)
+
+    monkeypatch.setattr(gateway, "open_invoke_session", fake_open_invoke_session)
+
+    result = await gateway.get_task(
+        resolved=resolved,
+        task_id="task-1",
+        history_length=2,
+    )
+
+    assert result["success"] is True
+    assert result["task"] == {"id": "task-1"}
+    session_client.get_task.assert_awaited_once_with(
+        "task-1",
+        history_length=2,
+        metadata=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_get_task_forwards_to_gateway() -> None:
+    settings = A2ASettings(default_timeout=10.0, use_client_preference=False)
+    service = A2AService(settings)
+    service.gateway = SimpleNamespace(
+        get_task=AsyncMock(return_value={"success": True, "task": {"id": "task-1"}})
+    )
+    resolved = SimpleNamespace(
+        name="TestAgent",
+        url="http://example-agent.internal:24020",
+        description=None,
+        metadata={},
+        headers={},
+    )
+
+    result = await service.get_task(
+        resolved=resolved,
+        task_id="task-1",
+        history_length=4,
+        metadata={"trace_id": "trace-1"},
+    )
+
+    assert result["success"] is True
+    service.gateway.get_task.assert_awaited_once_with(
+        resolved=resolved,
+        task_id="task-1",
+        history_length=4,
+        metadata={"trace_id": "trace-1"},
+    )

--- a/backend/tests/test_a2a_client_interoperability.py
+++ b/backend/tests/test_a2a_client_interoperability.py
@@ -608,6 +608,84 @@ async def test_jsonrpc_slash_stream_message_maps_application_json_method_not_fou
 
 
 @pytest.mark.asyncio
+async def test_jsonrpc_slash_get_task_maps_method_not_found_to_unsupported_operation() -> (
+    None
+):
+    descriptor = SimpleNamespace(
+        selected_transport="JSONRPC",
+        selected_url="http://example-agent.internal:24020/jsonrpc",
+        supports_streaming=True,
+        card=Mock(),
+    )
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": "task-get-1",
+                "error": {
+                    "code": -32601,
+                    "message": "Unknown method: tasks/get",
+                },
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        adapter = client_module.JsonRpcSlashAdapter(
+            descriptor,
+            http_client=http_client,
+        )
+
+        with pytest.raises(client_module.A2AUnsupportedOperationError):
+            await adapter.get_task("task-1", history_length=2)
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_pascal_get_task_uses_pascal_method_and_history_length() -> None:
+    captured: dict[str, object] = {}
+    descriptor = SimpleNamespace(
+        selected_transport="JSONRPC",
+        selected_url="http://example-agent.internal:24020/jsonrpc",
+        supports_streaming=True,
+        card=Mock(),
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json={
+                "jsonrpc": "2.0",
+                "id": captured["body"]["id"],
+                "result": {"id": "task-1", "status": {"state": "working"}},
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as http_client:
+        adapter = client_module.JsonRpcPascalAdapter(
+            descriptor,
+            http_client=http_client,
+        )
+
+        result = await adapter.get_task(
+            "task-1",
+            history_length=5,
+            metadata={"trace_id": "trace-1"},
+        )
+
+    assert result["id"] == "task-1"
+    assert captured["body"]["method"] == "GetTask"
+    assert captured["body"]["params"] == {
+        "id": "task-1",
+        "historyLength": 5,
+        "metadata": {"trace_id": "trace-1"},
+    }
+
+
+@pytest.mark.asyncio
 async def test_stream_agent_falls_back_to_pascal_jsonrpc_streaming_for_http_json_preferred_peer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -743,6 +821,48 @@ async def test_sdk_http_json_adapter_send_message_uses_sdk_transport_defaults(
         TransportProtocol.jsonrpc,
         TransportProtocol.http_json,
     ]
+    await adapter.close()
+
+
+@pytest.mark.asyncio
+async def test_sdk_http_json_adapter_get_task_forwards_history_length_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeFactory:
+        def __init__(self, *, config, consumers) -> None:
+            captured["config"] = config
+            captured["consumers"] = consumers
+
+        def create(self, *_args, **_kwargs):
+            class FakeClient:
+                async def get_task(self, request):
+                    captured["request"] = request
+                    return {"id": request.id, "history_length": request.history_length}
+
+                async def close(self) -> None:
+                    return None
+
+            return FakeClient()
+
+    monkeypatch.setattr(sdk_module, "ClientFactory", FakeFactory)
+
+    adapter = SDKA2AAdapter(
+        SimpleNamespace(card=Mock(), selected_transport="HTTP+JSON"),
+        transport_http_client=AsyncMock(),
+    )
+
+    result = await adapter.get_task(
+        "task-1",
+        history_length=7,
+        metadata={"trace_id": "trace-1"},
+    )
+
+    assert result == {"id": "task-1", "history_length": 7}
+    assert captured["request"].id == "task-1"
+    assert captured["request"].history_length == 7
+    assert captured["request"].metadata == {"trace_id": "trace-1"}
     await adapter.close()
 
 


### PR DESCRIPTION
## 关联 Issues
- Closes #494
- Closes #493
- Follow-up for: #492

## 审查结论
- 本 PR 的实现路径与 `#493` / `#494` 当前收敛后的需求一致：先通过测试矩阵确认现有 SDK-backed `HTTP+JSON` 路径的能力边界，再补齐统一 task query 能力与结构化错误，而不是直接引入第二套独立 REST adapter。
- 当前代码改动整体合理，没有发现阻塞合并的问题。
- `Closes #493` 与 `Closes #494` 当前是准确的：`#494` 的测试矩阵已落地，`#493` 也已按收敛后的定义完成“评估并补齐缺口”的最小必要实现。

## Backend / Tests
- 新增 `backend/tests/test_a2a_client_interoperability.py`，把 binding / dialect 互操作相关 case 从生命周期测试中拆分出来。
- 覆盖 JSON-RPC slash / Pascal、dialect cache、unsupported binding、allowlist、SDK-backed `HTTP+JSON` non-streaming / streaming、reset / retry、task query 互操作等矩阵维度。
- `backend/tests/test_a2a_client.py` 收敛为 lifecycle、registry、gateway、cleanup，以及 facade / gateway / service 基础行为测试。

## Backend / Adapter & Client
- 在 `A2AAdapter` 抽象边界中新增 `get_task()`。
- 为 `SDKA2AAdapter` 复用 SDK 已有 `TaskQueryParams` / REST transport 能力，补齐 task query 转发。
- 为 `JsonRpcSlashAdapter` 补齐 `tasks/get`，为 `JsonRpcPascalAdapter` 补齐 `GetTask`。
- 在 `A2AClient` 中新增统一 `get_task()` facade，并为 `get_task()` / `cancel_task()` 收敛 `unsupported_operation`、`task_not_found` 等结构化错误结果。
- 为 `A2AUnsupportedOperationError` / `A2AStreamingNotSupportedError` 增加稳定 `error_code`，避免缺失 task capability 时退化为泛化失败。

## Backend / Gateway & Service
- 在 `gateway.py` 中新增 `get_task()` 协调入口，沿用现有共享 session、metrics、logging、client reset 处理边界。
- 在 `service.py` 中新增 `get_task()` facade，保持上层接入方式一致。
- 本 PR 不新增 route，也不暴露 REST path 细节到上层业务调用链。

## 边界与风险
- 当前改动补齐的是集成层能力与回归保护，不是新增一套独立 transport 实现；这降低了与上游 `a2a-sdk` 漂移的风险。
- 目前 `get_task()` 只补到了 adapter / client / gateway / service 边界，还没有对应的上层业务路由接入；如果后续需要面向会话或前端暴露该能力，应在独立 issue 中继续推进。
- 本次未跑 full regression，只执行了后端受影响范围的低负载验证。

## 验证记录
- `cd backend && uv run pytest tests/test_a2a_client.py tests/test_a2a_client_interoperability.py`
- `cd backend && uv run pre-commit run --files tests/test_a2a_client.py tests/test_a2a_client_interoperability.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pre-commit run --files app/integrations/a2a_client/errors.py app/integrations/a2a_client/adapters/base.py app/integrations/a2a_client/adapters/sdk.py app/integrations/a2a_client/adapters/jsonrpc_slash.py app/integrations/a2a_client/adapters/jsonrpc_pascal.py app/integrations/a2a_client/client.py app/integrations/a2a_client/gateway.py app/integrations/a2a_client/service.py tests/test_a2a_client.py tests/test_a2a_client_interoperability.py --config ../.pre-commit-config.yaml`

## 相关提交
- `tests(backend): add A2A interoperability matrix coverage (#494)`
- `feat(backend): add A2A task query adapter support (#493)`
