### PR TITLE
fix(validation): split agent card warnings from blocking errors (#542)

### DIFF
--- a/backend/app/integrations/a2a_client/validators.py
+++ b/backend/app/integrations/a2a_client/validators.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any
 
 
-def validate_agent_card(card_data: dict[str, Any]) -> list[str]:
+@dataclass(slots=True)
+class AgentCardValidationResult:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def validate_agent_card(card_data: dict[str, Any]) -> AgentCardValidationResult:
     """Validate the structure and fields of an agent card."""
-    errors: list[str] = []
+    result = AgentCardValidationResult()
 
     required_fields = frozenset(
         [
@@ -22,37 +29,41 @@ def validate_agent_card(card_data: dict[str, Any]) -> list[str]:
         ]
     )
 
-    for field in required_fields:
-        if field not in card_data:
-            errors.append(f"Required field is missing: '{field}'.")
+    for field_name in required_fields:
+        if field_name not in card_data:
+            result.errors.append(f"Required field is missing: '{field_name}'.")
 
     if "url" in card_data and not (
         card_data["url"].startswith("http://")
         or card_data["url"].startswith("https://")
     ):
-        errors.append(
+        result.errors.append(
             "Field 'url' must be an absolute URL starting with http:// or https://."
         )
 
     if "capabilities" in card_data and not isinstance(card_data["capabilities"], dict):
-        errors.append("Field 'capabilities' must be an object.")
+        result.errors.append("Field 'capabilities' must be an object.")
 
-    for field in ["defaultInputModes", "defaultOutputModes"]:
-        if field in card_data:
-            if not isinstance(card_data[field], list):
-                errors.append(f"Field '{field}' must be an array of strings.")
-            elif not all(isinstance(item, str) for item in card_data[field]):
-                errors.append(f"All items in '{field}' must be strings.")
+    for field_name in ["defaultInputModes", "defaultOutputModes"]:
+        if field_name in card_data:
+            if not isinstance(card_data[field_name], list):
+                result.errors.append(
+                    f"Field '{field_name}' must be an array of strings."
+                )
+            elif not all(isinstance(item, str) for item in card_data[field_name]):
+                result.errors.append(f"All items in '{field_name}' must be strings.")
 
     if "skills" in card_data:
         if not isinstance(card_data["skills"], list):
-            errors.append("Field 'skills' must be an array of AgentSkill objects.")
+            result.errors.append(
+                "Field 'skills' must be an array of AgentSkill objects."
+            )
         elif not card_data["skills"]:
-            errors.append(
+            result.warnings.append(
                 "Field 'skills' array is empty. Agent must have at least one skill if it performs actions."
             )
 
-    return errors
+    return result
 
 
 def _validate_task(data: dict[str, Any]) -> list[str]:
@@ -117,4 +128,4 @@ def validate_message(data: dict[str, Any]) -> list[str]:
     return [f"Unknown message kind received: '{kind}'."]
 
 
-__all__ = ["validate_agent_card", "validate_message"]
+__all__ = ["AgentCardValidationResult", "validate_agent_card", "validate_message"]

--- a/backend/app/schemas/a2a_agent_card.py
+++ b/backend/app/schemas/a2a_agent_card.py
@@ -57,9 +57,13 @@ class A2AAgentCardValidationResponse(BaseModel):
     validation_errors: Optional[List[str]] = Field(
         default=None, description="Detailed validation errors (only in debug mode)"
     )
+    validation_warnings: Optional[List[str]] = Field(
+        default=None,
+        description="Non-blocking validation warnings exposed to clients",
+    )
     shared_session_query: Optional[SharedSessionQueryDiagnostic] = Field(
         default=None,
-        description="接入期 shared session query extension 兼容诊断结果",
+        description="Shared session query extension compatibility diagnostics",
     )
 
 

--- a/backend/app/services/a2a_agent_card_validation.py
+++ b/backend/app/services/a2a_agent_card_validation.py
@@ -56,7 +56,9 @@ async def fetch_and_validate_agent_card(
         )
 
     card_payload = card.model_dump(exclude_none=True)
-    validation_errors = validate_agent_card_payload(card_payload)
+    validation_result = validate_agent_card_payload(card_payload)
+    validation_errors = list(validation_result.errors)
+    validation_warnings = list(validation_result.warnings)
     diagnostics_card: AgentCard | None = None
     try:
         diagnostics_card = AgentCard.model_validate(card_payload)
@@ -72,7 +74,9 @@ async def fetch_and_validate_agent_card(
         validation_errors.append(session_query.error)
 
     success = not validation_errors
-    if success:
+    if success and validation_warnings:
+        message = "Agent card validated with warnings"
+    elif success:
         message = "Agent card validated"
     elif session_query and session_query.status == "invalid" and session_query.error:
         message = f"Shared session query contract is invalid: {session_query.error}"
@@ -87,6 +91,8 @@ async def fetch_and_validate_agent_card(
         "card": card_payload,
         "shared_session_query": session_query,
     }
+    if validation_warnings:
+        response_kwargs["validation_warnings"] = validation_warnings
     if app.core.config.settings.debug:
         response_kwargs["validation_errors"] = validation_errors
 

--- a/backend/tests/test_a2a_validators.py
+++ b/backend/tests/test_a2a_validators.py
@@ -19,8 +19,9 @@ def valid_card_data():
 
 class TestValidateAgentCard:
     def test_valid_card(self, valid_card_data):
-        errors = validators.validate_agent_card(valid_card_data)
-        assert not errors
+        result = validators.validate_agent_card(valid_card_data)
+        assert not result.errors
+        assert not result.warnings
 
     @pytest.mark.parametrize(
         "missing_field",
@@ -38,8 +39,8 @@ class TestValidateAgentCard:
     def test_missing_required_field(self, valid_card_data, missing_field):
         card_data = valid_card_data.copy()
         del card_data[missing_field]
-        errors = validators.validate_agent_card(card_data)
-        assert f"Required field is missing: '{missing_field}'." in errors
+        result = validators.validate_agent_card(card_data)
+        assert f"Required field is missing: '{missing_field}'." in result.errors
 
     @pytest.mark.parametrize(
         "invalid_url",
@@ -48,45 +49,46 @@ class TestValidateAgentCard:
     def test_invalid_url(self, valid_card_data, invalid_url):
         card_data = valid_card_data.copy()
         card_data["url"] = invalid_url
-        errors = validators.validate_agent_card(card_data)
+        result = validators.validate_agent_card(card_data)
         assert (
             "Field 'url' must be an absolute URL starting with http:// or https://."
-            in errors
+            in result.errors
         )
 
     def test_invalid_capabilities_type(self, valid_card_data):
         card_data = valid_card_data.copy()
         card_data["capabilities"] = "not-an-object"
-        errors = validators.validate_agent_card(card_data)
-        assert "Field 'capabilities' must be an object." in errors
+        result = validators.validate_agent_card(card_data)
+        assert "Field 'capabilities' must be an object." in result.errors
 
     @pytest.mark.parametrize("field", ["defaultInputModes", "defaultOutputModes"])
     def test_invalid_modes_type_not_array(self, valid_card_data, field):
         card_data = valid_card_data.copy()
         card_data[field] = "not-a-list"
-        errors = validators.validate_agent_card(card_data)
-        assert f"Field '{field}' must be an array of strings." in errors
+        result = validators.validate_agent_card(card_data)
+        assert f"Field '{field}' must be an array of strings." in result.errors
 
     @pytest.mark.parametrize("field", ["defaultInputModes", "defaultOutputModes"])
     def test_invalid_modes_type_item_not_string(self, valid_card_data, field):
         card_data = valid_card_data.copy()
         card_data[field] = [123, "string"]
-        errors = validators.validate_agent_card(card_data)
-        assert f"All items in '{field}' must be strings." in errors
+        result = validators.validate_agent_card(card_data)
+        assert f"All items in '{field}' must be strings." in result.errors
 
     def test_invalid_skills_type(self, valid_card_data):
         card_data = valid_card_data.copy()
         card_data["skills"] = "not-a-list"
-        errors = validators.validate_agent_card(card_data)
-        assert "Field 'skills' must be an array of AgentSkill objects." in errors
+        result = validators.validate_agent_card(card_data)
+        assert "Field 'skills' must be an array of AgentSkill objects." in result.errors
 
     def test_empty_skills_array(self, valid_card_data):
         card_data = valid_card_data.copy()
         card_data["skills"] = []
-        errors = validators.validate_agent_card(card_data)
+        result = validators.validate_agent_card(card_data)
+        assert not result.errors
         assert (
             "Field 'skills' array is empty. Agent must have at least one skill if it performs actions."
-            in errors
+            in result.warnings
         )
 
 

--- a/backend/tests/test_hub_a2a_extensions_and_validate_routes.py
+++ b/backend/tests/test_hub_a2a_extensions_and_validate_routes.py
@@ -577,6 +577,48 @@ async def test_hub_card_validate_success_for_allowlisted_user(
 
 
 @pytest.mark.asyncio
+async def test_hub_card_validate_returns_warning_for_empty_skills(
+    async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "a2a_proxy_allowed_hosts", ["example.com"])
+
+    agent_id, user = await _create_allowlisted_hub_agent(
+        async_session_maker=async_session_maker,
+        async_db_session=async_db_session,
+        admin_email="admin_validate_warn@example.com",
+        user_email="alice_validate_warn@example.com",
+        token="secret-token-validate-warn",
+    )
+
+    fake_gateway = _FakeGateway()
+    fake_gateway.card_payload["skills"] = []
+    monkeypatch.setattr(
+        hub_router, "get_a2a_service", lambda: _FakeA2AService(fake_gateway)
+    )
+
+    async with create_test_client(
+        hub_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as user_client:
+        resp = await user_client.post(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/card:validate"
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert payload["message"] == "Agent card validated with warnings"
+    assert payload["validation_warnings"] == [
+        (
+            "Field 'skills' array is empty. Agent must have at least one skill "
+            "if it performs actions."
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_hub_card_validate_reports_shared_session_query_diagnostics(
     async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_validation_errors_debug_mode.py
+++ b/backend/tests/test_validation_errors_debug_mode.py
@@ -19,7 +19,11 @@ class _DummyGateway:
 async def test_fetch_and_validate_agent_card_validation_errors_gated(monkeypatch):
     monkeypatch.setattr(
         "app.services.a2a_agent_card_validation.validate_agent_card_payload",
-        lambda payload: ["bad-card"],
+        lambda payload: type(
+            "_ValidationResult",
+            (),
+            {"errors": ["bad-card"], "warnings": []},
+        )(),
     )
 
     monkeypatch.setattr(settings, "debug", False)
@@ -33,6 +37,31 @@ async def test_fetch_and_validate_agent_card_validation_errors_gated(monkeypatch
         gateway=_DummyGateway(), resolved=object()
     )
     assert resp_debug.validation_errors == ["bad-card"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_and_validate_agent_card_exposes_warning_only_success(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.a2a_agent_card_validation.validate_agent_card_payload",
+        lambda payload: type(
+            "_ValidationResult",
+            (),
+            {
+                "errors": [],
+                "warnings": ["Field 'skills' array is empty."],
+            },
+        )(),
+    )
+
+    monkeypatch.setattr(settings, "debug", False)
+    resp = await fetch_and_validate_agent_card(
+        gateway=_DummyGateway(), resolved=object()
+    )
+
+    assert resp.success is True
+    assert resp.message == "Agent card validated with warnings"
+    assert resp.validation_errors is None
+    assert resp.validation_warnings == ["Field 'skills' array is empty."]
 
 
 @pytest.mark.asyncio

--- a/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
+++ b/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
@@ -300,6 +300,36 @@ describe("useAgentsCatalogQuery mutations", () => {
     expect(typeof cached?.[0]?.lastCheckedAt).toBe("string");
   });
 
+  it("keeps warning-only validation responses in success state", async () => {
+    queryClient.setQueryData(queryKeys.agents.catalog(), [
+      buildAgent({ id: "agent-1" }),
+    ]);
+
+    mocks.validateAgentCard.mockResolvedValue({
+      success: true,
+      message: "Agent card validated with warnings",
+      validation_warnings: ["Field 'skills' array is empty."],
+    });
+
+    const { result } = renderHook(() => useValidateAgentMutation(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("agent-1");
+    });
+
+    const cached = queryClient.getQueryData<AgentConfig[]>(
+      queryKeys.agents.catalog(),
+    );
+    expect(cached?.[0]).toMatchObject({
+      id: "agent-1",
+      status: "success",
+      lastError: undefined,
+    });
+    expect(typeof cached?.[0]?.lastCheckedAt).toBe("string");
+  });
+
   it("appends newly created agent to cache without full refetch", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
       buildAgent({ id: "shared-1", source: "shared" }),

--- a/frontend/lib/__tests__/agentCatalogCache.test.ts
+++ b/frontend/lib/__tests__/agentCatalogCache.test.ts
@@ -172,4 +172,13 @@ describe("agentCatalogCache", () => {
       AGENT_ERROR_MESSAGES.connectionFailed,
     );
   });
+
+  it("does not treat warning-only validation payloads as error details", () => {
+    expect(
+      toValidationErrorMessage({
+        validation_warnings: ["empty skills"],
+        message: "Agent card validated with warnings",
+      }),
+    ).toBe("Agent card validated with warnings");
+  });
 });

--- a/frontend/lib/agentCatalogCache.ts
+++ b/frontend/lib/agentCatalogCache.ts
@@ -9,6 +9,7 @@ export const AGENT_ERROR_MESSAGES = {
 
 type ValidationResponseLike = {
   validation_errors?: unknown[] | null;
+  validation_warnings?: unknown[] | null;
   message?: unknown;
 };
 

--- a/frontend/lib/api/a2aAgents.ts
+++ b/frontend/lib/api/a2aAgents.ts
@@ -9,6 +9,7 @@ export type A2AAgentCardValidationResponse = {
   card_description?: string | null;
   card?: Record<string, unknown> | null;
   validation_errors?: string[] | null;
+  validation_warnings?: string[] | null;
 };
 
 export type A2AAgentResponse = {


### PR DESCRIPTION
## 关联 Issues
- Closes #542
- 参考：#467
- 参考：#469

## 相关提交
- `2c6a1a2` `fix(validation): downgrade empty skills validation to warnings (#542)`

## 需求评估
- `#542` 仍然有效：当前 `card:validate` 会把 `skills = []` 视为阻断失败，混淆“可运行但自描述较弱”和“结构性无效”两类结果。
- 本次额外审查了其它类似的我方私有协议硬失败点。
- 结论：`shared_session_query.status == invalid` 仍应保持阻断失败，因为这代表 Agent 已声明 Hub 会消费的扩展合同，但声明本身无效；继续返回 `success = false` 更符合当前协议治理边界。
- 因此本 PR 只把 `skills = []` 从 hard fail 降级为 warning，不放松 shared session query invalid 的阻断语义。

## 后端
- 在 `backend/app/integrations/a2a_client/validators.py` 中将 Agent Card 校验结果拆分为 `errors + warnings`。
- 将 `skills = []` 从 blocking error 调整为 `validation_warnings`。
- 在 `backend/app/services/a2a_agent_card_validation.py` 中调整 validate 响应语义：
  - `success` 仅由 blocking errors 决定。
  - warning-only 场景返回 `Agent card validated with warnings`。
  - `shared_session_query.status == invalid` 继续作为 blocking error 处理。
- 在 `backend/app/schemas/a2a_agent_card.py` 中新增 `validation_warnings` 字段，并保持 `validation_errors` 的 debug-only 暴露策略。

## 前端
- 在 `frontend/lib/api/a2aAgents.ts` 中补齐 `validation_warnings` 类型。
- 在 `frontend/lib/agentCatalogCache.ts` 中维持错误文案解析只围绕 `validation_errors/message`，避免把 warning-only 结果当作失败态文案。
- 现有 validate mutation 在 `success = true` 的 warning-only 场景下继续走成功分支，不会把状态写成 error。

## 协议边界说明
- 这次没有放松 shared session query 的严格契约。
- 如果 Card 只声明了分页参数形式，但没有声明默认值和上限，例如缺少 `pagination.default_size/max_size` 或 `default_limit/max_limit`，当前仍会被判为 `invalid`，并在 `card:validate` 中继续表现为 hard fail。
- 原因是 Hub 需要明确的分页边界来安全、可预测地调用扩展；若缺少这些值，只能靠猜测实现或阅读源码，这不符合 `#467` / `#469` 约束下的协议治理方向。

## 测试
### Backend
- `cd backend && uv run pre-commit run --files app/integrations/a2a_client/validators.py app/services/a2a_agent_card_validation.py app/schemas/a2a_agent_card.py tests/test_a2a_validators.py tests/test_validation_errors_debug_mode.py tests/test_hub_a2a_extensions_and_validate_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/test_a2a_validators.py tests/test_validation_errors_debug_mode.py tests/test_hub_a2a_extensions_and_validate_routes.py`
- 结果：`79 passed in 28.76s`

### Frontend
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/__tests__/useAgentsCatalogQuery.test.tsx lib/__tests__/agentCatalogCache.test.ts lib/agentCatalogCache.ts lib/api/a2aAgents.ts --maxWorkers=25%`
- 结果：`36 passed, 173 tests`

## 风险与边界
- 当前前端仅做最小兼容，没有新增 warning 专用展示层；warning-only 结果会保持成功态，不再被当作失败。
- 这次没有调整运行时扩展能力路由中的 `invalid` 契约处理，避免把协议治理问题和 onboarding 校验宽松化混在同一个 PR 里。
