### PR TITLE
feat(chat): expose OpenCode working directory controls (#289)

### DIFF
--- a/frontend/components/chat/ChatComposer.tsx
+++ b/frontend/components/chat/ChatComposer.tsx
@@ -16,8 +16,10 @@ import { type SharedModelSelection } from "@/lib/chat-utils";
 
 export const ChatComposer = memo(function ChatComposer({
   modelSelectionStatus,
+  currentDirectory,
   pendingInterrupt,
   showShortcutManager,
+  onOpenDirectoryPicker,
   onOpenShortcutManager,
   selectedModel,
   onOpenModelPicker,
@@ -38,8 +40,10 @@ export const ChatComposer = memo(function ChatComposer({
   onScrollToBottom,
 }: {
   modelSelectionStatus: GenericCapabilityStatus;
+  currentDirectory?: string | null;
   pendingInterrupt: PendingRuntimeInterrupt | null;
   showShortcutManager: boolean;
+  onOpenDirectoryPicker: () => void;
   onOpenShortcutManager: () => void;
   selectedModel: SharedModelSelection | null;
   onOpenModelPicker: () => void;
@@ -64,6 +68,7 @@ export const ChatComposer = memo(function ChatComposer({
   const modelLabel = selectedModel
     ? `${selectedModel.providerID} / ${selectedModel.modelID}`
     : "Model: Default";
+  const hasDirectory = Boolean(currentDirectory?.trim());
 
   return (
     <View className="relative border-t border-slate-800 px-2 sm:px-6 py-4">
@@ -80,7 +85,7 @@ export const ChatComposer = memo(function ChatComposer({
         <View className="flex-row items-center gap-2">
           {modelSelectionStatus !== "unsupported" && !isFocused && (
             <Pressable
-              className="h-9 max-w-[180px] flex-row items-center gap-2 rounded-xl bg-slate-800/40 px-3"
+              className="h-9 max-w-[156px] flex-row items-center gap-2 rounded-xl bg-slate-800/40 px-3"
               onPress={onOpenModelPicker}
               accessibilityRole="button"
               accessibilityLabel="Choose model"
@@ -107,6 +112,26 @@ export const ChatComposer = memo(function ChatComposer({
               </Text>
             </Pressable>
           )}
+
+          <Pressable
+            className={`h-9 w-14 items-center justify-center rounded-xl ${
+              hasDirectory ? "bg-primary" : "bg-slate-800/40"
+            }`}
+            onPress={onOpenDirectoryPicker}
+            accessibilityRole="button"
+            accessibilityLabel="Configure working directory"
+            accessibilityHint={
+              hasDirectory
+                ? `Current directory: ${currentDirectory}`
+                : "Set the working directory for this session"
+            }
+          >
+            <Ionicons
+              name={hasDirectory ? "folder-open" : "folder-open-outline"}
+              size={18}
+              color={hasDirectory ? "#000000" : "#FFFFFF"}
+            />
+          </Pressable>
 
           <Pressable
             className={`h-9 w-14 items-center justify-center rounded-xl ${

--- a/frontend/components/chat/ChatHeaderPanel.tsx
+++ b/frontend/components/chat/ChatHeaderPanel.tsx
@@ -5,6 +5,7 @@ import { Pressable, Text, View } from "react-native";
 import { BackButton } from "@/components/ui/BackButton";
 import { Button } from "@/components/ui/Button";
 import { type AgentSession } from "@/lib/chat-utils";
+import { getOpencodeDirectory } from "@/lib/opencodeMetadata";
 import { type AgentConfig } from "@/store/agents";
 
 export function ChatHeaderPanel({
@@ -30,6 +31,8 @@ export function ChatHeaderPanel({
   onTestConnection: () => void;
   testingConnection: boolean;
 }) {
+  const workingDirectory = getOpencodeDirectory(session?.metadata);
+
   return (
     <View
       className="border-b border-white/5 bg-background px-2 sm:px-6 pb-4"
@@ -135,6 +138,20 @@ export function ChatHeaderPanel({
           </View>
 
           <View className="h-[1px] bg-white/5" />
+
+          {workingDirectory ? (
+            <>
+              <View>
+                <Text className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+                  Working Directory
+                </Text>
+                <Text className="mt-1 break-all text-[11px] font-normal text-slate-300">
+                  {workingDirectory}
+                </Text>
+              </View>
+              <View className="h-[1px] bg-white/5" />
+            </>
+          ) : null}
 
           <View className="flex-row items-center justify-between">
             <Text className="text-[11px] font-medium uppercase tracking-wider text-slate-500">

--- a/frontend/components/chat/OpencodeDirectoryModal.tsx
+++ b/frontend/components/chat/OpencodeDirectoryModal.tsx
@@ -1,0 +1,108 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { useEffect, useState } from "react";
+import { Modal, Pressable, Text, View } from "react-native";
+
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+
+export function OpencodeDirectoryModal({
+  visible,
+  onClose,
+  currentDirectory,
+  onSave,
+  onClear,
+}: {
+  visible: boolean;
+  onClose: () => void;
+  currentDirectory?: string | null;
+  onSave: (directory: string) => void;
+  onClear: () => void;
+}) {
+  const [draftDirectory, setDraftDirectory] = useState("");
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    setDraftDirectory(currentDirectory ?? "");
+  }, [currentDirectory, visible]);
+
+  const normalizedDraft = draftDirectory.trim();
+
+  return (
+    <Modal
+      transparent
+      visible={visible}
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 justify-end bg-black/60 sm:items-center sm:justify-center">
+        <Pressable
+          className="absolute inset-0"
+          accessibilityRole="button"
+          accessibilityLabel="Close working directory modal"
+          onPress={onClose}
+        />
+        <View className="w-full rounded-t-3xl border-t border-white/5 bg-surface p-6 sm:w-[min(92vw,640px)] sm:rounded-3xl sm:border">
+          <View className="mb-6 flex-row items-center justify-between">
+            <View className="flex-1 pr-4">
+              <Text className="text-lg font-bold text-white">
+                Working Directory
+              </Text>
+              <Text className="mt-1 text-xs text-slate-400">
+                Stored in session metadata as metadata.opencode.directory.
+              </Text>
+            </View>
+            <Pressable
+              onPress={onClose}
+              className="rounded-xl bg-slate-800 p-2 active:bg-slate-700"
+              accessibilityRole="button"
+              accessibilityLabel="Close working directory modal"
+            >
+              <Ionicons name="close" size={20} color="#FFFFFF" />
+            </Pressable>
+          </View>
+
+          <View className="mb-4 rounded-2xl border border-white/10 bg-black/20 px-4 py-3">
+            <Text className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+              Current
+            </Text>
+            <Text className="mt-1 text-sm text-white" numberOfLines={2}>
+              {currentDirectory?.trim() || "Not set"}
+            </Text>
+          </View>
+
+          <Input
+            label="Directory"
+            value={draftDirectory}
+            onChangeText={setDraftDirectory}
+            autoCapitalize="none"
+            autoCorrect={false}
+            placeholder="/workspace/project"
+            accessibilityLabel="Working directory input"
+          />
+
+          <View className="mt-6 flex-row justify-end gap-3">
+            <Button
+              label="Clear"
+              variant="secondary"
+              onPress={() => {
+                onClear();
+                onClose();
+              }}
+              disabled={!currentDirectory?.trim()}
+            />
+            <Button
+              label="Save"
+              onPress={() => {
+                onSave(normalizedDraft);
+                onClose();
+              }}
+              disabled={!normalizedDraft}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/frontend/components/chat/__tests__/ChatComposer.test.tsx
+++ b/frontend/components/chat/__tests__/ChatComposer.test.tsx
@@ -11,8 +11,10 @@ jest.mock("@expo/vector-icons", () => ({
 describe("ChatComposer clear button", () => {
   const mockProps = {
     modelSelectionStatus: "supported" as const,
+    currentDirectory: null,
     pendingInterrupt: null,
     showShortcutManager: false,
+    onOpenDirectoryPicker: jest.fn(),
     onOpenShortcutManager: jest.fn(),
     selectedModel: null,
     onOpenModelPicker: jest.fn(),
@@ -77,6 +79,19 @@ describe("ChatComposer clear button", () => {
     expect(onOpenModelPicker).toHaveBeenCalled();
   });
 
+  it("opens the working directory modal", () => {
+    const onOpenDirectoryPicker = jest.fn();
+    const { getByLabelText } = render(
+      <ChatComposer
+        {...mockProps}
+        onOpenDirectoryPicker={onOpenDirectoryPicker}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Configure working directory"));
+    expect(onOpenDirectoryPicker).toHaveBeenCalled();
+  });
+
   it("renders selected provider/model in button", () => {
     const { getByText } = render(
       <ChatComposer
@@ -122,6 +137,7 @@ describe("ChatComposer clear button", () => {
     fireEvent(UNSAFE_getByType(TextInput), "focus");
 
     expect(queryByLabelText("Choose model")).toBeNull();
+    expect(getByLabelText("Configure working directory")).toBeTruthy();
     expect(getByLabelText("Open shortcut manager")).toBeTruthy();
     expect(getByLabelText("Clear input")).toBeTruthy();
     expect(getByLabelText("Scroll to bottom")).toBeTruthy();

--- a/frontend/hooks/__tests__/useChatInterruptController.test.tsx
+++ b/frontend/hooks/__tests__/useChatInterruptController.test.tsx
@@ -1,0 +1,159 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useChatInterruptController } from "@/hooks/useChatInterruptController";
+import {
+  rejectQuestionInterrupt,
+  replyPermissionInterrupt,
+  replyQuestionInterrupt,
+} from "@/lib/api/a2aExtensions";
+import { toast } from "@/lib/toast";
+
+jest.mock("@/lib/api/a2aExtensions", () => ({
+  replyPermissionInterrupt: jest.fn(),
+  replyQuestionInterrupt: jest.fn(),
+  rejectQuestionInterrupt: jest.fn(),
+  A2AExtensionCallError: class extends Error {},
+}));
+
+jest.mock("@/lib/api/client", () => ({
+  ApiRequestError: class extends Error {
+    errorCode: string | null = null;
+    upstreamError: Record<string, unknown> | null = null;
+  },
+}));
+
+jest.mock("@/lib/toast", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockedReplyPermissionInterrupt = jest.mocked(replyPermissionInterrupt);
+const mockedReplyQuestionInterrupt = jest.mocked(replyQuestionInterrupt);
+const mockedRejectQuestionInterrupt = jest.mocked(rejectQuestionInterrupt);
+const mockedToast = toast as jest.Mocked<typeof toast>;
+
+describe("useChatInterruptController", () => {
+  const clearPendingInterrupt = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedReplyPermissionInterrupt.mockResolvedValue({
+      ok: true,
+      requestId: "perm-1",
+    });
+    mockedReplyQuestionInterrupt.mockResolvedValue({
+      ok: true,
+      requestId: "question-1",
+    });
+    mockedRejectQuestionInterrupt.mockResolvedValue({
+      ok: true,
+      requestId: "question-1",
+    });
+  });
+
+  it("forwards opencode directory metadata with permission replies", async () => {
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "perm-1",
+          type: "permission",
+          phase: "asked",
+          details: { permission: "read", patterns: ["/workspace/**"] },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 0,
+        sessionMetadata: {
+          opencode: {
+            directory: "/workspace/app",
+          },
+        },
+        clearPendingInterrupt,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handlePermissionReply("once");
+      await Promise.resolve();
+    });
+
+    expect(mockedReplyPermissionInterrupt).toHaveBeenCalledWith({
+      source: "personal",
+      agentId: "agent-1",
+      requestId: "perm-1",
+      reply: "once",
+      metadata: {
+        opencode: {
+          directory: "/workspace/app",
+        },
+      },
+    });
+    expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "perm-1");
+    expect(mockedToast.success).toHaveBeenCalledWith(
+      "Action submitted",
+      "Permission reply delivered to upstream.",
+    );
+  });
+
+  it("forwards opencode directory metadata with question answers", async () => {
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "question-1",
+          type: "question",
+          phase: "asked",
+          details: {
+            questions: [
+              {
+                header: null,
+                question: "Proceed?",
+                options: [],
+              },
+            ],
+          },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 1,
+        sessionMetadata: {
+          opencode: {
+            directory: "/workspace/app",
+          },
+        },
+        clearPendingInterrupt,
+      }),
+    );
+
+    act(() => {
+      result.current.handleQuestionAnswerChange(0, "yes");
+    });
+
+    await act(async () => {
+      result.current.handleQuestionReply();
+      await Promise.resolve();
+    });
+
+    expect(mockedReplyQuestionInterrupt).toHaveBeenCalledWith({
+      source: "personal",
+      agentId: "agent-1",
+      requestId: "question-1",
+      answers: [["yes"]],
+      metadata: {
+        opencode: {
+          directory: "/workspace/app",
+        },
+      },
+    });
+    expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "question-1");
+    expect(mockedToast.success).toHaveBeenCalledWith(
+      "Action submitted",
+      "Question answers delivered to upstream.",
+    );
+  });
+});

--- a/frontend/hooks/__tests__/useContinueSession.test.tsx
+++ b/frontend/hooks/__tests__/useContinueSession.test.tsx
@@ -98,6 +98,9 @@ describe("useContinueSession", () => {
       metadata: {
         provider: "opencode",
         externalSessionId: "upstream-1",
+        opencode: {
+          directory: "/workspace/app",
+        },
       },
     });
 
@@ -123,6 +126,11 @@ describe("useContinueSession", () => {
       provider: "opencode",
       externalSessionId: "upstream-1",
       contextId: undefined,
+      metadata: {
+        opencode: {
+          directory: "/workspace/app",
+        },
+      },
     });
     expect(mockedBlurActiveElement).toHaveBeenCalledTimes(1);
     expect(mockedBuildChatRoute).toHaveBeenCalledWith("agent-1", "conv-1");
@@ -139,6 +147,9 @@ describe("useContinueSession", () => {
       metadata: {
         provider: "opencode",
         externalSessionId: "upstream-1",
+        opencode: {
+          directory: "/workspace/app",
+        },
       },
     });
     const { result } = renderHook(() => useContinueSession());
@@ -172,6 +183,11 @@ describe("useContinueSession", () => {
         provider: "opencode",
         externalSessionId: "upstream-1",
         contextId: undefined,
+        metadata: {
+          opencode: {
+            directory: "/workspace/app",
+          },
+        },
       },
     );
     expect(mockedBuildChatRoute).toHaveBeenCalledWith(

--- a/frontend/hooks/useChatComposerController.ts
+++ b/frontend/hooks/useChatComposerController.ts
@@ -62,6 +62,7 @@ export function useChatComposerController({
   const [shortcutManagerInitialPrompt, setShortcutManagerInitialPrompt] =
     useState("");
   const [showShortcutManager, setShowShortcutManager] = useState(false);
+  const [showDirectoryPicker, setShowDirectoryPicker] = useState(false);
   const [showModelPicker, setShowModelPicker] = useState(false);
   const minInputHeight = 44;
   const maxInputHeight = 128;
@@ -155,6 +156,14 @@ export function useChatComposerController({
 
   const closeModelPicker = useCallback(() => {
     setShowModelPicker(false);
+  }, []);
+
+  const openDirectoryPicker = useCallback(() => {
+    setShowDirectoryPicker(true);
+  }, []);
+
+  const closeDirectoryPicker = useCallback(() => {
+    setShowDirectoryPicker(false);
   }, []);
 
   const handleModelSelect = useCallback(
@@ -256,9 +265,12 @@ export function useChatComposerController({
     inputHeight,
     maxInputHeight,
     showShortcutManager,
+    showDirectoryPicker,
     showModelPicker,
     openShortcutManager,
     closeShortcutManager,
+    openDirectoryPicker,
+    closeDirectoryPicker,
     openModelPicker,
     closeModelPicker,
     handleModelSelect,

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -9,6 +9,7 @@ import {
 import { type PendingRuntimeInterrupt } from "@/lib/api/chat-utils";
 import { ApiRequestError } from "@/lib/api/client";
 import { type ResolvedRuntimeInterruptRecord } from "@/lib/chat-utils";
+import { pickOpencodeDirectoryMetadata } from "@/lib/opencodeMetadata";
 import { toast } from "@/lib/toast";
 import type { AgentSource } from "@/store/agents";
 
@@ -25,6 +26,7 @@ type UseChatInterruptControllerParams = {
   pendingInterrupt: PendingRuntimeInterrupt | null;
   lastResolvedInterrupt: ResolvedRuntimeInterruptRecord | null;
   pendingQuestionCount: number;
+  sessionMetadata?: Record<string, unknown>;
   clearPendingInterrupt: (conversationId: string, requestId?: string) => void;
 };
 
@@ -35,6 +37,7 @@ export function useChatInterruptController({
   pendingInterrupt,
   lastResolvedInterrupt,
   pendingQuestionCount,
+  sessionMetadata,
   clearPendingInterrupt,
 }: UseChatInterruptControllerParams) {
   const [interruptAction, setInterruptAction] = useState<string | null>(null);
@@ -206,6 +209,7 @@ export function useChatInterruptController({
             agentId: activeAgentId,
             requestId,
             reply,
+            metadata: pickOpencodeDirectoryMetadata(sessionMetadata),
           });
           acknowledgeLocalInterruptResolution(
             requestId,
@@ -225,6 +229,7 @@ export function useChatInterruptController({
       conversationId,
       pendingInterrupt,
       runInterruptAction,
+      sessionMetadata,
     ],
   );
 
@@ -278,6 +283,7 @@ export function useChatInterruptController({
           agentId: activeAgentId,
           requestId,
           answers: normalizedAnswers,
+          metadata: pickOpencodeDirectoryMetadata(sessionMetadata),
         });
         acknowledgeLocalInterruptResolution(requestId, "question", "replied");
         clearPendingInterrupt(conversationId, requestId);
@@ -293,6 +299,7 @@ export function useChatInterruptController({
     pendingInterrupt,
     questionAnswers,
     runInterruptAction,
+    sessionMetadata,
   ]);
 
   const handleQuestionReject = useCallback(() => {
@@ -313,6 +320,7 @@ export function useChatInterruptController({
           source: agentSource,
           agentId: activeAgentId,
           requestId,
+          metadata: pickOpencodeDirectoryMetadata(sessionMetadata),
         });
         acknowledgeLocalInterruptResolution(requestId, "question", "rejected");
         clearPendingInterrupt(conversationId, requestId);
@@ -327,6 +335,7 @@ export function useChatInterruptController({
     conversationId,
     pendingInterrupt,
     runInterruptAction,
+    sessionMetadata,
   ]);
 
   return {

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -37,6 +37,10 @@ import {
 } from "@/lib/chatScroll";
 import { blurActiveElement } from "@/lib/focus";
 import { generateUuid } from "@/lib/id";
+import {
+  getOpencodeDirectory,
+  pickOpencodeDirectoryMetadata,
+} from "@/lib/opencodeMetadata";
 import { buildChatRoute } from "@/lib/routes";
 import { buildContinueBindingPayload } from "@/lib/sessionBinding";
 import { toast } from "@/lib/toast";
@@ -73,6 +77,9 @@ export function useChatScreenController({
   const cancelMessage = useChatStore((state) => state.cancelMessage);
   const clearPendingInterrupt = useChatStore(
     (state) => state.clearPendingInterrupt,
+  );
+  const setOpencodeDirectory = useChatStore(
+    (state) => state.setOpencodeDirectory,
   );
   const setSharedModelSelection = useChatStore(
     (state) => state.setSharedModelSelection,
@@ -126,6 +133,7 @@ export function useChatScreenController({
   const pendingInterrupt = session?.pendingInterrupt ?? null;
   const lastResolvedInterrupt = session?.lastResolvedInterrupt ?? null;
   const selectedModel = getSharedModelSelection(session?.metadata);
+  const opencodeDirectory = getOpencodeDirectory(session?.metadata);
   const extensionCapabilitiesQuery = useExtensionCapabilitiesQuery({
     agentId: activeAgentId,
     source: agent?.source,
@@ -217,6 +225,7 @@ export function useChatScreenController({
               messageID: promptMessageId,
               parts: [{ type: "text", text: content.trim() }],
             },
+            metadata: pickOpencodeDirectoryMetadata(currentSession?.metadata),
           });
           addConversationOverlayMessage(nextConversationId, {
             id: promptMessageId,
@@ -295,6 +304,7 @@ export function useChatScreenController({
     pendingInterrupt,
     lastResolvedInterrupt,
     pendingQuestionCount,
+    sessionMetadata: session?.metadata,
     clearPendingInterrupt,
   });
 
@@ -309,9 +319,12 @@ export function useChatScreenController({
     inputHeight,
     maxInputHeight,
     showShortcutManager,
+    showDirectoryPicker,
     showModelPicker,
     openShortcutManager,
     closeShortcutManager,
+    openDirectoryPicker,
+    closeDirectoryPicker,
     openModelPicker,
     closeModelPicker,
     handleModelSelect,
@@ -561,6 +574,27 @@ export function useChatScreenController({
     setShowSessionPicker(false);
   }, []);
 
+  const handleSaveOpencodeDirectory = useCallback(
+    (directory: string) => {
+      if (!conversationId || !activeAgentId) {
+        return;
+      }
+      ensureSession(conversationId, activeAgentId);
+      setOpencodeDirectory(conversationId, activeAgentId, directory);
+      toast.success("Working directory updated", directory);
+    },
+    [activeAgentId, conversationId, ensureSession, setOpencodeDirectory],
+  );
+
+  const handleClearOpencodeDirectory = useCallback(() => {
+    if (!conversationId || !activeAgentId) {
+      return;
+    }
+    ensureSession(conversationId, activeAgentId);
+    setOpencodeDirectory(conversationId, activeAgentId, null);
+    toast.success("Working directory cleared", "Using upstream default.");
+  }, [activeAgentId, conversationId, ensureSession, setOpencodeDirectory]);
+
   const handleRetry = useCallback(() => {
     if (
       !conversationId ||
@@ -634,6 +668,7 @@ export function useChatScreenController({
     sessionSource,
     modelSelectionStatus,
     selectedModel,
+    opencodeDirectory,
     messages,
     historyLoading,
     historyLoadingMore,
@@ -649,15 +684,20 @@ export function useChatScreenController({
     scrollToBottom,
     showShortcutManager,
     showSessionPicker,
+    showDirectoryPicker,
     showModelPicker,
     openShortcutManager,
     closeShortcutManager,
     openSessionPicker,
     closeSessionPicker,
+    openDirectoryPicker,
+    closeDirectoryPicker,
     openModelPicker,
     closeModelPicker,
     handleModelSelect,
     clearModelSelection,
+    handleSaveOpencodeDirectory,
+    handleClearOpencodeDirectory,
     handleUseShortcut,
     handleSessionSelect,
     handleTest,

--- a/frontend/lib/__tests__/chat-utils.test.ts
+++ b/frontend/lib/__tests__/chat-utils.test.ts
@@ -211,6 +211,9 @@ describe("chat store utils", () => {
     newest.contextId = "ctx-1";
     newest.metadata = {
       locale: "zh-CN",
+      opencode: {
+        directory: "/workspace/app",
+      },
       shared: {
         model: {
           providerID: "openai",
@@ -261,6 +264,9 @@ describe("chat store utils", () => {
     expect(persisted.newest.source).toBeNull();
     expect(persisted.newest.contextId).toBeNull();
     expect(persisted.newest.metadata).toEqual({
+      opencode: {
+        directory: "/workspace/app",
+      },
       shared: {
         model: {
           providerID: "openai",

--- a/frontend/lib/__tests__/opencodeMetadata.test.ts
+++ b/frontend/lib/__tests__/opencodeMetadata.test.ts
@@ -1,0 +1,78 @@
+import {
+  getOpencodeDirectory,
+  pickOpencodeDirectoryMetadata,
+  withOpencodeDirectory,
+} from "@/lib/opencodeMetadata";
+
+describe("opencode metadata helpers", () => {
+  it("reads a normalized directory from provider-private metadata", () => {
+    expect(
+      getOpencodeDirectory({
+        opencode: {
+          directory: "  /workspace/demo  ",
+        },
+      }),
+    ).toBe("/workspace/demo");
+  });
+
+  it("writes a directory while preserving unrelated metadata", () => {
+    expect(
+      withOpencodeDirectory(
+        {
+          locale: "en-CA",
+          shared: {
+            model: {
+              providerID: "openai",
+              modelID: "gpt-5",
+            },
+          },
+        },
+        "/workspace/demo",
+      ),
+    ).toEqual({
+      locale: "en-CA",
+      shared: {
+        model: {
+          providerID: "openai",
+          modelID: "gpt-5",
+        },
+      },
+      opencode: {
+        directory: "/workspace/demo",
+      },
+    });
+  });
+
+  it("removes the directory key and empties the provider section when cleared", () => {
+    expect(
+      withOpencodeDirectory(
+        {
+          opencode: {
+            directory: "/workspace/demo",
+          },
+        },
+        null,
+      ),
+    ).toEqual({});
+  });
+
+  it("picks only the directory metadata for extension callbacks", () => {
+    expect(
+      pickOpencodeDirectoryMetadata({
+        shared: {
+          model: {
+            providerID: "openai",
+            modelID: "gpt-5",
+          },
+        },
+        opencode: {
+          directory: "/workspace/demo",
+        },
+      }),
+    ).toEqual({
+      opencode: {
+        directory: "/workspace/demo",
+      },
+    });
+  });
+});

--- a/frontend/lib/chat-utils.ts
+++ b/frontend/lib/chat-utils.ts
@@ -3,6 +3,7 @@ import type {
   PendingRuntimeInterrupt,
   ResolvedRuntimeInterrupt,
 } from "@/lib/api/chat-utils";
+import { pickOpencodeDirectoryMetadata } from "@/lib/opencodeMetadata";
 import {
   pickSharedMetadataSections,
   withoutSharedSessionBinding,
@@ -202,9 +203,10 @@ export const sortSessionsByLastActive = (
 const normalizeSessionForPersistence = (
   session: AgentSession,
 ): AgentSession => {
-  const persistedMetadata = pickSharedMetadataSections(session.metadata, [
-    "model",
-  ]);
+  const persistedMetadata = {
+    ...pickSharedMetadataSections(session.metadata, ["model"]),
+    ...(pickOpencodeDirectoryMetadata(session.metadata) ?? {}),
+  };
 
   return {
     agentId: session.agentId,

--- a/frontend/lib/opencodeMetadata.ts
+++ b/frontend/lib/opencodeMetadata.ts
@@ -1,0 +1,46 @@
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+export const getOpencodeDirectory = (
+  metadata: Record<string, unknown> | null | undefined,
+): string | null => {
+  const opencode = asRecord(metadata?.opencode);
+  const directory =
+    typeof opencode?.directory === "string" ? opencode.directory.trim() : "";
+  return directory || null;
+};
+
+export const withOpencodeDirectory = (
+  metadata: Record<string, unknown> | null | undefined,
+  directory: string | null,
+): Record<string, unknown> => {
+  const nextMetadata = { ...(metadata ?? {}) };
+  const nextOpencode = asRecord(nextMetadata.opencode)
+    ? { ...(nextMetadata.opencode as Record<string, unknown>) }
+    : {};
+  const normalizedDirectory =
+    typeof directory === "string" ? directory.trim() : "";
+
+  if (normalizedDirectory) {
+    nextOpencode.directory = normalizedDirectory;
+    nextMetadata.opencode = nextOpencode;
+    return nextMetadata;
+  }
+
+  delete nextOpencode.directory;
+  if (Object.keys(nextOpencode).length > 0) {
+    nextMetadata.opencode = nextOpencode;
+  } else {
+    delete nextMetadata.opencode;
+  }
+  return nextMetadata;
+};
+
+export const pickOpencodeDirectoryMetadata = (
+  metadata: Record<string, unknown> | null | undefined,
+) => {
+  const directory = getOpencodeDirectory(metadata);
+  return directory ? { opencode: { directory } } : undefined;
+};

--- a/frontend/lib/sessionBinding.ts
+++ b/frontend/lib/sessionBinding.ts
@@ -1,4 +1,5 @@
 import { type SessionContinueBinding } from "@/lib/api/sessions";
+import { pickOpencodeDirectoryMetadata } from "@/lib/opencodeMetadata";
 import { readSharedSessionBinding } from "@/lib/sharedMetadata";
 
 export const buildContinueBindingPayload = (
@@ -7,6 +8,7 @@ export const buildContinueBindingPayload = (
 ) => {
   const metadata = binding.metadata || {};
   const sessionBinding = readSharedSessionBinding(metadata);
+  const opencodeMetadata = pickOpencodeDirectoryMetadata(metadata);
   return {
     agentId,
     source: binding.source,
@@ -14,5 +16,6 @@ export const buildContinueBindingPayload = (
     externalSessionId: sessionBinding.externalSessionId ?? undefined,
     contextId:
       typeof metadata.contextId === "string" ? metadata.contextId : undefined,
+    ...(opencodeMetadata ? { metadata: opencodeMetadata } : {}),
   };
 };

--- a/frontend/screens/ChatScreen.tsx
+++ b/frontend/screens/ChatScreen.tsx
@@ -5,6 +5,7 @@ import { ChatComposer } from "@/components/chat/ChatComposer";
 import { ChatHeaderPanel } from "@/components/chat/ChatHeaderPanel";
 import { ChatTimelinePanel } from "@/components/chat/ChatTimelinePanel";
 import { ModelPickerModal } from "@/components/chat/ModelPickerModal";
+import { OpencodeDirectoryModal } from "@/components/chat/OpencodeDirectoryModal";
 import { SessionPickerModal } from "@/components/chat/SessionPickerModal";
 import { ShortcutManagerModal } from "@/components/chat/ShortcutManagerModal";
 import { FullscreenLoader } from "@/components/ui/FullscreenLoader";
@@ -109,10 +110,20 @@ export function ChatScreen({
         onClearModelSelection={controller.clearModelSelection}
       />
 
+      <OpencodeDirectoryModal
+        visible={controller.showDirectoryPicker}
+        onClose={controller.closeDirectoryPicker}
+        currentDirectory={controller.opencodeDirectory}
+        onSave={controller.handleSaveOpencodeDirectory}
+        onClear={controller.handleClearOpencodeDirectory}
+      />
+
       <ChatComposer
         modelSelectionStatus={controller.modelSelectionStatus}
+        currentDirectory={controller.opencodeDirectory}
         pendingInterrupt={controller.pendingInterrupt}
         showShortcutManager={controller.showShortcutManager}
+        onOpenDirectoryPicker={controller.openDirectoryPicker}
         onOpenShortcutManager={controller.openShortcutManager}
         selectedModel={controller.selectedModel}
         onOpenModelPicker={controller.openModelPicker}

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -76,6 +76,10 @@ jest.mock("@/components/chat/SessionPickerModal", () => ({
   SessionPickerModal: () => null,
 }));
 
+jest.mock("@/components/chat/OpencodeDirectoryModal", () => ({
+  OpencodeDirectoryModal: () => null,
+}));
+
 jest.mock("@/components/chat/ShortcutManagerModal", () => ({
   ShortcutManagerModal: () => null,
 }));
@@ -222,6 +226,7 @@ const mockChatState: {
   cancelMessage: jest.Mock;
   clearPendingInterrupt: jest.Mock;
   bindExternalSession: jest.Mock;
+  setOpencodeDirectory: jest.Mock;
   getSessionsByAgentId: jest.Mock;
 } = {
   sessions: {},
@@ -231,6 +236,7 @@ const mockChatState: {
   cancelMessage: jest.fn(),
   clearPendingInterrupt: jest.fn(),
   bindExternalSession: jest.fn(),
+  setOpencodeDirectory: jest.fn(),
   getSessionsByAgentId: jest.fn(() => []),
 };
 
@@ -407,6 +413,7 @@ describe("ChatScreen interrupt handling", () => {
     mockChatState.cancelMessage.mockReset();
     mockChatState.clearPendingInterrupt.mockReset();
     mockChatState.bindExternalSession.mockReset();
+    mockChatState.setOpencodeDirectory.mockReset();
     mockPromptSessionAsync.mockReset().mockResolvedValue({
       ok: true,
       sessionId: "ses-upstream-1",
@@ -691,6 +698,11 @@ describe("ChatScreen interrupt handling", () => {
   it("appends input to the active upstream session during streaming", async () => {
     mockChatState.sessions[conversationId] = {
       ...baseSession(),
+      metadata: {
+        opencode: {
+          directory: "/workspace/app",
+        },
+      },
       streamState: "streaming",
       externalSessionRef: {
         provider: "OpenCode",
@@ -717,6 +729,11 @@ describe("ChatScreen interrupt handling", () => {
       request: {
         messageID: expect.any(String),
         parts: [{ type: "text", text: "append this" }],
+      },
+      metadata: {
+        opencode: {
+          directory: "/workspace/app",
+        },
       },
     });
     expect(mockChatState.sendMessage).not.toHaveBeenCalled();

--- a/frontend/store/chat.ts
+++ b/frontend/store/chat.ts
@@ -24,6 +24,10 @@ import {
 } from "@/lib/chatHistoryCache";
 import { generateUuid } from "@/lib/id";
 import {
+  getOpencodeDirectory,
+  withOpencodeDirectory,
+} from "@/lib/opencodeMetadata";
+import {
   buildPersistStorageName,
   createPersistStorage,
 } from "@/lib/storage/mmkv";
@@ -117,7 +121,13 @@ type ChatState = {
       provider?: string | null;
       externalSessionId?: string | null;
       contextId?: string | null;
+      metadata?: Record<string, unknown>;
     },
+  ) => void;
+  setOpencodeDirectory: (
+    conversationId: string,
+    agentId: string,
+    directory: string | null,
   ) => void;
   setSharedModelSelection: (
     conversationId: string,
@@ -185,13 +195,20 @@ export const useChatStore = create<ChatState>()(
           sessions: {
             ...state.sessions,
             [conversationId]: {
-              ...(state.sessions[conversationId] ??
-                createAgentSession(payload.agentId)),
+              ...((state.sessions[conversationId] ??
+                createAgentSession(payload.agentId)) as AgentSession),
               agentId: payload.agentId,
               source:
                 payload.source === undefined
                   ? (state.sessions[conversationId]?.source ?? null)
                   : payload.source,
+              metadata: payload.metadata
+                ? {
+                    ...((state.sessions[conversationId]?.metadata ??
+                      {}) as Record<string, unknown>),
+                    ...payload.metadata,
+                  }
+                : (state.sessions[conversationId]?.metadata ?? {}),
               externalSessionRef: mergeExternalSessionRef(
                 state.sessions[conversationId]?.externalSessionRef,
                 payload,
@@ -204,6 +221,26 @@ export const useChatStore = create<ChatState>()(
             },
           },
         }));
+      },
+      setOpencodeDirectory: (conversationId, agentId, directory) => {
+        set((state) => {
+          const current =
+            state.sessions[conversationId] ?? createAgentSession(agentId);
+          if (getOpencodeDirectory(current.metadata) === directory?.trim()) {
+            return state;
+          }
+          return {
+            sessions: {
+              ...state.sessions,
+              [conversationId]: {
+                ...current,
+                agentId,
+                metadata: withOpencodeDirectory(current.metadata, directory),
+                lastActiveAt: new Date().toISOString(),
+              },
+            },
+          };
+        });
       },
       setSharedModelSelection: (conversationId, agentId, selection) => {
         set((state) => {


### PR DESCRIPTION
## 需求评估

- `#289` 当前仍然有效，但原始方案中的“前端 API 需要新增 metadata 字段支持”已部分过时。当前主干已经具备通用 metadata / session_metadata 透传能力。
- 本 PR 聚焦当前真实缺口：为 `metadata.opencode.directory` 提供聊天页产品入口、会话级状态保留，以及在 continue / prompt-async / interrupt reply 中的继承闭环。
- 与 OpenCode extensions 总领 `#525` 的关系应为 `Related`，而不是 `Closes`。本 PR 完成后，`#289` 应关闭，`#525` 继续保留作为总领盘点 issue。

## 模块变更

### Frontend - Chat UI
- 新增工作目录配置弹层，允许在聊天页设置或清空当前会话的 `metadata.opencode.directory`。
- 在 Composer 工具栏增加工作目录入口按钮，并在会话详情中展示当前目录。

### Frontend - Session State / Metadata
- 新增 `opencodeMetadata` 辅助函数，统一读取、写入和裁剪 `metadata.opencode.directory`。
- 将工作目录写入 chat store 的 session metadata，并在本地持久化时保留该字段。
- `continueSession` 绑定结果如果包含目录元数据，会合并回本地 session。

### Frontend - Extension Flow
- `promptSessionAsync` 在流式追加消息时会继承当前 session 的目录元数据。
- permission/question interrupt reply 与 reject 会继承当前 session 的目录元数据。

### Tests
- 补充 metadata helper、interrupt controller、continue session、chat composer、chat screen 相关测试。
- 验证目录元数据在 prompt-async 与 interrupt reply 中被正确透传。

## Issue 关联

- Closes #289
- Related #525
- Related #285

## 验证记录

- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/chat/ChatComposer.tsx components/chat/ChatHeaderPanel.tsx components/chat/__tests__/ChatComposer.test.tsx components/chat/OpencodeDirectoryModal.tsx hooks/useChatComposerController.ts hooks/useChatInterruptController.ts hooks/useChatScreenController.ts hooks/__tests__/useContinueSession.test.tsx hooks/__tests__/useChatInterruptController.test.tsx lib/chat-utils.ts lib/sessionBinding.ts lib/opencodeMetadata.ts lib/__tests__/chat-utils.test.ts lib/__tests__/opencodeMetadata.test.ts screens/ChatScreen.tsx screens/__tests__/ChatScreen.interrupt.test.tsx store/chat.ts --maxWorkers=25%`

## 风险与后续

- 当前前端尚无稳定的 capability 信号可用于严格判断某个 agent 是否支持 `metadata.opencode.directory`，因此工作目录入口目前按聊天会话通用展示。功能上是兼容的，但这仍是一个可继续优化的 UX 收口点。
- 当前没有对 `OpencodeDirectoryModal` 和会话详情目录展示增加独立组件测试；现有测试主要通过 screen/controller 路径覆盖这部分行为。
