### PR TITLE
fix(frontend): clear chat composer immediately on send (#569)

### DIFF
--- a/frontend/hooks/__tests__/useChatComposerController.test.tsx
+++ b/frontend/hooks/__tests__/useChatComposerController.test.tsx
@@ -19,6 +19,10 @@ describe("useChatComposerController", () => {
   const setSharedModelSelection = jest.fn();
   const onAfterSend = jest.fn();
 
+  const flushMicrotasks = async () => {
+    await Promise.resolve();
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     sendMessage.mockResolvedValue(undefined);
@@ -67,14 +71,21 @@ describe("useChatComposerController", () => {
     expect(result.current.inputResetKey).toBe(1);
   });
 
-  it("sends the current draft from the ref-backed buffer and clears the composer", async () => {
+  it("sends the current draft from the ref-backed buffer and clears the composer immediately", () => {
     const { result } = renderComposer();
+    let resolveSend: (() => void) | undefined;
+    sendMessage.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSend = resolve;
+        }),
+    );
 
     act(() => {
       result.current.handleInputChange("Ship the patch");
     });
-    await act(async () => {
-      await result.current.handleSend();
+    act(() => {
+      result.current.handleSend();
     });
 
     expect(sendMessage).toHaveBeenCalledWith(
@@ -87,6 +98,64 @@ describe("useChatComposerController", () => {
     expect(result.current.inputDefaultValue).toBe("");
     expect(result.current.hasInput).toBe(false);
     expect(result.current.hasSendableInput).toBe(false);
+
+    resolveSend?.();
+  });
+
+  it("restores the failed draft when sending rejects and the composer is still empty", async () => {
+    const { result } = renderComposer();
+    sendMessage.mockRejectedValueOnce(new Error("network down"));
+
+    act(() => {
+      result.current.handleInputChange("Ship the patch");
+      result.current.handleSend();
+    });
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    expect(mockedToast.error).toHaveBeenCalledWith(
+      "Send failed",
+      "network down",
+    );
+    expect(result.current.inputDefaultValue).toBe("Ship the patch");
+    expect(result.current.hasInput).toBe(true);
+    expect(result.current.hasSendableInput).toBe(true);
+  });
+
+  it("does not overwrite a newer draft when the previous send fails", async () => {
+    const { result } = renderComposer();
+    let rejectSend: ((error?: unknown) => void) | undefined;
+    sendMessage.mockImplementationOnce(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectSend = reject;
+        }),
+    );
+
+    act(() => {
+      result.current.handleInputChange("Ship the patch");
+      result.current.handleSend();
+    });
+
+    act(() => {
+      result.current.handleInputChange("New draft");
+    });
+
+    await act(async () => {
+      rejectSend?.(new Error("network down"));
+      await flushMicrotasks();
+    });
+
+    act(() => {
+      result.current.openShortcutManager();
+    });
+
+    expect(mockedToast.error).toHaveBeenCalledWith(
+      "Send failed",
+      "network down",
+    );
+    expect(result.current.shortcutManagerInitialPrompt).toBe("New draft");
   });
 
   it("shows a toast once when the hard input limit is reached", () => {

--- a/frontend/hooks/useChatComposerController.ts
+++ b/frontend/hooks/useChatComposerController.ts
@@ -112,7 +112,7 @@ export function useChatComposerController({
     [minInputHeight, updateInputFlags],
   );
 
-  const handleSend = useCallback(async () => {
+  const handleSend = useCallback(() => {
     if (!activeAgentId || !conversationId || !agentSource) {
       return;
     }
@@ -128,9 +128,21 @@ export function useChatComposerController({
       return;
     }
 
-    await sendMessage(conversationId, activeAgentId, input, agentSource);
     replaceInput("", { resetHeight: true });
     onAfterSend();
+    const sendPromise = sendMessage(
+      conversationId,
+      activeAgentId,
+      input,
+      agentSource,
+    );
+    sendPromise.catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : "Unknown error.";
+      toast.error("Send failed", message);
+      if (draftInputRef.current.length === 0) {
+        replaceInput(input, { focus: true });
+      }
+    });
   }, [
     activeAgentId,
     agentSource,


### PR DESCRIPTION
## 关联
- Closes #569
- Related #420

## 背景与结论
- `#569` 在当前主干上仍然成立：聊天输入框会等到 `sendMessage` 对应的 streaming 生命周期结束后才清空。
- 本 PR 只修复“发送后输入框未及时清空”的问题，不扩展到 `#420` 所讨论的中断反馈层与意图区分。
- 审查结论：当前改动与 `#569` 的边界一致，方案合理，未发现阻塞性问题。

## 模块变更
### frontend/hooks/useChatComposerController.ts
- 将 composer 清空与发送后的滚动意图前移到异步发送调用之前，避免输入框被 streaming 生命周期阻塞。
- 将发送改为显式 Promise 错误处理，发送失败时弹出错误提示。
- 失败恢复时增加保护条件：仅在当前输入框仍为空时恢复旧草稿，避免覆盖用户在失败等待期间重新输入的新内容。

### frontend/hooks/__tests__/useChatComposerController.test.tsx
- 补充“发送后立即清空”的行为测试。
- 补充“发送失败后恢复草稿”的测试。
- 补充“发送失败时不覆盖新输入”的保护测试。

## 审查说明
### 与 issue 的匹配度
- 本 PR 完整覆盖 `#569` 的核心诉求。
- 本 PR 没有引入 `#420` 中的本地中断反馈文案、`replace_current_reply / refine_current_reply` 意图建模或去重提示逻辑，因此 `#420` 只能标记为 Related，不应标记为 Closes。

### 实现评价
- 方案足够直接，且保留了现有 `pendingInterrupt`、空输入和长度限制逻辑，没有引入额外状态耦合。
- 对失败恢复增加“仅在输入框仍为空时恢复”的保护是必要的，能避免比 issue 原方案更隐蔽的输入覆盖问题。

### 当前边界与残余风险
- 本 PR 主要覆盖 hook 层行为与相关联的屏幕测试；没有新增更高层的手工 UI 验证记录。
- `onAfterSend` 仍然是发送意图层的滚动触发，不承担更复杂的中断反馈职责；这部分后续若推进，应在 `#420` 处理。

## 验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/useChatComposerController.ts hooks/__tests__/useChatComposerController.test.tsx --maxWorkers=25%`
- 结果：全部通过
