### PR TITLE
fix(frontend): dismiss stale interrupt action cards (#571)

### DIFF
--- a/frontend/hooks/__tests__/useChatInterruptController.test.tsx
+++ b/frontend/hooks/__tests__/useChatInterruptController.test.tsx
@@ -6,6 +6,7 @@ import {
   replyPermissionInterrupt,
   replyQuestionInterrupt,
 } from "@/lib/api/a2aExtensions";
+import { ApiRequestError } from "@/lib/api/client";
 import { toast } from "@/lib/toast";
 
 jest.mock("@/lib/api/a2aExtensions", () => ({
@@ -17,13 +18,40 @@ jest.mock("@/lib/api/a2aExtensions", () => ({
 
 jest.mock("@/lib/api/client", () => ({
   ApiRequestError: class extends Error {
-    errorCode: string | null = null;
-    upstreamError: Record<string, unknown> | null = null;
+    status: number;
+    errorCode: string | null;
+    source: string | null;
+    jsonrpcCode: number | null;
+    missingParams: { name: string; required: boolean }[] | null;
+    upstreamError: Record<string, unknown> | null;
+
+    constructor(
+      message: string,
+      status: number,
+      options?: {
+        errorCode?: string | null;
+        source?: string | null;
+        jsonrpcCode?: number | null;
+        missingParams?: { name: string; required: boolean }[] | null;
+        upstreamError?: Record<string, unknown> | null;
+      },
+    ) {
+      super(message);
+      this.name = "ApiRequestError";
+      this.status = status;
+      this.errorCode = options?.errorCode ?? null;
+      this.source = options?.source ?? null;
+      this.jsonrpcCode = options?.jsonrpcCode ?? null;
+      this.missingParams = options?.missingParams ?? null;
+      this.upstreamError = options?.upstreamError ?? null;
+      Object.setPrototypeOf(this, new.target.prototype);
+    }
   },
 }));
 
 jest.mock("@/lib/toast", () => ({
   toast: {
+    info: jest.fn(),
     success: jest.fn(),
     error: jest.fn(),
   },
@@ -154,6 +182,174 @@ describe("useChatInterruptController", () => {
     expect(mockedToast.success).toHaveBeenCalledWith(
       "Action submitted",
       "Question answers delivered to upstream.",
+    );
+  });
+
+  it("clears stale permission interrupts when upstream reports expiration", async () => {
+    mockedReplyPermissionInterrupt.mockRejectedValueOnce(
+      new ApiRequestError("Conflict", 409, {
+        errorCode: "interrupt_request_expired",
+        upstreamError: { message: "Interrupt request expired" },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "perm-1",
+          type: "permission",
+          phase: "asked",
+          details: { permission: "read", patterns: ["/workspace/**"] },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 0,
+        clearPendingInterrupt,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handlePermissionReply("once");
+      await Promise.resolve();
+    });
+
+    expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "perm-1");
+    expect(mockedToast.info).toHaveBeenCalledWith(
+      "Interrupt closed",
+      "The interrupt request expired and was removed.",
+    );
+    expect(mockedToast.error).not.toHaveBeenCalled();
+  });
+
+  it("clears stale question reply interrupts when upstream reports not found", async () => {
+    mockedReplyQuestionInterrupt.mockRejectedValueOnce(
+      new ApiRequestError("Not Found", 404, {
+        errorCode: "interrupt_request_not_found",
+        upstreamError: { message: "Interrupt request not found" },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "question-1",
+          type: "question",
+          phase: "asked",
+          details: {
+            questions: [
+              {
+                header: null,
+                question: "Proceed?",
+                options: [],
+              },
+            ],
+          },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 1,
+        clearPendingInterrupt,
+      }),
+    );
+
+    act(() => {
+      result.current.handleQuestionAnswerChange(0, "yes");
+    });
+
+    await act(async () => {
+      result.current.handleQuestionReply();
+      await Promise.resolve();
+    });
+
+    expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "question-1");
+    expect(mockedToast.info).toHaveBeenCalledWith(
+      "Interrupt closed",
+      "The interrupt request no longer exists and was removed.",
+    );
+    expect(mockedToast.error).not.toHaveBeenCalled();
+  });
+
+  it("clears stale question reject interrupts when upstream reports expiration", async () => {
+    mockedRejectQuestionInterrupt.mockRejectedValueOnce(
+      new ApiRequestError("Conflict", 409, {
+        errorCode: "interrupt_request_expired",
+        upstreamError: { message: "Interrupt request expired" },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "question-1",
+          type: "question",
+          phase: "asked",
+          details: {
+            questions: [
+              {
+                header: null,
+                question: "Proceed?",
+                options: [],
+              },
+            ],
+          },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 1,
+        clearPendingInterrupt,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handleQuestionReject();
+      await Promise.resolve();
+    });
+
+    expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "question-1");
+    expect(mockedToast.info).toHaveBeenCalledWith(
+      "Interrupt closed",
+      "The interrupt request expired and was removed.",
+    );
+    expect(mockedToast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps pending interrupts visible for non-terminal callback errors", async () => {
+    mockedReplyPermissionInterrupt.mockRejectedValueOnce(
+      new ApiRequestError("Bad Request", 400, {
+        errorCode: "invalid_params",
+        upstreamError: { message: "reply is invalid" },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "perm-1",
+          type: "permission",
+          phase: "asked",
+          details: { permission: "read", patterns: ["/workspace/**"] },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 0,
+        clearPendingInterrupt,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handlePermissionReply("once");
+      await Promise.resolve();
+    });
+
+    expect(clearPendingInterrupt).not.toHaveBeenCalled();
+    expect(mockedToast.info).not.toHaveBeenCalled();
+    expect(mockedToast.error).toHaveBeenCalledWith(
+      "Interrupt callback failed",
+      "Bad Request [invalid_params]：reply is invalid",
     );
   });
 });

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -13,6 +13,11 @@ import { pickOpencodeDirectoryMetadata } from "@/lib/opencodeMetadata";
 import { toast } from "@/lib/toast";
 import type { AgentSource } from "@/store/agents";
 
+const TERMINAL_INTERRUPT_ERROR_CODES = new Set([
+  "interrupt_request_expired",
+  "interrupt_request_not_found",
+]);
+
 type ResolvedInterruptKeyInput = {
   requestId: string;
   type: "permission" | "question";
@@ -78,6 +83,26 @@ export function useChatInterruptController({
       : "Interrupt callback failed.";
   }, []);
 
+  const getInterruptErrorCode = useCallback((error: unknown) => {
+    if (
+      error instanceof ApiRequestError ||
+      error instanceof A2AExtensionCallError
+    ) {
+      return error.errorCode;
+    }
+    return null;
+  }, []);
+
+  const buildTerminalInterruptDismissMessage = useCallback(
+    (errorCode: string | null) => {
+      if (errorCode === "interrupt_request_expired") {
+        return "The interrupt request expired and was removed.";
+      }
+      return "The interrupt request no longer exists and was removed.";
+    },
+    [],
+  );
+
   const buildResolvedInterruptKey = useCallback(
     (interrupt: ResolvedInterruptKeyInput | null) =>
       interrupt
@@ -130,12 +155,29 @@ export function useChatInterruptController({
       actionKey: string,
       executor: () => Promise<void>,
       successMessage: string,
+      options?: {
+        conversationId: string;
+        requestId: string;
+      },
     ) => {
       setInterruptAction(actionKey);
       try {
         await executor();
         toast.success("Action submitted", successMessage);
       } catch (error) {
+        const errorCode = getInterruptErrorCode(error);
+        if (
+          options &&
+          errorCode &&
+          TERMINAL_INTERRUPT_ERROR_CODES.has(errorCode)
+        ) {
+          clearPendingInterrupt(options.conversationId, options.requestId);
+          toast.info(
+            "Interrupt closed",
+            buildTerminalInterruptDismissMessage(errorCode),
+          );
+          return;
+        }
         toast.error(
           "Interrupt callback failed",
           buildInterruptErrorMessage(error),
@@ -144,7 +186,12 @@ export function useChatInterruptController({
         setInterruptAction(null);
       }
     },
-    [buildInterruptErrorMessage],
+    [
+      buildInterruptErrorMessage,
+      buildTerminalInterruptDismissMessage,
+      clearPendingInterrupt,
+      getInterruptErrorCode,
+    ],
   );
 
   useEffect(() => {
@@ -219,6 +266,10 @@ export function useChatInterruptController({
           clearPendingInterrupt(conversationId, requestId);
         },
         "Permission reply delivered to upstream.",
+        {
+          conversationId,
+          requestId,
+        },
       ).catch(() => undefined);
     },
     [
@@ -289,6 +340,10 @@ export function useChatInterruptController({
         clearPendingInterrupt(conversationId, requestId);
       },
       "Question answers delivered to upstream.",
+      {
+        conversationId,
+        requestId,
+      },
     ).catch(() => undefined);
   }, [
     activeAgentId,
@@ -326,6 +381,10 @@ export function useChatInterruptController({
         clearPendingInterrupt(conversationId, requestId);
       },
       "Question request rejected.",
+      {
+        conversationId,
+        requestId,
+      },
     ).catch(() => undefined);
   }, [
     activeAgentId,

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -1,5 +1,6 @@
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 
+import { ApiRequestError } from "@/lib/api/client";
 import { ChatScreen } from "@/screens/ChatScreen";
 
 const mockReplyPermission = jest.fn();
@@ -523,6 +524,53 @@ describe("ChatScreen interrupt handling", () => {
       "perm-1",
     );
     expect(mockToastSuccess).toHaveBeenCalled();
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it("clears stale permission interrupts when the callback returns expiration", async () => {
+    mockReplyPermission.mockRejectedValueOnce(
+      new ApiRequestError("Conflict", 409, {
+        errorCode: "interrupt_request_expired",
+        upstreamError: {
+          message: "Interrupt request expired",
+        },
+      }),
+    );
+    mockChatState.sessions[conversationId] = {
+      ...baseSession(),
+      pendingInterrupt: {
+        requestId: "perm-stale-1",
+        type: "permission",
+        phase: "asked",
+        details: {
+          permission: "read",
+          patterns: ["/repo/.env"],
+        },
+      },
+    };
+
+    const tree = renderChatScreen(conversationId);
+    const root = tree.root;
+    const allowOnceButton = root.findByProps({
+      testID: "interrupt-permission-once",
+    });
+
+    await act(async () => {
+      allowOnceButton.props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(mockChatState.clearPendingInterrupt).toHaveBeenCalledWith(
+      conversationId,
+      "perm-stale-1",
+    );
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      "Interrupt closed",
+      "The interrupt request expired and was removed.",
+    );
+    expect(mockToastError).not.toHaveBeenCalled();
     act(() => {
       tree.unmount();
     });


### PR DESCRIPTION
## 关联
- Closes #571

## 背景与结论
- `#571` 聚焦的是 `permission:reply` 在 `interrupt_request_expired` / `interrupt_request_not_found` 下未清理本地 action card 的问题。
- 本 PR 修复点落在共享的 interrupt callback 失败路径，因此除了 `permission reply` 外，也一并补强了同类的 `question reply` 与 `question reject`。
- 审查结论：当前改动与问题边界一致，扩展范围合理，未发现阻塞性问题。

## 模块变更
### frontend/hooks/useChatInterruptController.ts
- 在统一的 interrupt callback 失败处理里识别终态错误码：
  - `interrupt_request_expired`
  - `interrupt_request_not_found`
- 命中上述错误时，自动执行 `clearPendingInterrupt(conversationId, requestId)`，关闭本地 stale action card。
- 同时展示明确的关闭提示，帮助用户理解不是“提交成功”，而是“该 interrupt 已失效并被移除”。
- 对 `invalid_params` 等非终态错误维持原行为，只报错、不关闭，避免误清理仍可重试的 interrupt。

### frontend/hooks/__tests__/useChatInterruptController.test.tsx
- 补充 permission reply 遇到 409 过期时的本地清理测试。
- 补充 question reply 遇到 404 不存在时的本地清理测试。
- 补充 question reject 遇到 409 过期时的本地清理测试。
- 补充非终态错误不应清理 action card 的保护测试。

### frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
- 补充屏幕层测试，验证 permission reply 在 stale interrupt 过期时会触发本地清理与用户提示。

## 审查说明
### 与 issue 的匹配度
- `#571` 明确描述的是 permission interrupt 的用户可见问题，本 PR 已完整覆盖。
- 本 PR 对 question reply / reject 的补强属于同一共享失败路径的顺手修复，不改变 issue 主体，也不构成偏题。

### 实现评价
- 终态错误码白名单控制得当，只在明确“该 interrupt 已失效”的场景下自动关闭本地卡片。
- 清理逻辑集中在共享 handler 中，避免把同类漏洞分别散落在三个 action 分支里重复修补。
- 测试同时覆盖 hook 层与 screen 层，足以支撑这次前端行为修复。

### 当前边界与风险
- 本 PR 只处理 interrupt callback 的 stale-terminal 错误，不扩展到其它 extension callback。
- 若未来上游新增新的“已终态但应本地关闭”的错误码，需要同步补充白名单与测试。

## 相关提交
- `f747fcc` `fix(frontend): recover from stale interrupt action cards (#571)`

## 验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/useChatInterruptController.ts hooks/__tests__/useChatInterruptController.test.tsx screens/__tests__/ChatScreen.interrupt.test.tsx --maxWorkers=25%`
- 结果：全部通过
