### PR TITLE
fix(frontend): queue pending interrupts (#575)

### DIFF
--- a/frontend/components/chat/ChatComposer.tsx
+++ b/frontend/components/chat/ChatComposer.tsx
@@ -18,6 +18,7 @@ export const ChatComposer = memo(function ChatComposer({
   modelSelectionStatus,
   currentDirectory,
   pendingInterrupt,
+  pendingInterruptCount,
   showShortcutManager,
   onOpenDirectoryPicker,
   onOpenShortcutManager,
@@ -42,6 +43,7 @@ export const ChatComposer = memo(function ChatComposer({
   modelSelectionStatus: GenericCapabilityStatus;
   currentDirectory?: string | null;
   pendingInterrupt: PendingRuntimeInterrupt | null;
+  pendingInterruptCount: number;
   showShortcutManager: boolean;
   onOpenDirectoryPicker: () => void;
   onOpenShortcutManager: () => void;
@@ -78,6 +80,12 @@ export const ChatComposer = memo(function ChatComposer({
             Agent is waiting for authorization/input. Resolve the action card
             first.
           </Text>
+          {pendingInterruptCount > 1 ? (
+            <Text className="mt-1 text-xs text-amber-200">
+              {pendingInterruptCount} pending requests are queued for this
+              session.
+            </Text>
+          ) : null}
         </View>
       ) : null}
 

--- a/frontend/components/chat/ChatTimelinePanel.tsx
+++ b/frontend/components/chat/ChatTimelinePanel.tsx
@@ -41,6 +41,7 @@ export function ChatTimelinePanel({
   onListContentSizeChange,
   onListScroll,
   pendingInterrupt,
+  pendingInterruptCount,
   interruptAction,
   questionAnswers,
   onPermissionReply,
@@ -65,6 +66,7 @@ export function ChatTimelinePanel({
   onListContentSizeChange: (w: number, h: number) => void;
   onListScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   pendingInterrupt: PendingRuntimeInterrupt | null;
+  pendingInterruptCount: number;
   interruptAction: string | null;
   questionAnswers: string[];
   onPermissionReply: (reply: "once" | "always" | "reject") => void;
@@ -132,6 +134,7 @@ export function ChatTimelinePanel({
       pendingInterrupt ? (
         <InterruptActionCard
           pendingInterrupt={pendingInterrupt}
+          pendingInterruptCount={pendingInterruptCount}
           interruptAction={interruptAction}
           questionAnswers={questionAnswers}
           onPermissionReply={onPermissionReply}
@@ -149,6 +152,7 @@ export function ChatTimelinePanel({
       onQuestionReject,
       onQuestionReply,
       pendingInterrupt,
+      pendingInterruptCount,
       questionAnswers,
     ],
   );

--- a/frontend/components/chat/InterruptActionCard.tsx
+++ b/frontend/components/chat/InterruptActionCard.tsx
@@ -6,6 +6,7 @@ import { type PendingRuntimeInterrupt } from "@/lib/api/chat-utils";
 
 export function InterruptActionCard({
   pendingInterrupt,
+  pendingInterruptCount,
   interruptAction,
   questionAnswers,
   onPermissionReply,
@@ -15,6 +16,7 @@ export function InterruptActionCard({
   onQuestionReject,
 }: {
   pendingInterrupt: PendingRuntimeInterrupt;
+  pendingInterruptCount: number;
   interruptAction: string | null;
   questionAnswers: string[];
   onPermissionReply: (reply: "once" | "always" | "reject") => void;
@@ -23,6 +25,8 @@ export function InterruptActionCard({
   onQuestionReply: () => void;
   onQuestionReject: () => void;
 }) {
+  const remainingInterruptCount = Math.max(pendingInterruptCount - 1, 0);
+
   if (pendingInterrupt.type === "permission") {
     const permission = pendingInterrupt.details.permission ?? "unknown";
     const patterns = pendingInterrupt.details.patterns ?? [];
@@ -32,6 +36,13 @@ export function InterruptActionCard({
         <Text className="text-xs font-semibold uppercase tracking-wide text-amber-300">
           Authorization Required
         </Text>
+        {remainingInterruptCount > 0 ? (
+          <Text className="mt-2 text-xs text-amber-200">
+            {remainingInterruptCount} more pending request
+            {remainingInterruptCount === 1 ? "" : "s"} will appear after this
+            one is resolved.
+          </Text>
+        ) : null}
         {displayMessage ? (
           <Text className="mt-2 text-sm text-amber-50">{displayMessage}</Text>
         ) : null}
@@ -86,6 +97,13 @@ export function InterruptActionCard({
       <Text className="text-xs font-semibold uppercase tracking-wide text-sky-300">
         Additional Input Required
       </Text>
+      {remainingInterruptCount > 0 ? (
+        <Text className="mt-2 text-xs text-sky-200">
+          {remainingInterruptCount} more pending request
+          {remainingInterruptCount === 1 ? "" : "s"} will appear after this one
+          is resolved.
+        </Text>
+      ) : null}
       {displayMessage ? (
         <Text className="mt-2 text-sm text-sky-50">{displayMessage}</Text>
       ) : null}

--- a/frontend/components/chat/__tests__/ChatComposer.test.tsx
+++ b/frontend/components/chat/__tests__/ChatComposer.test.tsx
@@ -13,6 +13,7 @@ describe("ChatComposer clear button", () => {
     modelSelectionStatus: "supported" as const,
     currentDirectory: null,
     pendingInterrupt: null,
+    pendingInterruptCount: 0,
     showShortcutManager: false,
     onOpenDirectoryPicker: jest.fn(),
     onOpenShortcutManager: jest.fn(),

--- a/frontend/components/chat/__tests__/InterruptActionCard.test.tsx
+++ b/frontend/components/chat/__tests__/InterruptActionCard.test.tsx
@@ -18,6 +18,7 @@ describe("InterruptActionCard", () => {
     const { getByText } = render(
       <InterruptActionCard
         {...baseProps}
+        pendingInterruptCount={1}
         pendingInterrupt={{
           requestId: "perm-1",
           type: "permission",
@@ -42,6 +43,7 @@ describe("InterruptActionCard", () => {
     const { getByText } = render(
       <InterruptActionCard
         {...baseProps}
+        pendingInterruptCount={1}
         onQuestionOptionPick={onQuestionOptionPick}
         pendingInterrupt={{
           requestId: "q-1",

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -28,7 +28,11 @@ import {
 } from "@/lib/api/a2aExtensions";
 import type { ChatMessage } from "@/lib/api/chat-utils";
 import { continueSession } from "@/lib/api/sessions";
-import { getSharedModelSelection } from "@/lib/chat-utils";
+import {
+  getPendingInterrupt,
+  getPendingInterruptQueue,
+  getSharedModelSelection,
+} from "@/lib/chat-utils";
 import { addConversationOverlayMessage } from "@/lib/chatHistoryCache";
 import {
   getAnchoredOffsetAfterContentResize,
@@ -130,7 +134,9 @@ export function useChatScreenController({
       ? sessionHistoryQuery.error.message
       : null;
   const sessionSource = session?.source ?? null;
-  const pendingInterrupt = session?.pendingInterrupt ?? null;
+  const pendingInterrupts = getPendingInterruptQueue(session);
+  const pendingInterrupt = getPendingInterrupt(session);
+  const pendingInterruptCount = pendingInterrupts.length;
   const lastResolvedInterrupt = session?.lastResolvedInterrupt ?? null;
   const selectedModel = getSharedModelSelection(session?.metadata);
   const opencodeDirectory = getOpencodeDirectory(session?.metadata);
@@ -339,7 +345,7 @@ export function useChatScreenController({
     activeAgentId,
     conversationId,
     agentSource: agent?.source,
-    pendingInterruptActive: Boolean(pendingInterrupt),
+    pendingInterruptActive: pendingInterruptCount > 0,
     ensureSession,
     sendMessage: sendMessageWithCapabilities,
     setSharedModelSelection,
@@ -676,6 +682,7 @@ export function useChatScreenController({
     historyPaused,
     historyError,
     pendingInterrupt,
+    pendingInterruptCount,
     interruptAction,
     questionAnswers,
     showDetails,

--- a/frontend/lib/__tests__/chat-utils.test.ts
+++ b/frontend/lib/__tests__/chat-utils.test.ts
@@ -3,6 +3,8 @@ import {
   buildInvokePayload,
   buildSessionCleanupPlan,
   createAgentSession,
+  getPendingInterrupt,
+  getPendingInterruptQueue,
   getSharedModelSelection,
   mergeExternalSessionRef,
   sortSessionsByLastActive,
@@ -15,6 +17,7 @@ describe("chat store utils", () => {
     expect(session.agentId).toBe("agent-1");
     expect(session.contextId).toBeNull();
     expect(session.streamState).toBe("idle");
+    expect(session.pendingInterrupts).toEqual([]);
     expect(session.pendingInterrupt).toBeNull();
     expect(session.lastResolvedInterrupt).toBeNull();
     expect(session.transport).toBe("http_json");
@@ -160,6 +163,55 @@ describe("chat store utils", () => {
     expect(sorted.map(([id]) => id)).toEqual(["s1", "s2"]);
   });
 
+  it("prefers queued pending interrupts and falls back to legacy state", () => {
+    const session = createAgentSession("agent-1");
+    session.pendingInterrupt = {
+      requestId: "legacy-perm-1",
+      type: "permission",
+      phase: "asked",
+      details: {
+        permission: "read",
+        patterns: ["/repo/.env"],
+      },
+    };
+
+    expect(getPendingInterruptQueue(session)).toEqual([
+      session.pendingInterrupt,
+    ]);
+    expect(getPendingInterrupt(session)?.requestId).toBe("legacy-perm-1");
+
+    session.pendingInterrupts = [
+      {
+        requestId: "perm-1",
+        type: "permission",
+        phase: "asked",
+        details: {
+          permission: "read",
+          patterns: ["/repo/.env"],
+        },
+      },
+      {
+        requestId: "q-1",
+        type: "question",
+        phase: "asked",
+        details: {
+          questions: [
+            {
+              header: null,
+              question: "Proceed?",
+              options: [],
+            },
+          ],
+        },
+      },
+    ];
+
+    expect(
+      getPendingInterruptQueue(session).map((item) => item.requestId),
+    ).toEqual(["perm-1", "q-1"]);
+    expect(getPendingInterrupt(session)?.requestId).toBe("perm-1");
+  });
+
   it("builds cleanup plan for expired and orphaned sessions", () => {
     const active = createAgentSession("agent-1");
     active.lastActiveAt = "2026-02-14T12:00:00.000Z";
@@ -241,6 +293,7 @@ describe("chat store utils", () => {
       phase: "asked",
       details: { permission: "read", patterns: ["/repo/.env"] },
     };
+    newest.pendingInterrupts = [newest.pendingInterrupt];
     newest.lastResolvedInterrupt = {
       requestId: "q-1",
       type: "question",
@@ -258,6 +311,7 @@ describe("chat store utils", () => {
     expect(persisted.newest.streamState).toBe("idle");
     expect(persisted.newest.lastStreamError).toBeNull();
     expect(persisted.newest.runtimeStatus).toBeNull();
+    expect(persisted.newest.pendingInterrupts).toEqual([]);
     expect(persisted.newest.pendingInterrupt).toBeNull();
     expect(persisted.newest.lastResolvedInterrupt).toBeNull();
     expect(persisted.newest.transport).toBe("http_json");

--- a/frontend/lib/chat-utils.ts
+++ b/frontend/lib/chat-utils.ts
@@ -29,6 +29,7 @@ export type AgentSession = {
   source?: "manual" | "scheduled" | null;
   contextId: string | null;
   runtimeStatus?: string | null;
+  pendingInterrupts: PendingRuntimeInterrupt[];
   pendingInterrupt?: PendingRuntimeInterrupt | null;
   lastResolvedInterrupt?: ResolvedRuntimeInterruptRecord | null;
   streamState?: "idle" | "streaming" | "recoverable" | "error";
@@ -55,6 +56,7 @@ export const createAgentSession = (agentId: string): AgentSession => ({
   source: null,
   contextId: null,
   runtimeStatus: null,
+  pendingInterrupts: [],
   pendingInterrupt: null,
   lastResolvedInterrupt: null,
   streamState: "idle",
@@ -77,6 +79,59 @@ export const mergeExternalSessionRef = (
   provider: current?.provider ?? incoming.provider ?? null,
   externalSessionId:
     current?.externalSessionId ?? incoming.externalSessionId ?? null,
+});
+
+const isPendingRuntimeInterrupt = (
+  value: unknown,
+): value is PendingRuntimeInterrupt => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as PendingRuntimeInterrupt;
+  return (
+    typeof candidate.requestId === "string" &&
+    (candidate.type === "permission" || candidate.type === "question") &&
+    candidate.phase === "asked"
+  );
+};
+
+export const getPendingInterruptQueue = (
+  session:
+    | Pick<AgentSession, "pendingInterrupts" | "pendingInterrupt">
+    | null
+    | undefined,
+): PendingRuntimeInterrupt[] => {
+  const pendingInterrupts = Array.isArray(session?.pendingInterrupts)
+    ? session.pendingInterrupts.filter(isPendingRuntimeInterrupt)
+    : [];
+  if (pendingInterrupts.length > 0) {
+    return pendingInterrupts;
+  }
+  return isPendingRuntimeInterrupt(session?.pendingInterrupt)
+    ? [session.pendingInterrupt]
+    : [];
+};
+
+export const getPendingInterrupt = (
+  session:
+    | Pick<AgentSession, "pendingInterrupts" | "pendingInterrupt">
+    | null
+    | undefined,
+): PendingRuntimeInterrupt | null =>
+  getPendingInterruptQueue(session)[0] ?? null;
+
+export const hasPendingInterrupt = (
+  session:
+    | Pick<AgentSession, "pendingInterrupts" | "pendingInterrupt">
+    | null
+    | undefined,
+) => getPendingInterruptQueue(session).length > 0;
+
+export const buildPendingInterruptState = (
+  pendingInterrupts: PendingRuntimeInterrupt[],
+): Pick<AgentSession, "pendingInterrupts" | "pendingInterrupt"> => ({
+  pendingInterrupts,
+  pendingInterrupt: pendingInterrupts[0] ?? null,
 });
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
@@ -214,6 +269,7 @@ const normalizeSessionForPersistence = (
     source: null,
     contextId: null,
     runtimeStatus: null,
+    pendingInterrupts: [],
     pendingInterrupt: null,
     lastResolvedInterrupt: null,
     streamState: "idle",

--- a/frontend/screens/ChatScreen.tsx
+++ b/frontend/screens/ChatScreen.tsx
@@ -74,6 +74,7 @@ export function ChatScreen({
         onListContentSizeChange={controller.handleListContentSizeChange}
         onListScroll={controller.handleListScroll}
         pendingInterrupt={controller.pendingInterrupt}
+        pendingInterruptCount={controller.pendingInterruptCount}
         interruptAction={controller.interruptAction}
         questionAnswers={controller.questionAnswers}
         onPermissionReply={controller.handlePermissionReply}
@@ -122,6 +123,7 @@ export function ChatScreen({
         modelSelectionStatus={controller.modelSelectionStatus}
         currentDirectory={controller.opencodeDirectory}
         pendingInterrupt={controller.pendingInterrupt}
+        pendingInterruptCount={controller.pendingInterruptCount}
         showShortcutManager={controller.showShortcutManager}
         onOpenDirectoryPicker={controller.openDirectoryPicker}
         onOpenShortcutManager={controller.openShortcutManager}

--- a/frontend/store/__tests__/chatRuntime.test.ts
+++ b/frontend/store/__tests__/chatRuntime.test.ts
@@ -6,7 +6,11 @@ import {
   listSessionMessagesPage,
   type SessionMessageItem,
 } from "@/lib/api/sessions";
-import { createAgentSession } from "@/lib/chat-utils";
+import {
+  buildPendingInterruptState,
+  createAgentSession,
+  getPendingInterruptQueue,
+} from "@/lib/chat-utils";
 import {
   addConversationMessage,
   clearAllConversationMessages,
@@ -810,6 +814,7 @@ describe("executeChatRuntime empty-content recovery", () => {
       type: "interrupt_event",
       content: "Agent requested authorization: read.\nTargets: /repo/.env",
     });
+    expect(state.sessions[conversationId]?.pendingInterrupts).toEqual([]);
     expect(state.sessions[conversationId]?.pendingInterrupt).toBeNull();
   });
 
@@ -858,7 +863,9 @@ describe("executeChatRuntime empty-content recovery", () => {
       };
     };
 
-    let pendingAfterWorking = state.sessions[conversationId]?.pendingInterrupt;
+    let pendingAfterWorking = getPendingInterruptQueue(
+      state.sessions[conversationId],
+    );
     mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
       async (params: {
         callbacks: {
@@ -888,7 +895,9 @@ describe("executeChatRuntime empty-content recovery", () => {
           status: { state: "working" },
           final: false,
         });
-        pendingAfterWorking = state.sessions[conversationId]?.pendingInterrupt;
+        pendingAfterWorking = getPendingInterruptQueue(
+          state.sessions[conversationId],
+        );
         params.callbacks.onData({
           kind: "status-update",
           status: { state: "completed" },
@@ -913,11 +922,13 @@ describe("executeChatRuntime empty-content recovery", () => {
       set,
     );
 
-    expect(pendingAfterWorking).toMatchObject({
+    expect(pendingAfterWorking).toHaveLength(1);
+    expect(pendingAfterWorking[0]).toMatchObject({
       requestId: "perm-1",
       type: "permission",
       phase: "asked",
     });
+    expect(state.sessions[conversationId]?.pendingInterrupts).toEqual([]);
     expect(state.sessions[conversationId]?.pendingInterrupt).toBeNull();
     expect(state.sessions[conversationId]?.lastResolvedInterrupt).toBeNull();
   });
@@ -967,7 +978,9 @@ describe("executeChatRuntime empty-content recovery", () => {
       };
     };
 
-    let pendingAfterAlias = state.sessions[conversationId]?.pendingInterrupt;
+    let pendingAfterAlias = getPendingInterruptQueue(
+      state.sessions[conversationId],
+    );
     mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
       async (params: {
         callbacks: {
@@ -991,7 +1004,9 @@ describe("executeChatRuntime empty-content recovery", () => {
             },
           },
         });
-        pendingAfterAlias = state.sessions[conversationId]?.pendingInterrupt;
+        pendingAfterAlias = getPendingInterruptQueue(
+          state.sessions[conversationId],
+        );
         params.callbacks.onData({
           kind: "status-update",
           status: { state: "completed" },
@@ -1025,12 +1040,185 @@ describe("executeChatRuntime empty-content recovery", () => {
       { runtimeStatusContract: customRuntimeStatusContract },
     );
 
-    expect(pendingAfterAlias).toMatchObject({
+    expect(pendingAfterAlias).toHaveLength(1);
+    expect(pendingAfterAlias[0]).toMatchObject({
       requestId: "perm-contract-1",
       type: "permission",
       phase: "asked",
     });
     expect(state.sessions[conversationId]?.runtimeStatus).toBe("completed");
+  });
+
+  it("queues multiple pending interrupts and advances by matching request id", async () => {
+    const conversationId = "conv-interrupt-queue-1";
+    const agentId = "agent-interrupt-queue-1";
+    const userMessageId = "user-msg-interrupt-queue-1";
+    const agentMessageId = "agent-msg-interrupt-queue-1";
+
+    addConversationMessage(conversationId, {
+      id: userMessageId,
+      role: "user",
+      content: "hello",
+      createdAt: "2026-03-12T07:45:00.000Z",
+      status: "done",
+    });
+    addConversationMessage(conversationId, {
+      id: agentMessageId,
+      role: "agent",
+      content: "",
+      blocks: [],
+      createdAt: "2026-03-12T07:45:01.000Z",
+      status: "streaming",
+    });
+
+    let state: ChatRuntimeState = {
+      sessions: {
+        [conversationId]: {
+          ...createAgentSession(agentId),
+          streamState: "streaming",
+          lastUserMessageId: userMessageId,
+          lastAgentMessageId: agentMessageId,
+        },
+      },
+    };
+
+    const get = () => state;
+    const set: ChatRuntimeSetState<ChatRuntimeState> = (partial) => {
+      const next =
+        typeof partial === "function"
+          ? partial(state as ChatRuntimeState)
+          : partial;
+      state = {
+        ...state,
+        ...(next as Partial<ChatRuntimeState>),
+      };
+    };
+
+    const queueSnapshots: string[][] = [];
+    mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
+      async (params: {
+        callbacks: {
+          onData: (data: Record<string, unknown>) => boolean | void;
+        };
+      }) => {
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "input-required" },
+          final: false,
+          metadata: {
+            shared: {
+              interrupt: {
+                request_id: "perm-1",
+                type: "permission",
+                phase: "asked",
+                details: {
+                  permission: "read",
+                  patterns: ["/repo/.env"],
+                },
+              },
+            },
+          },
+        });
+        queueSnapshots.push(
+          getPendingInterruptQueue(state.sessions[conversationId]).map(
+            (interrupt) => interrupt.requestId,
+          ),
+        );
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "auth-required" },
+          final: false,
+          metadata: {
+            shared: {
+              interrupt: {
+                request_id: "perm-2",
+                type: "permission",
+                phase: "asked",
+                details: {
+                  permission: "write",
+                  patterns: ["/repo/src/**"],
+                },
+              },
+            },
+          },
+        });
+        queueSnapshots.push(
+          getPendingInterruptQueue(state.sessions[conversationId]).map(
+            (interrupt) => interrupt.requestId,
+          ),
+        );
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "working" },
+          final: false,
+          metadata: {
+            shared: {
+              interrupt: {
+                request_id: "perm-2",
+                type: "permission",
+                phase: "resolved",
+                resolution: "replied",
+              },
+            },
+          },
+        });
+        queueSnapshots.push(
+          getPendingInterruptQueue(state.sessions[conversationId]).map(
+            (interrupt) => interrupt.requestId,
+          ),
+        );
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "working" },
+          final: false,
+          metadata: {
+            shared: {
+              interrupt: {
+                request_id: "perm-1",
+                type: "permission",
+                phase: "resolved",
+                resolution: "replied",
+              },
+            },
+          },
+        });
+        queueSnapshots.push(
+          getPendingInterruptQueue(state.sessions[conversationId]).map(
+            (interrupt) => interrupt.requestId,
+          ),
+        );
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "completed" },
+          final: true,
+        });
+        return true;
+      },
+    );
+
+    await executeChatRuntime(
+      conversationId,
+      agentId,
+      "personal",
+      {
+        query: "hello",
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      },
+      agentMessageId,
+      get,
+      set,
+    );
+
+    expect(queueSnapshots).toEqual([
+      ["perm-1"],
+      ["perm-1", "perm-2"],
+      ["perm-1"],
+      [],
+    ]);
+    expect(state.sessions[conversationId]?.pendingInterrupts).toEqual([]);
+    expect(state.sessions[conversationId]?.pendingInterrupt).toBeNull();
   });
 
   it("records resolved interrupt state and only clears matching pending interrupt", async () => {
@@ -1060,15 +1248,17 @@ describe("executeChatRuntime empty-content recovery", () => {
         [conversationId]: {
           ...createAgentSession(agentId),
           streamState: "streaming",
-          pendingInterrupt: {
-            requestId: "perm-1",
-            type: "permission",
-            phase: "asked",
-            details: {
-              permission: "read",
-              patterns: ["/repo/.env"],
+          ...buildPendingInterruptState([
+            {
+              requestId: "perm-1",
+              type: "permission",
+              phase: "asked",
+              details: {
+                permission: "read",
+                patterns: ["/repo/.env"],
+              },
             },
-          },
+          ]),
           lastUserMessageId: userMessageId,
           lastAgentMessageId: agentMessageId,
         },
@@ -1147,6 +1337,7 @@ describe("executeChatRuntime empty-content recovery", () => {
       set,
     );
 
+    expect(state.sessions[conversationId]?.pendingInterrupts).toEqual([]);
     expect(state.sessions[conversationId]?.pendingInterrupt).toBeNull();
     expect(state.sessions[conversationId]?.lastResolvedInterrupt).toMatchObject(
       {

--- a/frontend/store/chat.ts
+++ b/frontend/store/chat.ts
@@ -3,11 +3,14 @@ import { persist } from "zustand/middleware";
 
 import { type RuntimeStatusContract } from "@/lib/api/chat-utils";
 import {
+  buildPendingInterruptState,
   buildPersistedSessions,
   buildInvokePayload,
   buildSessionCleanupPlan,
   createAgentSession,
   getSharedModelSelection,
+  getPendingInterruptQueue,
+  hasPendingInterrupt,
   mergeExternalSessionRef,
   sortSessionsByLastActive,
   withSharedModelSelection,
@@ -272,10 +275,19 @@ export const useChatStore = create<ChatState>()(
       clearPendingInterrupt: (conversationId, requestId) => {
         set((state) => {
           const current = state.sessions[conversationId];
-          if (!current?.pendingInterrupt) {
+          if (!current) {
             return state;
           }
-          if (requestId && current.pendingInterrupt.requestId !== requestId) {
+          const currentQueue = getPendingInterruptQueue(current);
+          if (currentQueue.length === 0) {
+            return state;
+          }
+          const nextQueue = requestId
+            ? currentQueue.filter(
+                (interrupt) => interrupt.requestId !== requestId,
+              )
+            : [];
+          if (nextQueue.length === currentQueue.length) {
             return state;
           }
           return {
@@ -283,7 +295,7 @@ export const useChatStore = create<ChatState>()(
               ...state.sessions,
               [conversationId]: {
                 ...current,
-                pendingInterrupt: null,
+                ...buildPendingInterruptState(nextQueue),
               },
             },
           };
@@ -410,7 +422,7 @@ export const useChatStore = create<ChatState>()(
           }
           if (
             targetSession.streamState === "idle" &&
-            targetSession.pendingInterrupt == null &&
+            !hasPendingInterrupt(targetSession) &&
             targetSession.lastStreamError == null
           ) {
             return state;
@@ -421,7 +433,7 @@ export const useChatStore = create<ChatState>()(
               [targetConversationId]: {
                 ...targetSession,
                 streamState: "idle",
-                pendingInterrupt: null,
+                ...buildPendingInterruptState([]),
                 lastStreamError: null,
               },
             },
@@ -474,7 +486,7 @@ export const useChatStore = create<ChatState>()(
               lastAgentMessageId: agentMessage.id,
               lastReceivedSequence: undefined,
               transport: chatConnectionService.getPreferredTransport(),
-              pendingInterrupt: null,
+              ...buildPendingInterruptState([]),
             },
           },
         }));
@@ -557,7 +569,7 @@ export const useChatStore = create<ChatState>()(
               lastUserMessageId: userMessageId,
               lastAgentMessageId: agentMessageId,
               lastReceivedSequence: undefined,
-              pendingInterrupt: null,
+              ...buildPendingInterruptState([]),
             },
           },
         }));

--- a/frontend/store/chatRuntime.ts
+++ b/frontend/store/chatRuntime.ts
@@ -24,6 +24,8 @@ import {
 import { invokeHubAgent } from "@/lib/api/hubA2aAgentsUser";
 import { listSessionMessagesPage } from "@/lib/api/sessions";
 import {
+  buildPendingInterruptState,
+  getPendingInterruptQueue,
   mergeExternalSessionRef,
   type AgentSession,
   type ResolvedRuntimeInterruptRecord,
@@ -137,6 +139,21 @@ const isSameResolvedInterrupt = (
     lhs.type === rhs.type &&
     lhs.phase === rhs.phase &&
     lhs.resolution === rhs.resolution
+  );
+};
+
+const arePendingInterruptQueuesEqual = (
+  left: PendingRuntimeInterrupt[],
+  right: PendingRuntimeInterrupt[],
+) => {
+  if (left === right) {
+    return true;
+  }
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((item, index) =>
+    isSamePendingInterrupt(item, right[index]),
   );
 };
 
@@ -289,7 +306,7 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
     patchSession({
       streamState: "idle",
       lastStreamError: null,
-      pendingInterrupt: null,
+      ...buildPendingInterruptState([]),
     });
   };
 
@@ -321,17 +338,24 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
         nextPatch.runtimeStatus = meta.runtimeStatus;
       }
       if (meta.runtimeInterruptEvent?.phase === "asked") {
-        if (
-          !isSamePendingInterrupt(
-            current.pendingInterrupt,
-            meta.runtimeInterruptEvent,
-          )
-        ) {
-          nextPatch.pendingInterrupt = meta.runtimeInterruptEvent;
+        const askedInterrupt = meta.runtimeInterruptEvent;
+        const currentQueue = getPendingInterruptQueue(current);
+        const existingIndex = currentQueue.findIndex(
+          (interrupt) => interrupt.requestId === askedInterrupt.requestId,
+        );
+        const nextQueue =
+          existingIndex >= 0
+            ? currentQueue.map((interrupt, index) =>
+                index === existingIndex ? askedInterrupt : interrupt,
+              )
+            : [...currentQueue, askedInterrupt];
+        if (!arePendingInterruptQueuesEqual(currentQueue, nextQueue)) {
+          Object.assign(nextPatch, buildPendingInterruptState(nextQueue));
         }
       } else if (meta.runtimeInterruptEvent?.phase === "resolved") {
+        const resolvedRuntimeInterrupt = meta.runtimeInterruptEvent;
         const resolvedInterrupt: ResolvedRuntimeInterruptRecord = {
-          ...meta.runtimeInterruptEvent,
+          ...resolvedRuntimeInterrupt,
           observedAt: new Date().toISOString(),
         };
         if (
@@ -342,13 +366,14 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
         ) {
           nextPatch.lastResolvedInterrupt = resolvedInterrupt;
         }
-        if (
-          current.pendingInterrupt &&
-          current.pendingInterrupt.requestId ===
-            meta.runtimeInterruptEvent.requestId
-        ) {
-          // Only a matching resolved event should close the current action card.
-          nextPatch.pendingInterrupt = null;
+        const currentQueue = getPendingInterruptQueue(current);
+        const nextQueue = currentQueue.filter(
+          (interrupt) =>
+            interrupt.requestId !== resolvedRuntimeInterrupt.requestId,
+        );
+        if (!arePendingInterruptQueuesEqual(currentQueue, nextQueue)) {
+          // Only a matching resolved event should close the corresponding action card.
+          Object.assign(nextPatch, buildPendingInterruptState(nextQueue));
         }
       }
       if (
@@ -872,7 +897,7 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
     patchSession({
       streamState: "error",
       lastStreamError: normalizedErrorMessage,
-      pendingInterrupt: null,
+      ...buildPendingInterruptState([]),
     });
     warnStreamOnce(
       `error:${conversationId}:${errorText}`,
@@ -1098,7 +1123,7 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
     patchSession({
       streamState: "error",
       lastStreamError: message,
-      pendingInterrupt: null,
+      ...buildPendingInterruptState([]),
     });
     return;
   }


### PR DESCRIPTION
## 概述
- 将会话状态从单个 `pendingInterrupt` 升级为 `pendingInterrupts` 有序队列，保持 UI 默认串行展示队首。
- 新增队列辅助函数，兼容旧的持久化会话数据，并在 resolved / 本地清理时按 `requestId` 精确移除。
- 在中断卡片和输入区补充排队提示，用户处理完当前请求后会自动进入下一个待处理请求。

## 模块变更
### 状态与流处理
- `frontend/lib/chat-utils.ts`：新增 pending interrupt 队列读取与构建辅助函数。
- `frontend/store/chatRuntime.ts`：遇到多个 `permission/question asked` 时按到达顺序入队；收到 `resolved` 时仅移除匹配 `requestId`。
- `frontend/store/chat.ts`：本地清理、取消、重新发送时按队列模型清空或精确删除。

### 控制器与界面
- `frontend/hooks/useChatScreenController.ts`：从会话中派生当前队首 interrupt 和队列长度。
- `frontend/components/chat/InterruptActionCard.tsx` / `ChatComposer.tsx` / `ChatTimelinePanel.tsx` / `screens/ChatScreen.tsx`：继续串行展示当前 interrupt，并提示后续仍有待处理请求。

### 测试
- `frontend/store/__tests__/chatRuntime.test.ts`：新增同会话多个 interrupt 排队、按 `requestId` 解析推进的回归测试。
- `frontend/lib/__tests__/chat-utils.test.ts`：补充队列辅助函数与旧状态兼容测试。
- 组件测试同步适配新的 `pendingInterruptCount` 入参。

### 文档
- 本 PR 无需更新文档；当前变更仅影响前端会话状态、交互控制器与回归测试。

## 验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/chat/ChatComposer.tsx components/chat/ChatTimelinePanel.tsx components/chat/InterruptActionCard.tsx components/chat/__tests__/ChatComposer.test.tsx components/chat/__tests__/InterruptActionCard.test.tsx hooks/useChatScreenController.ts lib/__tests__/chat-utils.test.ts lib/chat-utils.ts screens/ChatScreen.tsx store/__tests__/chatRuntime.test.ts store/chat.ts store/chatRuntime.ts --maxWorkers=25%`
- 结果：39 个相关测试套件、202 个测试全部通过。

Closes #575
