### PR TITLE
fix(frontend): handle chunk seq resets after interrupt resume (#577)

### DIFF
--- a/frontend/store/__tests__/chatRuntime.test.ts
+++ b/frontend/store/__tests__/chatRuntime.test.ts
@@ -1348,6 +1348,174 @@ describe("executeChatRuntime empty-content recovery", () => {
       },
     );
   });
+
+  it("continues rendering chunks after interrupt resolution when upstream seq restarts", async () => {
+    const conversationId = "conv-interrupt-resume-seq-reset-1";
+    const agentId = "agent-interrupt-resume-seq-reset-1";
+    const userMessageId = "user-msg-interrupt-resume-seq-reset-1";
+    const agentMessageId = "agent-msg-interrupt-resume-seq-reset-1";
+
+    addConversationMessage(conversationId, {
+      id: userMessageId,
+      role: "user",
+      content: "hello",
+      createdAt: "2026-03-21T08:10:00.000Z",
+      status: "done",
+    });
+    addConversationMessage(conversationId, {
+      id: agentMessageId,
+      role: "agent",
+      content: "",
+      blocks: [],
+      createdAt: "2026-03-21T08:10:01.000Z",
+      status: "streaming",
+    });
+
+    let state: ChatRuntimeState = {
+      sessions: {
+        [conversationId]: {
+          ...createAgentSession(agentId),
+          streamState: "streaming",
+          lastUserMessageId: userMessageId,
+          lastAgentMessageId: agentMessageId,
+        },
+      },
+    };
+
+    const get = () => state;
+    const set: ChatRuntimeSetState<ChatRuntimeState> = (partial) => {
+      const next =
+        typeof partial === "function"
+          ? partial(state as ChatRuntimeState)
+          : partial;
+      state = {
+        ...state,
+        ...(next as Partial<ChatRuntimeState>),
+      };
+    };
+
+    let contentDuringResume = "";
+    mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
+      async (params: {
+        callbacks: {
+          onData: (data: Record<string, unknown>) => boolean | void;
+        };
+      }) => {
+        params.callbacks.onData({
+          kind: "artifact-update",
+          message_id: agentMessageId,
+          event_id: `${agentMessageId}:1`,
+          seq: 1,
+          append: true,
+          artifact: {
+            artifactId: `${agentMessageId}:stream:1`,
+            parts: [{ kind: "text", text: "Before interrupt. " }],
+            metadata: {
+              shared: {
+                stream: {
+                  block_type: "text",
+                  source: "assistant_text",
+                  message_id: agentMessageId,
+                  event_id: `${agentMessageId}:1`,
+                  sequence: 1,
+                },
+              },
+            },
+          },
+        });
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "input-required" },
+          final: false,
+          metadata: {
+            shared: {
+              interrupt: {
+                request_id: "perm-resume-1",
+                type: "permission",
+                phase: "asked",
+                details: {
+                  permission: "read",
+                  patterns: ["/repo/.env"],
+                },
+              },
+            },
+          },
+        });
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "working" },
+          final: false,
+          metadata: {
+            shared: {
+              interrupt: {
+                request_id: "perm-resume-1",
+                type: "permission",
+                phase: "resolved",
+                resolution: "replied",
+              },
+            },
+          },
+        });
+        params.callbacks.onData({
+          kind: "artifact-update",
+          message_id: agentMessageId,
+          event_id: `${agentMessageId}:resume:1`,
+          seq: 1,
+          append: true,
+          artifact: {
+            artifactId: `${agentMessageId}:stream:resume:1`,
+            parts: [{ kind: "text", text: "After resume." }],
+            metadata: {
+              shared: {
+                stream: {
+                  block_type: "text",
+                  source: "assistant_text",
+                  message_id: agentMessageId,
+                  event_id: `${agentMessageId}:resume:1`,
+                  sequence: 1,
+                },
+              },
+            },
+          },
+        });
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        contentDuringResume =
+          getConversationMessages(conversationId).find(
+            (message) => message.id === agentMessageId,
+          )?.content ?? "";
+        params.callbacks.onData({
+          kind: "status-update",
+          status: { state: "completed" },
+          final: true,
+        });
+        return true;
+      },
+    );
+
+    await executeChatRuntime(
+      conversationId,
+      agentId,
+      "personal",
+      {
+        query: "hello",
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      },
+      agentMessageId,
+      get,
+      set,
+    );
+
+    expect(contentDuringResume).toContain("Before interrupt.");
+    expect(contentDuringResume).toContain("After resume.");
+    expect(mockedListSessionMessagesPage).not.toHaveBeenCalled();
+    expect(
+      getConversationMessages(conversationId).find(
+        (message) => message.id === agentMessageId,
+      )?.content,
+    ).toContain("After resume.");
+  });
 });
 
 describe("executeChatRuntime failure handling", () => {

--- a/frontend/store/chatRuntime.ts
+++ b/frontend/store/chatRuntime.ts
@@ -277,6 +277,7 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
     string,
     Map<number, StreamBlockUpdate>
   >();
+  const resettableSeqByMessageId = new Set<string>();
   let terminalHandled = false;
   let hasObservedStreamEvent = false;
   let highestReceivedSequence =
@@ -769,7 +770,19 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
       });
     }
 
-    const currentExpected = nextExpectedSeqByMessageId.get(chunk.messageId);
+    let currentExpected = nextExpectedSeqByMessageId.get(chunk.messageId);
+    if (
+      typeof currentExpected === "number" &&
+      chunk.seq < currentExpected &&
+      resettableSeqByMessageId.has(chunk.messageId)
+    ) {
+      // Some upstreams restart per-message chunk sequence after an interrupt is
+      // resolved. Treat the resumed chunk stream as a new ordered segment.
+      resettableSeqByMessageId.delete(chunk.messageId);
+      nextExpectedSeqByMessageId.delete(chunk.messageId);
+      pendingChunksByMessageId.delete(chunk.messageId);
+      currentExpected = undefined;
+    }
     if (typeof currentExpected === "number" && chunk.seq < currentExpected) {
       return;
     }
@@ -828,6 +841,9 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
           messageId: activeAgentMessageId,
         }),
       );
+      if (runtimeStatusEvent.interrupt.phase === "resolved") {
+        resettableSeqByMessageId.add(activeAgentMessageId);
+      }
     }
 
     const meta = extractSessionMeta(data);


### PR DESCRIPTION
## 关联 Issues
- Closes #577

## 模块变更
### frontend/store
- 在 `chatRuntime` 中为 interrupt resolved 后的同消息续流增加一次性 `seq` 重起容错。
- 当该消息后续收到比当前期望值更小的 `seq` 时，允许将其识别为恢复后的新有序片段，而不是直接按旧包丢弃。
- 该重起逻辑只在 interrupt resolved 后对对应消息生效，避免放宽普通流式场景下的有序约束。

### frontend/store/__tests__
- 新增回归测试，复现“interrupt resolved 后同一消息的上游 chunk `seq` 从较小值重新开始”的场景。
- 断言恢复后的正文会继续实时渲染，且不需要依赖 history backfill 才显示最终内容。

## 代码审查结论
### 实现合理性
- 本次改动直接命中已定位根因：前端对同一 `message_id` 的 chunk 使用严格递增 `seq` 排序，导致恢复后的合法 chunk 被误判为旧包。
- 修复点放在前端 runtime 的入流排序层，位置正确，没有把问题转嫁到渲染层或 history fallback。
- 测试覆盖了最关键的回归链路，能够防止同类问题再次引入。

### 风险与边界
- 当前实现假设 interrupt resolved 之后出现的更小 `seq` 属于同消息恢复后的新片段；这与当前现象和传输顺序模型一致。
- 由于该放宽是一次性的、按消息粒度启用，风险范围可控。
- 本 PR 未引入文档文件变更；现有 issue 与 PR 的关系准确，使用 `Closes #577` 合适，不需要补充额外 `related` 或 `closes` 项。

## 验证结果
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests store/chatRuntime.ts store/__tests__/chatRuntime.test.ts --maxWorkers=25%`

以上命令已本地串行执行通过。
