### PR TITLE
fix(streaming): canonicalize history backfill message projection (#581)

### DIFF
--- a/backend/app/features/sessions/block_store.py
+++ b/backend/app/features/sessions/block_store.py
@@ -108,6 +108,32 @@ async def find_last_block_for_message(
     return cast(AgentMessageBlock | None, await db.scalar(stmt))
 
 
+async def find_last_block_for_message_and_type(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    message_id: UUID,
+    block_type: str,
+) -> AgentMessageBlock | None:
+    stmt = (
+        select(AgentMessageBlock)
+        .where(
+            and_(
+                AgentMessageBlock.user_id == user_id,
+                AgentMessageBlock.message_id == message_id,
+                AgentMessageBlock.block_type == block_type,
+            )
+        )
+        .order_by(
+            AgentMessageBlock.block_seq.desc(),
+            AgentMessageBlock.created_at.desc(),
+            AgentMessageBlock.id.desc(),
+        )
+        .limit(1)
+    )
+    return cast(AgentMessageBlock | None, await db.scalar(stmt))
+
+
 async def create_block(
     db: AsyncSession,
     *,
@@ -164,6 +190,7 @@ __all__ = [
     "create_block",
     "find_block_by_message_and_block_seq",
     "find_last_block_for_message",
+    "find_last_block_for_message_and_type",
     "has_blocks_for_message",
     "list_blocks_by_message_id",
     "list_blocks_by_message_ids",

--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -63,6 +63,7 @@ INFLIGHT_CANCEL_TERMINAL_ERROR_CODES = {
     "task_not_cancelable",
     "invalid_task_id",
 }
+PRIMARY_TEXT_SNAPSHOT_SOURCES = frozenset({"final_snapshot", "finalize_snapshot"})
 
 
 def parse_conversation_id(value: str) -> UUID:
@@ -180,6 +181,8 @@ def derive_session_title_from_query(query: str) -> str | None:
 
 def normalize_block_type(raw_type: str | None) -> str:
     normalized = (raw_type or "").strip().lower()
+    if not normalized:
+        return "text"
     if normalized in {
         "text",
         "reasoning",
@@ -188,7 +191,7 @@ def normalize_block_type(raw_type: str | None) -> str:
         "system_error",
     }:
         return normalized
-    return "text"
+    return normalized
 
 
 def normalize_interrupt_lifecycle_event(
@@ -352,6 +355,10 @@ def write_block_cursor_state(metadata: dict[str, Any], cursor: dict[str, int]) -
     }
 
 
+def is_primary_text_snapshot_source(source: str | None) -> bool:
+    return normalize_non_empty_text(source) in PRIMARY_TEXT_SNAPSHOT_SOURCES
+
+
 def render_block_item(
     block: AgentMessageBlock,
     *,
@@ -386,6 +393,46 @@ def render_blocks(
     message_status: str | None = None,
 ) -> list[dict[str, Any]]:
     return [render_block_item(block, message_status=message_status) for block in blocks]
+
+
+def project_message_blocks(
+    blocks: list[AgentMessageBlock],
+    *,
+    message_status: str | None = None,
+) -> tuple[list[dict[str, Any]], str]:
+    projected_blocks: list[dict[str, Any]] = []
+
+    for block in blocks:
+        block_type = normalize_block_type(cast(str | None, block.block_type))
+        rendered = render_block_item(block, message_status=message_status)
+        if block_type == "text" and is_primary_text_snapshot_source(
+            cast(str | None, block.source)
+        ):
+            # History list views expose a canonical read model rather than raw
+            # persistence rows, so a final text snapshot rewrites the last text slot.
+            target_index = next(
+                (
+                    index
+                    for index in range(len(projected_blocks) - 1, -1, -1)
+                    if str(projected_blocks[index].get("type") or "") == "text"
+                ),
+                None,
+            )
+            if target_index is not None:
+                projected_blocks[target_index] = {
+                    **projected_blocks[target_index],
+                    "content": rendered.get("content", ""),
+                    "isFinished": rendered.get("isFinished", True),
+                }
+                continue
+        projected_blocks.append(rendered)
+
+    content = "".join(
+        str(block.get("content") or "")
+        for block in projected_blocks
+        if str(block.get("type") or "") == "text"
+    )
+    return projected_blocks, content
 
 
 def render_block_detail_item(

--- a/backend/app/features/sessions/history_projection.py
+++ b/backend/app/features/sessions/history_projection.py
@@ -24,6 +24,7 @@ from app.features.sessions.common import (
     derive_session_title_from_query,
     is_agent_message_pk_violation,
     is_idempotency_unique_violation,
+    is_primary_text_snapshot_source,
     normalize_block_type,
     normalize_interrupt_lifecycle_event,
     read_block_cursor_state,
@@ -800,6 +801,9 @@ class SessionHistoryProjectionService:
             "finalize_snapshot",
         }
         active_block_seq = cursor_state["active_block_seq"]
+        allow_snapshot_text_rewrite = normalized_type == "text" and (
+            is_primary_text_snapshot_source(normalized_source)
+        )
 
         active_block: AgentMessageBlock | None = None
         if active_block_seq > 0:
@@ -815,34 +819,59 @@ class SessionHistoryProjectionService:
                 user_id=user_id,
                 message_id=agent_message_id,
             )
+        overwrite_target = active_block
+        if allow_snapshot_text_rewrite:
+            # Final text snapshots are authoritative for the existing primary text
+            # lane even if a non-text block was the most recent active block.
+            text_block = await block_store.find_last_block_for_message_and_type(
+                db,
+                user_id=user_id,
+                message_id=agent_message_id,
+                block_type="text",
+            )
+            if text_block is not None:
+                overwrite_target = text_block
 
         persisted_block: AgentMessageBlock | None = None
         if overwrite:
             if (
-                active_block is not None
-                and cast(str | None, active_block.block_type) == normalized_type
-                and not bool(active_block.is_finished)
-            ):
-                setattr(active_block, "content", normalized_content)
-                setattr(active_block, "is_finished", bool(is_finished))
-                setattr(
-                    active_block,
-                    "source",
-                    normalized_source or cast(str | None, active_block.source),
+                overwrite_target is not None
+                and cast(str | None, overwrite_target.block_type) == normalized_type
+                and (
+                    not bool(overwrite_target.is_finished)
+                    or allow_snapshot_text_rewrite
                 )
-                active_start_event_seq = cast(int | None, active_block.start_event_seq)
+            ):
+                if (
+                    active_block is not None
+                    and overwrite_target is not active_block
+                    and not bool(active_block.is_finished)
+                ):
+                    setattr(active_block, "is_finished", True)
+                setattr(overwrite_target, "content", normalized_content)
+                setattr(overwrite_target, "is_finished", bool(is_finished))
+                setattr(
+                    overwrite_target,
+                    "source",
+                    normalized_source or cast(str | None, overwrite_target.source),
+                )
+                active_start_event_seq = cast(
+                    int | None, overwrite_target.start_event_seq
+                )
                 if active_start_event_seq is None:
-                    setattr(active_block, "start_event_seq", seq)
-                active_end_event_seq = cast(int | None, active_block.end_event_seq)
+                    setattr(overwrite_target, "start_event_seq", seq)
+                active_end_event_seq = cast(int | None, overwrite_target.end_event_seq)
                 if active_end_event_seq is None or seq >= active_end_event_seq:
-                    setattr(active_block, "end_event_seq", seq)
+                    setattr(overwrite_target, "end_event_seq", seq)
                 normalized_event_id = normalize_non_empty_text(event_id)
-                active_start_event_id = cast(str | None, active_block.start_event_id)
+                active_start_event_id = cast(
+                    str | None, overwrite_target.start_event_id
+                )
                 if normalized_event_id and not active_start_event_id:
-                    setattr(active_block, "start_event_id", normalized_event_id)
+                    setattr(overwrite_target, "start_event_id", normalized_event_id)
                 if normalized_event_id:
-                    setattr(active_block, "end_event_id", normalized_event_id)
-                persisted_block = active_block
+                    setattr(overwrite_target, "end_event_id", normalized_event_id)
+                persisted_block = overwrite_target
             else:
                 if active_block is not None and not bool(active_block.is_finished):
                     setattr(active_block, "is_finished", True)

--- a/backend/app/features/sessions/query_service.py
+++ b/backend/app/features/sessions/query_service.py
@@ -22,8 +22,8 @@ from app.features.sessions.common import (
     encode_messages_before_cursor,
     parse_conversation_id,
     parse_messages_before_cursor,
+    project_message_blocks,
     render_block_detail_item,
-    render_blocks,
     resolve_session_source,
     sender_priority_for_role,
     sender_to_role,
@@ -243,13 +243,18 @@ class SessionQueryService:
             status = (
                 normalize_non_empty_text(getattr(message, "status", None)) or "done"
             )
+            rendered_blocks, content = project_message_blocks(
+                raw_blocks,
+                message_status=status,
+            )
             items.append(
                 {
                     "id": str(message_id),
                     "role": role,
+                    "content": content,
                     "created_at": message.created_at,
                     "status": status,
-                    "blocks": render_blocks(raw_blocks, message_status=status),
+                    "blocks": rendered_blocks,
                 }
             )
 

--- a/backend/app/features/sessions/schemas.py
+++ b/backend/app/features/sessions/schemas.py
@@ -60,6 +60,7 @@ class SessionMessagesQueryRequest(BaseModel):
 class SessionMessageItem(BaseModel):
     id: str
     role: Literal["user", "agent", "system"]
+    content: str = ""
     created_at: datetime
     status: str
     blocks: list[SessionMessageBlockItem] = Field(default_factory=list)

--- a/backend/tests/sessions/test_session_hub_service.py
+++ b/backend/tests/sessions/test_session_hub_service.py
@@ -7,6 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models.agent_message import AgentMessage
+from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
 from app.features.sessions import (
     history_projection as session_history_projection_module,
@@ -1424,6 +1425,103 @@ async def test_list_messages_overwrite_preserves_block_boundaries(
     assert len(text_blocks) == 2
     assert text_blocks[0]["content"] == "first final"
     assert text_blocks[1]["content"] == "second final"
+
+
+async def test_interleaved_reasoning_final_snapshot_rewrites_primary_text_slot(
+    async_db_session,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    thread = ConversationThread(
+        user_id=user.id,
+        source=ConversationThread.SOURCE_SCHEDULED,
+        title="Scheduled Session",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(thread)
+    await async_db_session.flush()
+
+    refs = await session_hub_service.record_local_invoke_messages(
+        async_db_session,
+        session=thread,
+        source="scheduled",
+        user_id=user.id,
+        agent_id=uuid4(),
+        agent_source="personal",
+        query="hello",
+        response_content="",
+        success=False,
+        context_id="ctx-1",
+        idempotency_key="run:interleaved-final-snapshot:scheduled",
+    )
+
+    agent_message_id = refs["agent_message_id"]
+    await session_hub_service.append_agent_message_block_update(
+        async_db_session,
+        user_id=user.id,
+        agent_message_id=agent_message_id,
+        seq=1,
+        block_type="text",
+        content="draft",
+        append=True,
+        is_finished=False,
+        event_id="evt-1",
+        source=None,
+    )
+    await session_hub_service.append_agent_message_block_update(
+        async_db_session,
+        user_id=user.id,
+        agent_message_id=agent_message_id,
+        seq=2,
+        block_type="reasoning",
+        content="internal-plan",
+        append=False,
+        is_finished=True,
+        event_id="evt-2",
+        source="reasoning_part_update",
+    )
+    await session_hub_service.append_agent_message_block_update(
+        async_db_session,
+        user_id=user.id,
+        agent_message_id=agent_message_id,
+        seq=3,
+        block_type="text",
+        content="final answer",
+        append=False,
+        is_finished=True,
+        event_id="evt-3",
+        source="final_snapshot",
+    )
+    await async_db_session.flush()
+
+    persisted_blocks = list(
+        (
+            await async_db_session.scalars(
+                select(AgentMessageBlock)
+                .where(AgentMessageBlock.message_id == agent_message_id)
+                .order_by(AgentMessageBlock.block_seq.asc())
+            )
+        ).all()
+    )
+    text_blocks = [
+        block for block in persisted_blocks if str(block.block_type or "") == "text"
+    ]
+    assert len(text_blocks) == 1
+    assert text_blocks[0].content == "final answer"
+
+    message_items = await _list_message_items(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=str(thread.id),
+    )
+    agent_item = next(item for item in message_items if item.get("role") == "agent")
+    assert agent_item["content"] == "final answer"
+    assert [block["type"] for block in agent_item["blocks"]] == [
+        "text",
+        "reasoning",
+    ]
+    assert agent_item["blocks"][0]["content"] == "final answer"
+    assert agent_item["blocks"][1]["content"] == ""
 
 
 async def test_append_agent_message_block_update_unique_conflict_does_not_rollback_session(

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -164,6 +164,8 @@ async def test_conversation_routes_use_conversation_id_only(
         )
         assert messages_user_item["id"] == str(user_message.id)
         assert messages_agent_item["id"] == str(agent_message.id)
+        assert messages_user_item["content"] == "hello"
+        assert messages_agent_item["content"] == "world"
         assert len(messages_user_item["blocks"]) == 1
         assert len(messages_agent_item["blocks"]) == 2
         assert messages_agent_item["blocks"][0]["content"] == "world"

--- a/frontend/lib/__tests__/sessionHistory.test.ts
+++ b/frontend/lib/__tests__/sessionHistory.test.ts
@@ -227,4 +227,33 @@ describe("session history mapping", () => {
       },
     });
   });
+
+  it("prefers server-provided content over recomputing text from blocks", () => {
+    const mapped = mapSessionMessagesToChatMessages([
+      {
+        id: "msg-projected-1",
+        role: "agent",
+        created_at: "2026-03-21T00:00:00.000Z",
+        content: "final answer",
+        blocks: [
+          {
+            id: "text-block-1",
+            type: "text",
+            content: "draft",
+            isFinished: true,
+          },
+          {
+            id: "reasoning-block-1",
+            type: "reasoning",
+            content: "",
+            isFinished: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(mapped).toHaveLength(1);
+    expect(mapped[0]?.content).toBe("final answer");
+    expect(mapped[0]?.blocks?.[0]?.content).toBe("draft");
+  });
 });

--- a/frontend/lib/api/sessions.ts
+++ b/frontend/lib/api/sessions.ts
@@ -42,6 +42,7 @@ export type SessionMessageBlockDetailItem = {
 export type SessionMessageItem = {
   id: string;
   role: "user" | "agent" | "system";
+  content?: string;
   created_at: string;
   status?: string;
   blocks?: SessionMessageBlockItem[];

--- a/frontend/lib/sessionHistory.ts
+++ b/frontend/lib/sessionHistory.ts
@@ -9,6 +9,7 @@ import {
 export type SessionMessageItem = {
   id: string;
   role: string;
+  content?: string;
   created_at: string;
   status?: string;
   blocks?: {
@@ -99,9 +100,15 @@ export const mapSessionMessagesToChatMessages = (
       return;
     }
     const blocks = mapBlocks(item);
+    const serviceContent =
+      typeof item.content === "string" ? item.content : undefined;
     const blockContent = projectPrimaryTextContent(blocks);
     const normalizedContent =
-      blockContent.trim().length > 0 ? blockContent : "";
+      typeof serviceContent === "string"
+        ? serviceContent
+        : blockContent.trim().length > 0
+          ? blockContent
+          : "";
     if (
       normalizedContent.trim().length === 0 &&
       blocks.length === 0 &&


### PR DESCRIPTION
## 关联 issue

Closes #581

## 背景

本次问题不在 live streaming 渲染阶段，而在 history backfill / 历史回填阶段：

- 服务端历史消息接口此前直接暴露原始持久化 blocks
- 前端回填时会再基于 blocks 重算消息主文本
- `final_snapshot` 只覆盖当前 active block，跨过 `reasoning` / `tool_call` 后可能形成额外 text block

结果是：streaming 过程中看起来正常，但回填后主文本被额外 text block 污染，出现推理内容混入文本展示的现象。

## 本次改动

### Backend / Sessions Read Model

- 为历史消息查询增加 canonical projector，由服务端统一生成权威 `content`
- 历史消息列表不再把原始持久化 blocks 原样透传给前端，而是输出 canonical blocks + canonical content
- `final_snapshot` / `finalize_snapshot` 在 history read model 中会回写最近的 text 槽位，避免生成额外可见 text block
- block type 规范收紧：未知类型不再静默降级为 `text`

### Backend / Sessions Persistence

- 在块持久化路径中，为文本 final snapshot 增加“回写最近 text block”的语义
- 当最近 active block 是 `reasoning` 等非文本块时，文本快照会重定向到最近的 text block
- 避免 `text -> reasoning -> text final_snapshot` 形成重复 text block 并污染回填结果

### Frontend / History Mapping

- 回填映射优先使用服务端返回的权威 `content`
- 前端不再把 blocks 当成主文本的唯一事实来源
- 保留对旧响应形态的 fallback，但新契约以下游服务端 read model 为准

### Tests

- 新增后端集成回归，覆盖 `text -> reasoning -> final_snapshot -> history` 场景
- 补充历史消息接口 `content` 输出断言
- 新增前端回填映射回归，覆盖“服务端权威 content 优先于本地 blocks 重算”

## 边界说明

- 本 PR 解决的是后续回填链路的 canonical 投影问题，不包含对既有历史脏数据的离线迁移或修复脚本
- 如线上已经存在被污染的旧消息记录，是否需要补数据修复，应另起 issue 评估

## 验证

### Backend

- `cd backend && uv run pre-commit run --files app/features/sessions/block_store.py app/features/sessions/common.py app/features/sessions/history_projection.py app/features/sessions/query_service.py app/features/sessions/schemas.py tests/sessions/test_session_hub_service.py tests/sessions/test_unified_session_domain_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/sessions/test_session_hub_service.py tests/sessions/test_unified_session_domain_routes.py`

### Frontend

- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/sessionHistory.ts lib/api/sessions.ts lib/__tests__/sessionHistory.test.ts --maxWorkers=25%`
