### PR TITLE
feat(chat): unify interrupt lifecycle blocks

### DIFF
--- a/backend/app/features/invoke/route_runner.py
+++ b/backend/app/features/invoke/route_runner.py
@@ -76,7 +76,7 @@ from app.features.invoke.stream_persistence import (
 from app.features.invoke.stream_persistence import (
     persist_synthetic_final_block_if_needed as persist_synthetic_final_block_if_needed_impl,
 )
-from app.features.sessions.common import build_interrupt_lifecycle_message_content
+from app.features.sessions.common import serialize_interrupt_event_block_content
 from app.features.sessions.service import session_hub_service
 from app.integrations.a2a_extensions import get_a2a_extensions_service
 from app.integrations.a2a_extensions.errors import (
@@ -808,7 +808,7 @@ async def _persist_interrupt_lifecycle_event(
         transport=transport,
         stream_enabled=stream_enabled,
         stream_service=a2a_invoke_service,
-        build_interrupt_message_content=build_interrupt_lifecycle_message_content,
+        build_interrupt_message_content=serialize_interrupt_event_block_content,
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,

--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -329,6 +329,82 @@ def build_interrupt_lifecycle_message_content(event: dict[str, Any]) -> str:
     return "Agent requested additional input."
 
 
+def build_interrupt_block_view(event: dict[str, Any]) -> dict[str, Any]:
+    normalized_event = normalize_interrupt_lifecycle_event(event)
+    if normalized_event is None:
+        raise ValueError("invalid_interrupt_event")
+
+    item: dict[str, Any] = {
+        "requestId": normalized_event["request_id"],
+        "type": normalized_event["type"],
+        "phase": normalized_event["phase"],
+    }
+    if normalized_event["phase"] == "resolved":
+        item["resolution"] = normalized_event["resolution"]
+        return item
+
+    details = normalized_event.get("details")
+    normalized_details = details if isinstance(details, dict) else {}
+    raw_patterns = normalized_details.get("patterns")
+    raw_questions = normalized_details.get("questions")
+    item["details"] = {
+        "permission": normalize_non_empty_text(normalized_details.get("permission")),
+        "patterns": (
+            [pattern for pattern in raw_patterns if isinstance(pattern, str)]
+            if isinstance(raw_patterns, list)
+            else []
+        ),
+        "displayMessage": normalize_non_empty_text(
+            normalized_details.get("display_message")
+            or normalized_details.get("displayMessage")
+        ),
+        "questions": (
+            [item for item in raw_questions if isinstance(item, dict)]
+            if isinstance(raw_questions, list)
+            else []
+        ),
+    }
+    return item
+
+
+def serialize_interrupt_event_block_content(event: dict[str, Any]) -> str:
+    normalized_event = normalize_interrupt_lifecycle_event(event)
+    if normalized_event is None:
+        raise ValueError("invalid_interrupt_event")
+
+    payload = {
+        "kind": "interrupt_event",
+        "schemaVersion": 1,
+        "interrupt": normalized_event,
+        "content": build_interrupt_lifecycle_message_content(normalized_event),
+    }
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def deserialize_interrupt_event_block_content(
+    raw_content: str | None,
+) -> tuple[str, dict[str, Any] | None]:
+    normalized_raw_content = raw_content or ""
+    try:
+        payload = json.loads(normalized_raw_content)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return normalized_raw_content, None
+
+    if not isinstance(payload, dict) or payload.get("kind") != "interrupt_event":
+        return normalized_raw_content, None
+
+    normalized_event = normalize_interrupt_lifecycle_event(
+        cast(dict[str, Any] | None, payload.get("interrupt"))
+    )
+    if normalized_event is None:
+        return normalized_raw_content, None
+
+    content = normalize_non_empty_text(payload.get("content")) or (
+        build_interrupt_lifecycle_message_content(normalized_event)
+    )
+    return content, build_interrupt_block_view(normalized_event)
+
+
 def read_block_cursor_state(metadata: dict[str, Any]) -> dict[str, int]:
     raw_cursor = metadata.get("_block_cursor")
     cursor = raw_cursor if isinstance(raw_cursor, dict) else {}
@@ -368,12 +444,15 @@ def render_block_item(
     raw_content = block_content or ""
     block_type = normalize_block_type(cast(str | None, block.block_type))
     tool_call = None
+    interrupt = None
     if block_type == "tool_call":
         tool_call = build_tool_call_view(
             raw_content,
             is_finished=bool(block.is_finished),
             message_status=message_status,
         )
+    if block_type == "interrupt_event":
+        raw_content, interrupt = deserialize_interrupt_event_block_content(raw_content)
     if block_type in {"reasoning", "tool_call"}:
         raw_content = ""
     block_id = normalize_non_empty_text(getattr(block, "block_id", None)) or (
@@ -393,6 +472,8 @@ def render_block_item(
     }
     if tool_call is not None:
         item["toolCall"] = tool_call
+    if interrupt is not None:
+        item["interrupt"] = interrupt
     return item
 
 
@@ -426,6 +507,9 @@ def render_block_detail_item(
     block_content = cast(str | None, block.content)
     raw_content = block_content or ""
     block_type = normalize_block_type(cast(str | None, block.block_type))
+    interrupt = None
+    if block_type == "interrupt_event":
+        raw_content, interrupt = deserialize_interrupt_event_block_content(raw_content)
     block_id = normalize_non_empty_text(getattr(block, "block_id", None)) or (
         f"{block.message_id}:{block_type}:{getattr(block, 'block_seq', 0) or 0}"
     )
@@ -457,6 +541,8 @@ def render_block_detail_item(
         )
         if tool_call_detail is not None:
             item["toolCallDetail"] = tool_call_detail
+    if interrupt is not None:
+        item["interrupt"] = interrupt
     return item
 
 

--- a/backend/app/features/sessions/schemas.py
+++ b/backend/app/features/sessions/schemas.py
@@ -118,6 +118,38 @@ class ToolCallDetailItem(ToolCallViewItem):
     raw: Optional[str] = None
 
 
+class InterruptQuestionOptionItem(BaseModel):
+    label: str
+    description: Optional[str] = None
+    value: Optional[str] = None
+
+
+class InterruptQuestionItem(BaseModel):
+    header: Optional[str] = None
+    description: Optional[str] = None
+    question: str
+    options: list[InterruptQuestionOptionItem] = Field(default_factory=list)
+
+
+class InterruptDetailsItem(BaseModel):
+    permission: Optional[str] = None
+    patterns: list[str] = Field(default_factory=list)
+    display_message: Optional[str] = Field(alias="displayMessage", default=None)
+    questions: list[InterruptQuestionItem] = Field(default_factory=list)
+
+    model_config = {"populate_by_name": True}
+
+
+class InterruptViewItem(BaseModel):
+    request_id: str = Field(alias="requestId")
+    type: Literal["permission", "question"]
+    phase: Literal["asked", "resolved"]
+    resolution: Optional[Literal["replied", "rejected"]] = None
+    details: Optional[InterruptDetailsItem] = None
+
+    model_config = {"populate_by_name": True}
+
+
 class SessionMessageBlockItem(BaseModel):
     id: str
     type: str
@@ -127,6 +159,7 @@ class SessionMessageBlockItem(BaseModel):
     lane_id: Optional[str] = Field(alias="laneId", default=None)
     base_seq: Optional[int] = Field(alias="baseSeq", default=None)
     tool_call: Optional[ToolCallViewItem] = Field(alias="toolCall", default=None)
+    interrupt: Optional[InterruptViewItem] = None
 
     model_config = {"populate_by_name": True}
 
@@ -145,6 +178,7 @@ class SessionMessageBlockDetailItem(BaseModel):
         alias="toolCallDetail",
         default=None,
     )
+    interrupt: Optional[InterruptViewItem] = None
 
     model_config = {"populate_by_name": True}
 

--- a/backend/tests/invoke/test_interrupt_metadata_normalization.py
+++ b/backend/tests/invoke/test_interrupt_metadata_normalization.py
@@ -5,9 +5,12 @@ from app.features.invoke.stream_payloads import (
     extract_interrupt_lifecycle_from_serialized_event,
 )
 from app.features.sessions.common import (
+    build_interrupt_block_view,
     build_interrupt_lifecycle_message_code,
     build_interrupt_lifecycle_message_content,
+    deserialize_interrupt_event_block_content,
     normalize_interrupt_lifecycle_event,
+    serialize_interrupt_event_block_content,
 )
 
 _MESSAGE_CASES = json.loads(
@@ -249,3 +252,22 @@ def test_build_interrupt_lifecycle_message_contract_cases() -> None:
         assert (
             build_interrupt_lifecycle_message_content(case["event"]) == case["content"]
         )
+
+
+def test_interrupt_event_block_content_round_trips_structured_payload() -> None:
+    event = {
+        "request_id": "perm-structured-1",
+        "type": "permission",
+        "phase": "asked",
+        "details": {
+            "permission": "read",
+            "patterns": ["/repo/.env"],
+            "display_message": "Agent requested authorization: read.",
+        },
+    }
+
+    serialized = serialize_interrupt_event_block_content(event)
+    content, interrupt = deserialize_interrupt_event_block_content(serialized)
+
+    assert content == "Agent requested authorization: read.\nTargets: /repo/.env"
+    assert interrupt == build_interrupt_block_view(event)

--- a/backend/tests/invoke/test_invoke_route_runner.py
+++ b/backend/tests/invoke/test_invoke_route_runner.py
@@ -19,6 +19,7 @@ from app.db.locking import (
 )
 from app.features.invoke import route_runner as invoke_route_runner
 from app.features.invoke.service import StreamFinishReason, StreamOutcome
+from app.features.sessions.common import deserialize_interrupt_event_block_content
 from app.integrations.a2a_extensions.errors import A2AExtensionUpstreamError
 from app.schemas.a2a_invoke import A2AAgentInvokeRequest, A2AAgentInvokeResponse
 
@@ -854,10 +855,21 @@ async def test_build_consume_stream_callbacks_persists_interrupt_lifecycle_event
     assert interrupt_call["append"] is False
     assert interrupt_call["is_finished"] is True
     assert interrupt_call["source"] == "interrupt_lifecycle"
-    assert (
+    content, interrupt = deserialize_interrupt_event_block_content(
         interrupt_call["content"]
-        == "Agent requested authorization: read.\nTargets: /repo/.env"
     )
+    assert content == "Agent requested authorization: read.\nTargets: /repo/.env"
+    assert interrupt == {
+        "requestId": "perm-1",
+        "type": "permission",
+        "phase": "asked",
+        "details": {
+            "permission": "read",
+            "patterns": ["/repo/.env"],
+            "displayMessage": None,
+            "questions": [],
+        },
+    }
     assert state.chunk_buffer == []
     assert state.persisted_block_count == 2
     assert state.next_event_seq == 4

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -11,6 +11,7 @@ from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
 from app.features.schedules.service import a2a_schedule_service
 from app.features.sessions import router as me_sessions
+from app.features.sessions.common import serialize_interrupt_event_block_content
 from app.features.sessions.service import session_hub_service
 from app.utils.timezone_util import utc_now
 from tests.support.api_utils import create_test_client
@@ -940,7 +941,17 @@ async def test_messages_query_keeps_interrupt_event_blocks_inline_on_agent_messa
                 message_id=agent_message.id,
                 block_seq=2,
                 block_type="interrupt_event",
-                content="Agent requested authorization: read.\nTargets: /repo/.env",
+                content=serialize_interrupt_event_block_content(
+                    {
+                        "request_id": "perm-inline-1",
+                        "type": "permission",
+                        "phase": "asked",
+                        "details": {
+                            "permission": "read",
+                            "patterns": ["/repo/.env"],
+                        },
+                    }
+                ),
                 is_finished=True,
                 source="interrupt_lifecycle",
             ),
@@ -980,6 +991,18 @@ async def test_messages_query_keeps_interrupt_event_blocks_inline_on_agent_messa
     assert returned_message["blocks"][1]["content"].startswith(
         "Agent requested authorization: read."
     )
+    assert returned_message["blocks"][1]["interrupt"] == {
+        "requestId": "perm-inline-1",
+        "type": "permission",
+        "phase": "asked",
+        "resolution": None,
+        "details": {
+            "permission": "read",
+            "patterns": ["/repo/.env"],
+            "displayMessage": None,
+            "questions": [],
+        },
+    }
 
 
 async def test_messages_query_keeps_non_interrupt_system_messages(

--- a/frontend/components/chat/__tests__/InterruptEventBlock.test.tsx
+++ b/frontend/components/chat/__tests__/InterruptEventBlock.test.tsx
@@ -1,0 +1,75 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+
+import { InterruptEventBlock } from "../blocks/InterruptEventBlock";
+
+import { type MessageBlock } from "@/lib/api/chat-utils";
+
+describe("InterruptEventBlock", () => {
+  it("renders asked permission interrupt with action badge and targets", () => {
+    const block: MessageBlock = {
+      id: "interrupt-asked-1",
+      type: "interrupt_event",
+      content: "Agent requested authorization: read.\nTargets: /repo/.env",
+      isFinished: true,
+      interrupt: {
+        requestId: "perm-1",
+        type: "permission",
+        phase: "asked",
+        details: {
+          permission: "read",
+          patterns: ["/repo/.env"],
+          displayMessage: null,
+        },
+      },
+      createdAt: "2026-03-23T00:00:00.000Z",
+      updatedAt: "2026-03-23T00:00:00.000Z",
+    };
+
+    const screen = render(
+      <InterruptEventBlock
+        block={block}
+        fallbackBlockId="interrupt-fallback-1"
+        isFirst
+      />,
+    );
+
+    expect(screen.getByText("Interrupt")).toBeTruthy();
+    expect(screen.getByText("Authorization requested")).toBeTruthy();
+    expect(screen.getByText("Action Required")).toBeTruthy();
+    expect(screen.getByText("Permission")).toBeTruthy();
+    expect(screen.getByText("read")).toBeTruthy();
+    expect(screen.getByText("Targets: /repo/.env")).toBeTruthy();
+  });
+
+  it("renders resolved interrupt with handled badge", () => {
+    const block: MessageBlock = {
+      id: "interrupt-resolved-1",
+      type: "interrupt_event",
+      content: "Authorization request was handled. Agent resumed.",
+      isFinished: true,
+      interrupt: {
+        requestId: "perm-2",
+        type: "permission",
+        phase: "resolved",
+        resolution: "replied",
+      },
+      createdAt: "2026-03-23T00:00:00.000Z",
+      updatedAt: "2026-03-23T00:00:00.000Z",
+    };
+
+    const screen = render(
+      <InterruptEventBlock
+        block={block}
+        fallbackBlockId="interrupt-fallback-2"
+        isFirst
+      />,
+    );
+
+    expect(screen.getByText("Authorization update")).toBeTruthy();
+    expect(screen.getByText("Handled")).toBeTruthy();
+    expect(
+      screen.getByText("Authorization request was handled. Agent resumed."),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/components/chat/blocks/InterruptEventBlock.tsx
+++ b/frontend/components/chat/blocks/InterruptEventBlock.tsx
@@ -9,6 +9,55 @@ interface InterruptEventBlockProps {
   isFirst?: boolean;
 }
 
+const BADGE_STYLES = {
+  actionRequired: {
+    container: "border-amber-500/30 bg-amber-500/10",
+    text: "text-amber-200",
+    label: "Action Required",
+  },
+  handled: {
+    container: "border-emerald-500/30 bg-emerald-500/10",
+    text: "text-emerald-200",
+    label: "Handled",
+  },
+  rejected: {
+    container: "border-rose-500/30 bg-rose-500/10",
+    text: "text-rose-200",
+    label: "Rejected",
+  },
+} as const;
+
+const resolveBadgeTone = (block: MessageBlock): keyof typeof BADGE_STYLES => {
+  const interrupt = block.interrupt;
+  if (!interrupt) {
+    return "actionRequired";
+  }
+  if (interrupt.phase === "resolved" && interrupt.resolution === "rejected") {
+    return "rejected";
+  }
+  if (interrupt.phase === "resolved") {
+    return "handled";
+  }
+  return "actionRequired";
+};
+
+const resolveInterruptTitle = (block: MessageBlock): string => {
+  const interrupt = block.interrupt;
+  if (!interrupt) {
+    return "Interrupt";
+  }
+  if (interrupt.phase === "resolved") {
+    if (interrupt.type === "permission") {
+      return "Authorization update";
+    }
+    return "Question update";
+  }
+  if (interrupt.type === "permission") {
+    return "Authorization requested";
+  }
+  return "Additional input requested";
+};
+
 export function InterruptEventBlock({
   block,
   fallbackBlockId,
@@ -16,25 +65,96 @@ export function InterruptEventBlock({
 }: InterruptEventBlockProps) {
   const blockText = block.content.trim();
   const blockId = block.id || fallbackBlockId;
+  const interrupt = block.interrupt;
 
-  if (!blockText) {
+  if (!blockText && !interrupt) {
     return null;
   }
+
+  const badgeTone = resolveBadgeTone(block);
+  const badge = BADGE_STYLES[badgeTone];
+  const patterns =
+    interrupt?.phase === "asked" && interrupt.type === "permission"
+      ? (interrupt.details.patterns ?? [])
+      : [];
+  const questions =
+    interrupt?.phase === "asked" && interrupt.type === "question"
+      ? (interrupt.details.questions ?? [])
+      : [];
 
   return (
     <View
       key={blockId}
       className={`${!isFirst ? "mt-3" : ""} rounded-xl border border-amber-500/30 bg-amber-500/10 p-3`}
     >
-      <Text className="text-[11px] font-medium uppercase tracking-wide text-amber-200">
-        Interrupt
-      </Text>
-      <Text
-        selectable
-        className="mt-2 text-[12px] leading-5 text-amber-50 font-normal"
-      >
-        {blockText}
-      </Text>
+      <View className="flex-row items-center justify-between gap-3">
+        <View className="min-w-0 flex-1">
+          <Text className="text-[11px] font-medium uppercase tracking-wide text-amber-200">
+            Interrupt
+          </Text>
+          <Text className="mt-1 text-[13px] font-semibold text-amber-50">
+            {resolveInterruptTitle(block)}
+          </Text>
+        </View>
+        <View className={`rounded-full border px-2 py-1 ${badge.container}`}>
+          <Text className={`text-[10px] font-semibold uppercase ${badge.text}`}>
+            {badge.label}
+          </Text>
+        </View>
+      </View>
+
+      {blockText ? (
+        <Text
+          selectable
+          className="mt-2 text-[12px] font-normal leading-5 text-amber-50"
+        >
+          {blockText}
+        </Text>
+      ) : null}
+
+      {interrupt?.phase === "asked" && interrupt.type === "permission" ? (
+        <View className="mt-3 rounded-lg border border-white/10 bg-white/5 p-2.5">
+          <Text className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+            Permission
+          </Text>
+          <Text className="mt-2 text-[12px] leading-5 text-slate-100">
+            {interrupt.details.permission ?? "unknown"}
+          </Text>
+          {patterns.length > 0 ? (
+            <Text className="mt-2 text-[11px] leading-5 text-slate-300">
+              Targets: {patterns.join(", ")}
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
+
+      {interrupt?.phase === "asked" && interrupt.type === "question" ? (
+        <View className="mt-3 rounded-lg border border-white/10 bg-white/5 p-2.5">
+          <Text className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+            Questions
+          </Text>
+          {questions.map((question, index) => (
+            <View
+              key={`${interrupt.requestId}:${index}:${question.question}`}
+              className={index === 0 ? "mt-2" : "mt-3"}
+            >
+              {question.header ? (
+                <Text className="text-[11px] font-semibold text-slate-200">
+                  {question.header}
+                </Text>
+              ) : null}
+              <Text className="mt-1 text-[12px] leading-5 text-slate-100">
+                {question.question}
+              </Text>
+              {question.description ? (
+                <Text className="mt-1 text-[11px] leading-5 text-slate-300">
+                  {question.description}
+                </Text>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      ) : null}
     </View>
   );
 }

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -233,7 +233,61 @@ describe("block-based stream parser and reducer", () => {
     expect(blocks?.[0]?.content).toBe(
       "Agent requested authorization: read.\nTargets: /repo/.env",
     );
+    expect(blocks?.[0]?.interrupt).toEqual({
+      requestId: "perm-1",
+      type: "permission",
+      phase: "asked",
+      details: {
+        permission: "read",
+        patterns: ["/repo/.env"],
+        displayMessage: null,
+      },
+    });
     expect(projectPrimaryTextContent(blocks)).toBe("");
+  });
+
+  it("replaces an inline interrupt_event block when the same request resolves", () => {
+    let blocks = applyStreamBlockUpdate(
+      undefined,
+      buildInterruptEventBlockUpdate({
+        messageId: "msg-interrupt-2",
+        interrupt: {
+          requestId: "perm-2",
+          type: "permission",
+          phase: "asked",
+          details: {
+            permission: "write",
+            patterns: ["/repo/config.yml"],
+            displayMessage: null,
+          },
+        },
+      }),
+    );
+
+    blocks = applyStreamBlockUpdate(
+      blocks,
+      buildInterruptEventBlockUpdate({
+        messageId: "msg-interrupt-2",
+        interrupt: {
+          requestId: "perm-2",
+          type: "permission",
+          phase: "resolved",
+          resolution: "replied",
+        },
+      }),
+    );
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks?.[0]?.type).toBe("interrupt_event");
+    expect(blocks?.[0]?.content).toBe(
+      "Authorization request was handled. Agent resumed.",
+    );
+    expect(blocks?.[0]?.interrupt).toEqual({
+      requestId: "perm-2",
+      type: "permission",
+      phase: "resolved",
+      resolution: "replied",
+    });
   });
 
   it("matches the shared interrupt lifecycle message contract cases", () => {

--- a/frontend/lib/api/chat-utils.ts
+++ b/frontend/lib/api/chat-utils.ts
@@ -16,6 +16,7 @@ export type MessageBlock = {
   baseSeq?: number | null;
   toolCall?: ToolCallView | null;
   toolCallDetail?: ToolCallDetailView | null;
+  interrupt?: RuntimeInterrupt | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -93,6 +94,7 @@ export type StreamBlockUpdate = {
   append: boolean;
   done: boolean;
   toolCall?: ToolCallView | null;
+  interrupt?: RuntimeInterrupt | null;
 };
 
 const PRIMARY_TEXT_SNAPSHOT_SOURCES = new Set([
@@ -211,6 +213,82 @@ export type ResolvedRuntimeInterrupt = RuntimeInterruptBase & {
 export type RuntimeInterrupt =
   | PendingRuntimeInterrupt
   | ResolvedRuntimeInterrupt;
+
+const isInterruptQuestionOption = (
+  value: unknown,
+): value is InterruptQuestionOption => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as InterruptQuestionOption;
+  return (
+    typeof candidate.label === "string" &&
+    (candidate.description === undefined ||
+      candidate.description === null ||
+      typeof candidate.description === "string") &&
+    (candidate.value === undefined ||
+      candidate.value === null ||
+      typeof candidate.value === "string")
+  );
+};
+
+const isInterruptQuestion = (value: unknown): value is InterruptQuestion => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as InterruptQuestion;
+  return (
+    typeof candidate.question === "string" &&
+    (candidate.header === undefined ||
+      candidate.header === null ||
+      typeof candidate.header === "string") &&
+    (candidate.description === undefined ||
+      candidate.description === null ||
+      typeof candidate.description === "string") &&
+    (candidate.options === undefined ||
+      (Array.isArray(candidate.options) &&
+        candidate.options.every(isInterruptQuestionOption)))
+  );
+};
+
+const isRuntimeInterrupt = (value: unknown): value is RuntimeInterrupt => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as RuntimeInterrupt;
+  if (
+    typeof candidate.requestId !== "string" ||
+    (candidate.type !== "permission" && candidate.type !== "question")
+  ) {
+    return false;
+  }
+  if (candidate.phase === "resolved") {
+    return (
+      candidate.resolution === "replied" || candidate.resolution === "rejected"
+    );
+  }
+  if (candidate.phase !== "asked") {
+    return false;
+  }
+  const details = candidate.details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return false;
+  }
+  return (
+    (details.permission === undefined ||
+      details.permission === null ||
+      typeof details.permission === "string") &&
+    (details.patterns === undefined ||
+      (Array.isArray(details.patterns) &&
+        details.patterns.every((item) => typeof item === "string"))) &&
+    (details.displayMessage === undefined ||
+      details.displayMessage === null ||
+      typeof details.displayMessage === "string") &&
+    (details.questions === undefined ||
+      (Array.isArray(details.questions) &&
+        details.questions.every(isInterruptQuestion)))
+  );
+};
 
 export const extractSessionMeta = (data: Record<string, unknown>) => {
   const contextId =
@@ -926,7 +1004,33 @@ export const buildInterruptEventBlockUpdate = ({
     delta: buildInterruptEventContent(interrupt),
     append: false,
     done: true,
+    interrupt,
   };
+};
+
+const parseSerializedInterruptEventContent = (
+  raw: string,
+): { content: string; interrupt: RuntimeInterrupt | null } => {
+  try {
+    const payload = JSON.parse(raw) as {
+      kind?: unknown;
+      content?: unknown;
+      interrupt?: unknown;
+    };
+    if (payload.kind !== "interrupt_event") {
+      return { content: raw, interrupt: null };
+    }
+    const content =
+      typeof payload.content === "string" && payload.content.trim().length > 0
+        ? payload.content
+        : raw;
+    const interrupt = isRuntimeInterrupt(payload.interrupt)
+      ? payload.interrupt
+      : null;
+    return { content, interrupt };
+  } catch {
+    return { content: raw, interrupt: null };
+  }
 };
 
 const normalizeRole = (raw: string | null): ChatRole => {
@@ -1261,6 +1365,10 @@ export const extractStreamBlockUpdate = (
             asRecord(artifact?.toolCall),
         )
       : null;
+  const interruptPayload =
+    blockType === "interrupt_event"
+      ? parseSerializedInterruptEventContent(delta)
+      : { content: delta, interrupt: null };
 
   return {
     eventId,
@@ -1276,10 +1384,11 @@ export const extractStreamBlockUpdate = (
     source,
     messageId,
     role,
-    delta,
+    delta: interruptPayload.content,
     append,
     done: op === "finalize" ? true : done,
     toolCall,
+    interrupt: interruptPayload.interrupt,
   };
 };
 
@@ -1321,6 +1430,11 @@ export const applyStreamBlockUpdate = (
         : targetBlock.toolCall !== undefined
           ? { toolCall: targetBlock.toolCall ?? null }
           : {}),
+      ...(resolvedUpdate.interrupt !== undefined
+        ? { interrupt: resolvedUpdate.interrupt ?? null }
+        : targetBlock.interrupt !== undefined
+          ? { interrupt: targetBlock.interrupt ?? null }
+          : {}),
       updatedAt: now,
     };
     return nextBlocks;
@@ -1347,6 +1461,9 @@ export const applyStreamBlockUpdate = (
       isFinished: resolvedUpdate.done,
       ...(resolvedUpdate.toolCall !== undefined
         ? { toolCall: resolvedUpdate.toolCall ?? null }
+        : {}),
+      ...(resolvedUpdate.interrupt !== undefined
+        ? { interrupt: resolvedUpdate.interrupt ?? null }
         : {}),
       createdAt: now,
       updatedAt: now,
@@ -1397,6 +1514,7 @@ export const applyLoadedBlockDetail = (
     isFinished?: boolean;
     toolCall?: ToolCallView | null;
     toolCallDetail?: ToolCallDetailView | null;
+    interrupt?: RuntimeInterrupt | null;
   },
 ): Pick<ChatMessage, "content" | "blocks"> => {
   const nextBlocks = (message.blocks ?? []).map((block) =>
@@ -1420,6 +1538,10 @@ export const applyLoadedBlockDetail = (
             input.toolCallDetail === undefined
               ? (block.toolCallDetail ?? null)
               : input.toolCallDetail,
+          interrupt:
+            input.interrupt === undefined
+              ? (block.interrupt ?? null)
+              : input.interrupt,
         }
       : block,
   );

--- a/frontend/lib/api/sessions.ts
+++ b/frontend/lib/api/sessions.ts
@@ -1,4 +1,5 @@
 import {
+  type RuntimeInterrupt,
   type ToolCallDetailView,
   type ToolCallView,
 } from "@/lib/api/chat-utils";
@@ -30,6 +31,7 @@ export type SessionMessageBlockItem = {
   laneId?: string | null;
   baseSeq?: number | null;
   toolCall?: ToolCallView | null;
+  interrupt?: RuntimeInterrupt | null;
 };
 
 export type SessionMessageBlockDetailItem = {
@@ -43,6 +45,7 @@ export type SessionMessageBlockDetailItem = {
   baseSeq?: number | null;
   toolCall?: ToolCallView | null;
   toolCallDetail?: ToolCallDetailView | null;
+  interrupt?: RuntimeInterrupt | null;
 };
 
 export type SessionMessageItem = {

--- a/frontend/lib/sessionHistory.ts
+++ b/frontend/lib/sessionHistory.ts
@@ -2,6 +2,7 @@ import {
   type ChatMessage,
   type ChatRole,
   type MessageBlock,
+  type RuntimeInterrupt,
   type ToolCallView,
   projectPrimaryTextContent,
 } from "@/lib/api/chat-utils";
@@ -21,6 +22,7 @@ export type SessionMessageItem = {
     laneId?: string | null;
     baseSeq?: number | null;
     toolCall?: ToolCallView | null;
+    interrupt?: RuntimeInterrupt | null;
   }[];
 };
 
@@ -97,6 +99,9 @@ const mapBlocks = (item: SessionMessageItem): MessageBlock[] => {
     };
     if (block.toolCall) {
       mappedBlock.toolCall = block.toolCall;
+    }
+    if (block.interrupt) {
+      mappedBlock.interrupt = block.interrupt;
     }
     return mappedBlock;
   });


### PR DESCRIPTION
## 关联 Issues
- Closes #604
- Related #564

## 变更概览
本 PR 聚焦 interrupt 生命周期块的展示层收敛：保持后端按 phase 记录的事实层不变，但把 agent message 内联的 `interrupt_event` 升级为单块状态化展示，避免 asked / resolved 在时间线上膨胀成两个独立块。

## 后端
- 在 `backend/app/features/sessions/common.py` 新增 `interrupt_event` 的结构化序列化 / 反序列化与视图渲染。
- `interrupt_event` 持久化内容改为包含 `kind/schemaVersion/interrupt/content` 的 JSON 字符串，刷新后仍可恢复结构化 `interrupt` 视图。
- `backend/app/features/sessions/schemas.py` 为消息块响应补充 `interrupt` 结构字段。
- `backend/app/features/invoke/route_runner.py` 改为把 inline interrupt block 写入结构化内容；隐藏的 system message 事实链路保持不变。

## 前端
- `frontend/lib/api/chat-utils.ts` 为 `MessageBlock` / `StreamBlockUpdate` 增加 `interrupt` 结构，并让 live reducer 在同一 `blockId` 上覆盖 asked / resolved。
- `frontend/lib/sessionHistory.ts` 与 `frontend/lib/api/sessions.ts` 同步 refresh path 的 `interrupt` 字段映射。
- `frontend/components/chat/blocks/InterruptEventBlock.tsx` 升级为状态化卡片，按 `phase/resolution/type` 展示 `Action Required` / `Handled` / `Rejected`，并展示 permission targets / question 内容。

## 测试
- 后端：补充 interrupt 结构化 round-trip、route runner 持久化、messages query 刷新返回的回归测试。
- 前端：补充 interrupt reducer 覆盖语义与 `InterruptEventBlock` 渲染测试。

## 验证
- `cd backend && uv run pre-commit run --files app/features/invoke/route_runner.py app/features/sessions/common.py app/features/sessions/schemas.py tests/invoke/test_interrupt_metadata_normalization.py tests/invoke/test_invoke_route_runner.py tests/sessions/test_unified_session_domain_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest tests/invoke/test_interrupt_metadata_normalization.py tests/invoke/test_invoke_route_runner.py tests/sessions/test_unified_session_domain_routes.py`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/chat/blocks/InterruptEventBlock.tsx components/chat/__tests__/InterruptEventBlock.test.tsx lib/__tests__/streamContract.test.ts lib/api/chat-utils.ts lib/api/sessions.ts lib/sessionHistory.ts --maxWorkers=25%`
