### PR TITLE
fix(logging): tighten header redaction defaults

### DIFF
--- a/backend/app/utils/logging_redaction.py
+++ b/backend/app/utils/logging_redaction.py
@@ -22,6 +22,20 @@ _SENSITIVE_KEYWORDS = (
     "x-api-key",
 )
 
+_SAFE_HEADER_ALLOWLIST = {
+    "accept",
+    "accept-encoding",
+    "accept-language",
+    "content-length",
+    "content-type",
+    "host",
+    "origin",
+    "traceparent",
+    "tracestate",
+    "user-agent",
+    "x-request-id",
+}
+
 
 def redact_sensitive_value(value: str | None) -> str | None:
     """Redact a sensitive value by keeping the first 6 characters and adding a hash.
@@ -46,14 +60,22 @@ def redact_sensitive_value(value: str | None) -> str | None:
 
 
 def redact_headers_for_logging(headers: Mapping[str, str]) -> dict[str, str]:
-    """Redact sensitive headers."""
+    """Redact headers for logs using a secure-by-default policy.
+
+    Only a small allowlist of operationally useful headers keeps its original
+    value. All other headers are hidden by default so user-defined custom
+    authentication headers do not leak into logs. Known sensitive headers keep a
+    stable prefix+hash representation to preserve limited debugging value.
+    """
     redacted: dict[str, str] = {}
     for key, value in headers.items():
         lower_key = key.lower()
-        if any(keyword in lower_key for keyword in _SENSITIVE_KEYWORDS):
+        if lower_key in _SAFE_HEADER_ALLOWLIST:
+            redacted[key] = value
+        elif any(keyword in lower_key for keyword in _SENSITIVE_KEYWORDS):
             redacted[key] = redact_sensitive_value(value) or "<redacted>"
         else:
-            redacted[key] = value
+            redacted[key] = "<redacted>"
     return redacted
 
 

--- a/backend/tests/runtime/test_logging_redaction.py
+++ b/backend/tests/runtime/test_logging_redaction.py
@@ -23,6 +23,7 @@ def test_redact_headers_for_logging():
     headers = {
         "Authorization": "Bearer super-secret-token-123456789",
         "X-API-Key": "my-secret-key-123456789",
+        "X-Custom-Credential": "opaque-user-secret",
         "Sec-WebSocket-Protocol": "a" * 48,
         "Content-Type": "application/json",
         "User-Agent": "Mozilla/5.0",
@@ -32,6 +33,7 @@ def test_redact_headers_for_logging():
     assert redacted["Authorization"].startswith("Bearer")
     assert "..." in redacted["Authorization"]
     assert redacted["X-API-Key"].startswith("my-sec")
+    assert redacted["X-Custom-Credential"] == "<redacted>"
     assert "..." in redacted["Sec-WebSocket-Protocol"]
     assert redacted["Content-Type"] == "application/json"
     assert redacted["User-Agent"] == "Mozilla/5.0"


### PR DESCRIPTION
## 关联 Issues
- Closes #599

## 审查结论
- 本 PR 的改动范围收敛，直接命中 `#599` 当前仍然存在的底层残留，而不是重复修已经收口的 personal agent 路由表层日志点。
- 当前实现通过收紧统一日志脱敏工具来解决问题，方向合理、影响面可控，没有引入第二套冗余基础设施。
- 未发现阻塞性问题；当前剩余注意点主要是 `query params` 仍保持关键词式脱敏，但这不属于 `#599` 的本次范围。

## 改动说明
### Backend / Logging Redaction
- 收紧 `backend/app/utils/logging_redaction.py` 中的 `redact_headers_for_logging()`。
- 将 header 日志策略改为“默认隐藏值，仅白名单 header 保留原值”。
- 对已知敏感 header 继续保留受控前缀 + hash 的输出形式，便于排障。
- 这样可以覆盖 `A2A client registry` 记录 `resolved.headers` 时，自定义认证 header 名称不典型而被明文输出的风险。

### Backend / Tests
- 更新 `backend/tests/runtime/test_logging_redaction.py`。
- 新增对非典型自定义凭证 header 的断言，确保其不会再以原文形式出现在日志脱敏结果中。

## 验证结果
### Backend scoped checks
- `cd backend && uv run --locked pre-commit run --files app/utils/logging_redaction.py tests/runtime/test_logging_redaction.py --config ../.pre-commit-config.yaml`
  - Passed
- `cd backend && uv run --locked pytest tests/runtime/test_logging_redaction.py`
  - Passed (`4 passed`)

## 风险与边界
- 本 PR 只处理 header 日志脱敏，不扩大到 query params 默认隐藏策略。
- 当前实现不会改动日志调用点，只在统一工具层收口，降低回归面。
