### PR TITLE
fix(a2a-client): normalize stream upstream errors and SSE handshake parsing

### DIFF
--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -45,6 +45,7 @@ from app.integrations.a2a_client.errors import (
     A2APeerProtocolError,
     A2AUnsupportedBindingError,
     A2AUnsupportedOperationError,
+    A2AUpstreamTimeoutError,
 )
 from app.integrations.a2a_client.http_clients import (
     SharedSDKTransportInvalidatedError,
@@ -253,16 +254,18 @@ class A2AClient:
                     "raw": final_payload,
                 }
             except Exception as exc:  # noqa: BLE001
-                http_error = _unwrap_httpx_error(exc)
-                if http_error and _should_reset_http_error(http_error):
+                translated_error = _translate_httpx_error(exc, agent_url=self.agent_url)
+                if isinstance(translated_error, A2AClientResetRequiredError):
                     logger.warning(
                         "Detected unrecoverable HTTP error, scheduling client reset",
                         extra={
                             "agent_url": redact_url_for_logging(self.agent_url),
-                            "error_type": type(http_error).__name__,
+                            "error_type": type(translated_error).__name__,
                         },
                     )
-                    raise A2AClientResetRequiredError(str(http_error)) from exc
+                    raise translated_error from exc
+                if translated_error is not None:
+                    exc = translated_error
                 logger.exception(
                     "Blocking invocation to %s failed",
                     redact_url_for_logging(self.agent_url),
@@ -310,22 +313,28 @@ class A2AClient:
     ) -> AsyncIterator[Any]:
         """Stream responses from the downstream agent."""
 
-        async with self._request_usage():
-            logger.info(
-                "Calling A2A agent %s (streaming)",
-                redact_url_for_logging(self.agent_url),
-                extra={
-                    "query_meta": summarize_query(query),
-                },
-            )
+        try:
+            async with self._request_usage():
+                logger.info(
+                    "Calling A2A agent %s (streaming)",
+                    redact_url_for_logging(self.agent_url),
+                    extra={
+                        "query_meta": summarize_query(query),
+                    },
+                )
 
-            request = A2AMessageRequest(
-                query=query,
-                context_id=context_id,
-                metadata=metadata,
-            )
-            async for payload in self._stream_with_fallback(request):
-                yield payload
+                request = A2AMessageRequest(
+                    query=query,
+                    context_id=context_id,
+                    metadata=metadata,
+                )
+                async for payload in self._stream_with_fallback(request):
+                    yield payload
+        except Exception as exc:  # noqa: BLE001
+            translated_error = _translate_httpx_error(exc, agent_url=self.agent_url)
+            if translated_error is not None:
+                raise translated_error from exc
+            raise
 
     async def cancel_task(
         self,
@@ -399,9 +408,10 @@ class A2AClient:
                     "error_code": getattr(exc, "error_code", "unsupported_operation"),
                 }
             except Exception as exc:  # noqa: BLE001
-                http_error = _unwrap_httpx_error(exc)
-                if http_error and _should_reset_http_error(http_error):
-                    raise A2AClientResetRequiredError(str(http_error)) from exc
+                translated_error = _translate_httpx_error(exc, agent_url=self.agent_url)
+                if isinstance(translated_error, A2AClientResetRequiredError):
+                    raise translated_error from exc
+                resolved_error = translated_error or exc
                 logger.exception(
                     "Failed to cancel A2A task %s for %s",
                     normalized_task_id,
@@ -411,8 +421,12 @@ class A2AClient:
                     "success": False,
                     "agent_url": self.agent_url,
                     "task_id": normalized_task_id,
-                    "error": str(exc),
-                    "error_code": "cancel_failed",
+                    "error": str(resolved_error),
+                    "error_code": getattr(
+                        resolved_error,
+                        "error_code",
+                        "cancel_failed",
+                    ),
                 }
 
     async def get_task(
@@ -489,9 +503,10 @@ class A2AClient:
                     "error_code": getattr(exc, "error_code", "unsupported_operation"),
                 }
             except Exception as exc:  # noqa: BLE001
-                http_error = _unwrap_httpx_error(exc)
-                if http_error and _should_reset_http_error(http_error):
-                    raise A2AClientResetRequiredError(str(http_error)) from exc
+                translated_error = _translate_httpx_error(exc, agent_url=self.agent_url)
+                if isinstance(translated_error, A2AClientResetRequiredError):
+                    raise translated_error from exc
+                resolved_error = translated_error or exc
                 logger.exception(
                     "Failed to fetch A2A task %s for %s",
                     normalized_task_id,
@@ -501,8 +516,12 @@ class A2AClient:
                     "success": False,
                     "agent_url": self.agent_url,
                     "task_id": normalized_task_id,
-                    "error": str(exc),
-                    "error_code": "task_query_failed",
+                    "error": str(resolved_error),
+                    "error_code": getattr(
+                        resolved_error,
+                        "error_code",
+                        "task_query_failed",
+                    ),
                 }
 
     async def get_agent_card(self) -> AgentCard:
@@ -1123,6 +1142,19 @@ class A2AClient:
             return True
         if _is_closed_http_client_error(exc):
             return True
+        translated_error = _translate_httpx_error(
+            exc,
+            agent_url=(
+                getattr(getattr(adapter, "descriptor", None), "agent_url", None)
+                or getattr(getattr(adapter, "descriptor", None), "selected_url", None)
+                or ""
+            ),
+        )
+        if isinstance(
+            translated_error,
+            (A2AAgentUnavailableError, A2AUpstreamTimeoutError),
+        ):
+            return False
         http_error = _unwrap_httpx_error(exc)
         return bool(http_error and isinstance(http_error, httpx.TransportError))
 
@@ -1142,6 +1174,19 @@ class A2AClient:
             return False
         if _is_closed_http_client_error(exc):
             return True
+        translated_error = _translate_httpx_error(
+            exc,
+            agent_url=(
+                getattr(getattr(adapter, "descriptor", None), "agent_url", None)
+                or getattr(getattr(adapter, "descriptor", None), "selected_url", None)
+                or ""
+            ),
+        )
+        if isinstance(
+            translated_error,
+            (A2AAgentUnavailableError, A2AUpstreamTimeoutError),
+        ):
+            return False
         http_error = _unwrap_httpx_error(exc)
         return bool(http_error and isinstance(http_error, httpx.TransportError))
 
@@ -1386,6 +1431,44 @@ def _is_closed_http_client_error(exc: Exception) -> bool:
             current, "__context__", None
         )
     return False
+
+
+def _format_upstream_agent_label(agent_url: str) -> str:
+    redacted = redact_url_for_logging(agent_url or "")
+    return redacted or "<unknown>"
+
+
+def _translate_httpx_error(
+    exc: Exception,
+    *,
+    agent_url: str,
+) -> A2AAgentUnavailableError | A2AClientResetRequiredError | None:
+    if _is_closed_http_client_error(exc):
+        return A2AClientResetRequiredError("A2A transport client has been closed")
+
+    http_error = _unwrap_httpx_error(exc)
+    if http_error is None:
+        return None
+
+    agent_label = _format_upstream_agent_label(agent_url)
+
+    if isinstance(http_error, httpx.ConnectTimeout):
+        return A2AUpstreamTimeoutError(
+            f"A2A agent '{agent_label}' timed out while establishing a connection"
+        )
+
+    if isinstance(http_error, httpx.TimeoutException):
+        return A2AUpstreamTimeoutError(
+            f"A2A agent '{agent_label}' timed out before completing the request"
+        )
+
+    if isinstance(http_error, (httpx.ConnectError, httpx.NetworkError)):
+        return A2AAgentUnavailableError(f"Unable to reach A2A agent '{agent_label}'")
+
+    if _should_reset_http_error(http_error):
+        return A2AClientResetRequiredError(str(http_error))
+
+    return None
 
 
 def _should_reset_http_error(error: httpx.HTTPError) -> bool:

--- a/backend/app/integrations/a2a_client/errors.py
+++ b/backend/app/integrations/a2a_client/errors.py
@@ -7,6 +7,12 @@ class A2AAgentUnavailableError(RuntimeError):
     error_code = "agent_unavailable"
 
 
+class A2AUpstreamTimeoutError(A2AAgentUnavailableError):
+    """Raised when a downstream A2A agent times out before responding."""
+
+    error_code = "timeout"
+
+
 class A2AOutboundNotAllowedError(A2AAgentUnavailableError):
     """Raised when an outbound A2A URL is blocked by the allowlist."""
 
@@ -60,6 +66,7 @@ __all__ = [
     "A2AClientResetRequiredError",
     "A2APeerProtocolError",
     "A2AStreamingNotSupportedError",
+    "A2AUpstreamTimeoutError",
     "A2AUnsupportedBindingError",
     "A2AUnsupportedOperationError",
 ]

--- a/backend/app/integrations/a2a_client/gateway.py
+++ b/backend/app/integrations/a2a_client/gateway.py
@@ -176,6 +176,7 @@ class A2AGateway:
                     "error_code": "outbound_not_allowed",
                 }
             except A2AAgentUnavailableError as exc:
+                error_code = getattr(exc, "error_code", "agent_unavailable")
                 elapsed = time.monotonic() - start_time
                 logger.error(
                     "A2A unavailable",
@@ -188,14 +189,14 @@ class A2AGateway:
                 a2a_metrics.record_call(
                     resolved.name,
                     success=False,
-                    error_code="agent_unavailable",
+                    error_code=error_code,
                 )
                 return {
                     "success": False,
                     "agent_name": resolved.name,
                     "agent_url": resolved.url,
                     "error": str(exc),
-                    "error_code": "agent_unavailable",
+                    "error_code": error_code,
                 }
             except asyncio.TimeoutError:
                 elapsed = time.monotonic() - start_time
@@ -377,6 +378,7 @@ class A2AGateway:
                 "error_code": "outbound_not_allowed",
             }
         except A2AAgentUnavailableError as exc:
+            error_code = getattr(exc, "error_code", "agent_unavailable")
             elapsed = time.monotonic() - start_time
             logger.error(
                 "A2A task cancel unavailable",
@@ -390,7 +392,7 @@ class A2AGateway:
             a2a_metrics.record_call(
                 resolved.name,
                 success=False,
-                error_code="agent_unavailable",
+                error_code=error_code,
             )
             return {
                 "success": False,
@@ -398,7 +400,7 @@ class A2AGateway:
                 "agent_url": resolved.url,
                 "task_id": normalized_task_id,
                 "error": str(exc),
-                "error_code": "agent_unavailable",
+                "error_code": error_code,
             }
         except Exception as exc:  # noqa: BLE001
             elapsed = time.monotonic() - start_time
@@ -544,6 +546,7 @@ class A2AGateway:
                 "error_code": "outbound_not_allowed",
             }
         except A2AAgentUnavailableError as exc:
+            error_code = getattr(exc, "error_code", "agent_unavailable")
             elapsed = time.monotonic() - start_time
             logger.error(
                 "A2A task get unavailable",
@@ -557,7 +560,7 @@ class A2AGateway:
             a2a_metrics.record_call(
                 resolved.name,
                 success=False,
-                error_code="agent_unavailable",
+                error_code=error_code,
             )
             return {
                 "success": False,
@@ -565,7 +568,7 @@ class A2AGateway:
                 "agent_url": resolved.url,
                 "task_id": normalized_task_id,
                 "error": str(exc),
-                "error_code": "agent_unavailable",
+                "error_code": error_code,
             }
         except Exception as exc:  # noqa: BLE001
             elapsed = time.monotonic() - start_time

--- a/backend/tests/client/test_a2a_client.py
+++ b/backend/tests/client/test_a2a_client.py
@@ -7,6 +7,7 @@ import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 from a2a.client.errors import A2AClientHTTPError
 from a2a.types import Message, Role, TextPart
@@ -25,6 +26,7 @@ from app.integrations.a2a_client.config import A2ASettings
 from app.integrations.a2a_client.errors import (
     A2AClientResetRequiredError,
     A2APeerProtocolError,
+    A2AUpstreamTimeoutError,
 )
 from app.integrations.a2a_client.http_clients import (
     SharedSDKTransportInvalidatedError,
@@ -845,6 +847,37 @@ async def test_call_agent_returns_structured_protocol_error_details() -> None:
 
 
 @pytest.mark.asyncio
+async def test_call_agent_maps_connect_error_to_agent_unavailable() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._send_with_fallback = AsyncMock(
+        side_effect=httpx.ConnectError("All connection attempts failed")
+    )
+
+    result = await a2a_client.call_agent("hello")
+
+    assert result["success"] is False
+    assert result["error_code"] == "agent_unavailable"
+    assert result["error"] == (
+        "Unable to reach A2A agent 'http://example-agent.internal:24020'"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_maps_connect_timeout_to_timeout() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+
+    async def _failing_stream(_request):
+        raise httpx.ConnectTimeout("timed out")
+        yield  # pragma: no cover
+
+    a2a_client._stream_with_fallback = _failing_stream
+
+    with pytest.raises(A2AUpstreamTimeoutError, match="timed out while establishing"):
+        async for _ in a2a_client.stream_agent("hello"):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_cancel_task_returns_success_for_valid_request() -> None:
     a2a_client = A2AClient("http://example-agent.internal:24020")
     a2a_client._cancel_with_fallback = AsyncMock(return_value={"id": "task-1"})
@@ -979,6 +1012,41 @@ async def test_gateway_get_task_returns_success_payload(
         history_length=2,
         metadata=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_gateway_get_task_preserves_timeout_error_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = gateway_module.A2AGateway(
+        A2ASettings(
+            default_timeout=10.0,
+            use_client_preference=False,
+            client_idle_timeout=1.0,
+        )
+    )
+    resolved = SimpleNamespace(
+        url="http://example-agent.internal:24020",
+        headers={},
+        name="TestAgent",
+    )
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def fake_open_invoke_session(**_kwargs):
+        raise A2AUpstreamTimeoutError("Timed out before completing the request")
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(gateway, "open_invoke_session", fake_open_invoke_session)
+
+    result = await gateway.get_task(
+        resolved=resolved,
+        task_id="task-1",
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "timeout"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/invoke/test_a2a_invoke_service.py
+++ b/backend/tests/invoke/test_a2a_invoke_service.py
@@ -12,7 +12,10 @@ from app.core.config import settings
 from app.features.invoke.payload_analysis import coerce_payload_to_dict
 from app.features.invoke.service import StreamFinishReason, a2a_invoke_service
 from app.features.invoke.stream_diagnostics import build_artifact_update_log_sample
-from app.integrations.a2a_client.errors import A2APeerProtocolError
+from app.integrations.a2a_client.errors import (
+    A2APeerProtocolError,
+    A2AUpstreamTimeoutError,
+)
 
 
 class _BrokenGateway:
@@ -117,6 +120,13 @@ class _GatewayWithStructuredProtocolError:
                     "details": {"token": "secret"},
                 },
             )
+        )
+
+
+class _GatewayWithTimeoutError:
+    def stream(self, **kwargs):  # noqa: ARG001
+        return _FailingAsyncIterator(
+            A2AUpstreamTimeoutError("Timed out before completing the request")
         )
 
 
@@ -242,6 +252,31 @@ async def test_sse_error_event_exposes_structured_upstream_payload():
         "message": "project_id/channel_id required",
         "data": {"missing_params": ["project_id", "channel_id"]},
     }
+
+
+@pytest.mark.asyncio
+async def test_sse_error_event_preserves_timeout_error_code():
+    response = a2a_invoke_service.stream_sse(
+        gateway=_GatewayWithTimeoutError(),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+    )
+    chunks: list[str] = []
+    async for chunk in response.body_iterator:
+        chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    payload = "".join(chunks)
+    error_data_line = next(
+        line for line in payload.splitlines() if line.startswith("data: {")
+    )
+    error_data = json.loads(error_data_line.removeprefix("data: "))
+    assert error_data["message"] == "Upstream streaming failed"
+    assert error_data["error_code"] == "timeout"
 
 
 @pytest.mark.asyncio

--- a/frontend/lib/api/__tests__/sse.test.ts
+++ b/frontend/lib/api/__tests__/sse.test.ts
@@ -2,16 +2,41 @@ jest.mock("@/lib/api/client", () => {
   class MockApiRequestError extends Error {
     status: number;
     errorCode: string | null;
+    source: string | null;
+    jsonrpcCode: number | null;
+    missingParams: { name: string; required: boolean }[] | null;
+    upstreamError: Record<string, unknown> | null;
 
     constructor(
       message: string,
       status: number,
-      errorCode: string | null = null,
+      options:
+        | string
+        | {
+            errorCode?: string | null;
+            source?: string | null;
+            jsonrpcCode?: number | null;
+            missingParams?: { name: string; required: boolean }[] | null;
+            upstreamError?: Record<string, unknown> | null;
+          }
+        | null = null,
     ) {
       super(message);
       this.name = "ApiRequestError";
       this.status = status;
-      this.errorCode = errorCode;
+      if (typeof options === "string" || options == null) {
+        this.errorCode = options ?? null;
+        this.source = null;
+        this.jsonrpcCode = null;
+        this.missingParams = null;
+        this.upstreamError = null;
+        return;
+      }
+      this.errorCode = options.errorCode ?? null;
+      this.source = options.source ?? null;
+      this.jsonrpcCode = options.jsonrpcCode ?? null;
+      this.missingParams = options.missingParams ?? null;
+      this.upstreamError = options.upstreamError ?? null;
     }
   }
 
@@ -37,6 +62,55 @@ jest.mock("@/lib/api/client", () => {
     AuthRecoverableError: MockAuthRecoverableError,
     ensureFreshAccessToken: jest.fn(async () => null),
     handleAuthExpiredOnce: jest.fn(),
+    parseApiErrorResponse: jest.fn(async (response: Response) => {
+      let payload: unknown = null;
+      try {
+        payload = await response.json();
+      } catch {
+        payload = null;
+      }
+      const detail =
+        payload && typeof payload === "object" && "detail" in payload
+          ? (payload as { detail?: unknown }).detail
+          : null;
+      const detailRecord =
+        detail && typeof detail === "object" && !Array.isArray(detail)
+          ? (detail as Record<string, unknown>)
+          : null;
+      return {
+        message:
+          (detailRecord &&
+            typeof detailRecord.message === "string" &&
+            detailRecord.message) ||
+          `Request failed (${response.status})`,
+        errorCode:
+          detailRecord && typeof detailRecord.error_code === "string"
+            ? detailRecord.error_code
+            : null,
+        source:
+          detailRecord && typeof detailRecord.source === "string"
+            ? detailRecord.source
+            : null,
+        jsonrpcCode:
+          detailRecord && typeof detailRecord.jsonrpc_code === "number"
+            ? detailRecord.jsonrpc_code
+            : null,
+        missingParams:
+          detailRecord && Array.isArray(detailRecord.missing_params)
+            ? (detailRecord.missing_params as {
+                name: string;
+                required: boolean;
+              }[])
+            : null,
+        upstreamError:
+          detailRecord &&
+          detailRecord.upstream_error &&
+          typeof detailRecord.upstream_error === "object" &&
+          !Array.isArray(detailRecord.upstream_error)
+            ? (detailRecord.upstream_error as Record<string, unknown>)
+            : null,
+      };
+    }),
     refreshAccessToken: jest.fn(async () => null),
     refreshAccessTokenWithOutcome: jest.fn(async () => ({
       result: null,
@@ -113,6 +187,34 @@ describe("fetchSSE", () => {
       missingParams: [{ name: "project_id", required: true }],
       upstreamError: { message: "project_id required" },
     });
+  });
+
+  it("parses non-2xx SSE handshake failures into structured ApiRequestError", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({
+        detail: {
+          message: "Outbound A2A URL is not allowed",
+          error_code: "outbound_not_allowed",
+          source: "hub_policy",
+        },
+      }),
+    } as Response);
+
+    const onError = jest.fn();
+
+    await fetchSSE("https://example.test/stream", { onError });
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "ApiRequestError",
+        status: 403,
+        errorCode: "outbound_not_allowed",
+        source: "hub_policy",
+        message: "Outbound A2A URL is not allowed",
+      }),
+    );
   });
 
   it("does not reset auth state when sse refresh fails transiently after 401", async () => {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -561,7 +561,7 @@ const executeJsonRequest = async (
   });
 };
 
-const parseApiErrorDetails = async (
+export const parseApiErrorResponse = async (
   response: Response,
 ): Promise<{
   message: string;
@@ -736,7 +736,7 @@ export async function apiRequest<Response, Body = unknown>(
   );
 
   if (!response.ok) {
-    const parsed = await parseApiErrorDetails(response);
+    const parsed = await parseApiErrorResponse(response);
     throw new ApiRequestError(parsed.message, response.status, {
       errorCode: parsed.errorCode,
       source: parsed.source,

--- a/frontend/lib/api/sse.ts
+++ b/frontend/lib/api/sse.ts
@@ -9,6 +9,7 @@ import {
   AuthRecoverableError,
   ensureFreshAccessToken,
   handleAuthExpiredOnce,
+  parseApiErrorResponse,
   refreshAccessTokenWithOutcome,
 } from "@/lib/api/client";
 import { useSessionStore } from "@/store/session";
@@ -229,13 +230,14 @@ export const fetchSSE = async (
             throw new AuthExpiredError();
           }
           if (!retryResponse.ok) {
-            const errorText = await retryResponse
-              .text()
-              .catch(() => "Unknown error");
-            throw new ApiRequestError(
-              `SSE request failed (${retryResponse.status}): ${errorText}`,
-              retryResponse.status,
-            );
+            const parsed = await parseApiErrorResponse(retryResponse);
+            throw new ApiRequestError(parsed.message, retryResponse.status, {
+              errorCode: parsed.errorCode,
+              source: parsed.source,
+              jsonrpcCode: parsed.jsonrpcCode,
+              missingParams: parsed.missingParams,
+              upstreamError: parsed.upstreamError,
+            });
           }
           await consumeSseStream(retryResponse, handlers, {
             resetIdleTimer,
@@ -255,11 +257,14 @@ export const fetchSSE = async (
       }
 
       if (!response.ok) {
-        const errorText = await response.text().catch(() => "Unknown error");
-        throw new ApiRequestError(
-          `SSE request failed (${response.status}): ${errorText}`,
-          response.status,
-        );
+        const parsed = await parseApiErrorResponse(response);
+        throw new ApiRequestError(parsed.message, response.status, {
+          errorCode: parsed.errorCode,
+          source: parsed.source,
+          jsonrpcCode: parsed.jsonrpcCode,
+          missingParams: parsed.missingParams,
+          upstreamError: parsed.upstreamError,
+        });
       }
 
       await consumeSseStream(response, handlers, {


### PR DESCRIPTION
## 概要
本 PR 聚焦修复 `#590` 与 `#598`：
- 补齐 streaming path 的 upstream 连接类错误映射，避免前端只看到模糊的 `upstream_stream_error`
- 统一 SSE 握手失败与普通 API 请求的错误解析路径，减少 transport 层级差异

## 变更模块
### Backend: A2A client / gateway
- 在 `backend/app/integrations/a2a_client/errors.py` 新增更明确的 upstream timeout 异常类型
- 在 `backend/app/integrations/a2a_client/client.py` 统一翻译 `httpx` 连接类异常：
  - 连接失败映射为 `agent_unavailable`
  - 超时映射为 `timeout`
  - 仅在真正的 shared transport / closed-client 场景下触发 `client_reset`
- 在 `backend/app/integrations/a2a_client/gateway.py` 保留更细粒度的 `error_code`，不再把所有 unavailable 类异常一律硬编码为 `agent_unavailable`

### Backend Tests
- 补充 `A2AClient` 对 connect error / connect timeout 的映射回归
- 补充 SSE stream 错误事件对 `timeout` 的透传断言

### Frontend: API / SSE
- 在 `frontend/lib/api/client.ts` 导出通用错误响应解析器
- 在 `frontend/lib/api/sse.ts` 复用同一解析器处理 SSE 握手期非 2xx 响应
- 让 SSE 握手失败能得到结构化 `ApiRequestError`，保留 `errorCode` / `source` / `jsonrpcCode` / `missingParams` / `upstreamError`

### Frontend Tests
- 补充 SSE 握手失败时的结构化 `ApiRequestError` 回归
- 维持现有 transport 相关测试通过，确认未破坏 SSE / chat runtime 错误承接链路

## 与 Issues 的关系
- Closes #590
- Closes #598
- Related #644

说明：
- `#644` 是本次审查时新建的 follow-up，用于跟进上游 `opencode-a2a#301` 的跨仓 error taxonomy 收敛，不在本 PR 的实现范围内

## 验证
### Backend
- `cd backend && uv sync --extra dev --locked`
- `cd backend && uv run --locked pre-commit run --files app/integrations/a2a_client/errors.py app/integrations/a2a_client/client.py app/integrations/a2a_client/gateway.py tests/client/test_a2a_client.py tests/invoke/test_a2a_invoke_service.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/client/test_a2a_client.py tests/invoke/test_a2a_invoke_service.py`

### Frontend
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/api/client.ts lib/api/sse.ts lib/api/__tests__/sse.test.ts --maxWorkers=25%`

## 风险与边界
- 本 PR 没有调整 OpenCode extension contract 的旧 upstream error taxonomy；该部分单独留在 `#644`
- 本 PR 主要修正聊天主链路与 SSE 握手错误承接，不扩展前端连接类提示文案策略
