### PR TITLE
feat(a2a-extensions): add session control capability contract (#648)

### DIFF
--- a/backend/app/features/extension_capabilities/common_router.py
+++ b/backend/app/features/extension_capabilities/common_router.py
@@ -8,7 +8,7 @@ This module centralises the route implementations to avoid drift.
 from __future__ import annotations
 
 import json
-from typing import Any, Awaitable, Callable, Dict, Optional, Type, cast
+from typing import Any, Awaitable, Callable, Dict, Literal, Optional, Type, cast
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Query, Response, status
@@ -41,6 +41,8 @@ from app.schemas.a2a_extension import (
     A2AExtensionResponse,
     A2AModelDiscoveryRequest,
     A2ARuntimeStatusContractResponse,
+    A2ASessionControlCapabilitiesResponse,
+    A2ASessionControlMethodResponse,
 )
 from app.utils.logging_redaction import redact_url_for_logging
 
@@ -77,6 +79,43 @@ def _summarize_metadata_keys(metadata: Optional[Dict[str, Any]]) -> list[str]:
     if not metadata:
         return []
     return sorted(str(k) for k in metadata.keys())[:20]
+
+
+_SESSION_CONTROL_HUB_CONSUMPTION = {
+    "prompt_async": True,
+    "command": False,
+    "shell": False,
+}
+
+
+def _build_session_control_response(
+    snapshot: Any,
+) -> A2ASessionControlCapabilitiesResponse:
+    resolved_methods = {}
+    capability = getattr(snapshot.session_query, "capability", None)
+    if capability is not None:
+        resolved_methods = dict(getattr(capability, "control_methods", {}) or {})
+
+    def _build_method(method_key: str) -> A2ASessionControlMethodResponse:
+        resolved = resolved_methods.get(method_key)
+        availability: Literal["always", "conditional", "unsupported"] = cast(
+            Literal["always", "conditional", "unsupported"],
+            getattr(resolved, "availability", "unsupported"),
+        )
+        return A2ASessionControlMethodResponse(
+            declared=bool(getattr(resolved, "declared", False)),
+            consumedByHub=_SESSION_CONTROL_HUB_CONSUMPTION[method_key],
+            availability=availability,
+            method=getattr(resolved, "method", None),
+            enabledByDefault=getattr(resolved, "enabled_by_default", None),
+            configKey=getattr(resolved, "config_key", None),
+        )
+
+    return A2ASessionControlCapabilitiesResponse(
+        promptAsync=_build_method("prompt_async"),
+        command=_build_method("command"),
+        shell=_build_method("shell"),
+    )
 
 
 def create_extension_capability_router(
@@ -165,15 +204,17 @@ def create_extension_capability_router(
         )
         model_selection = snapshot.model_selection.status == "supported"
         provider_discovery = snapshot.provider_discovery.status == "supported"
-        session_prompt_async = bool(
-            snapshot.session_query.capability
-            and snapshot.session_query.capability.ext.methods.get("prompt_async")
+        session_control = _build_session_control_response(snapshot)
+        session_prompt_async = (
+            session_control.prompt_async.declared
+            and session_control.prompt_async.consumed_by_hub
         )
 
         return A2AExtensionCapabilitiesResponse(
             modelSelection=model_selection,
             providerDiscovery=provider_discovery,
             sessionPromptAsync=session_prompt_async,
+            sessionControl=session_control,
             runtimeStatus=A2ARuntimeStatusContractResponse.model_validate(
                 runtime_status_contract_payload()
             ),

--- a/backend/app/integrations/a2a_extensions/session_query.py
+++ b/backend/app/integrations/a2a_extensions/session_query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 from a2a.types import AgentCard
 
@@ -25,6 +25,7 @@ from app.integrations.a2a_extensions.shared_contract import (
 from app.integrations.a2a_extensions.types import (
     PageSizePagination,
     ResolvedExtension,
+    ResolvedSessionControlMethodCapability,
     ResultEnvelopeMapping,
 )
 
@@ -184,6 +185,14 @@ def _resolve_extension(
         methods.get("prompt_async"),
         field="methods.prompt_async",
     )
+    command_method = normalize_method_name(
+        methods.get("command"),
+        field="methods.command",
+    )
+    shell_method = normalize_method_name(
+        methods.get("shell"),
+        field="methods.shell",
+    )
 
     pagination = as_dict(params.get("pagination"))
     mode = require_str(pagination.get("mode"), field="pagination.mode")
@@ -248,6 +257,8 @@ def _resolve_extension(
             "list_sessions": list_sessions_method,
             "get_session_messages": get_messages_method,
             "prompt_async": prompt_async_method,
+            "command": command_method,
+            "shell": shell_method,
         },
         pagination=PageSizePagination(
             mode=mode,
@@ -294,8 +305,78 @@ def resolve_legacy_session_query(card: AgentCard) -> ResolvedExtension:
     )
 
 
+def resolve_session_query_control_methods(
+    card: AgentCard,
+    *,
+    ext: ResolvedExtension,
+) -> dict[str, ResolvedSessionControlMethodCapability]:
+    """Resolve per-method session control capability metadata."""
+
+    raw_ext = _find_session_query_extension(card, allow_legacy_uri=True)
+    params: Dict[str, Any] = as_dict(getattr(raw_ext, "params", None))
+    raw_flags = as_dict(params.get("control_method_flags"))
+    control_methods: dict[str, ResolvedSessionControlMethodCapability] = {}
+
+    for method_key in ("prompt_async", "command", "shell"):
+        method_name = normalize_method_name(
+            ext.methods.get(method_key),
+            field=f"methods.{method_key}",
+        )
+        declared = method_name is not None
+        enabled_by_default: bool | None = None
+        config_key: str | None = None
+        availability: Literal["always", "conditional", "unsupported"] = (
+            "always" if declared else "unsupported"
+        )
+
+        raw_flag = raw_flags.get(method_key)
+        if raw_flag is not None:
+            if not isinstance(raw_flag, dict):
+                raise A2AExtensionContractError(
+                    f"'control_method_flags.{method_key}' must be an object if provided"
+                )
+
+            unknown_keys = sorted(
+                key
+                for key in raw_flag.keys()
+                if key not in {"enabled_by_default", "config_key"}
+            )
+            if unknown_keys:
+                raise A2AExtensionContractError(
+                    f"'control_method_flags.{method_key}' contains unsupported keys"
+                )
+
+            raw_enabled_by_default = raw_flag.get("enabled_by_default")
+            if raw_enabled_by_default is not None:
+                if not isinstance(raw_enabled_by_default, bool):
+                    raise A2AExtensionContractError(
+                        f"'control_method_flags.{method_key}.enabled_by_default' must be a boolean if provided"
+                    )
+                enabled_by_default = raw_enabled_by_default
+
+            raw_config_key = raw_flag.get("config_key")
+            if raw_config_key is not None:
+                config_key = require_str(
+                    raw_config_key,
+                    field=f"control_method_flags.{method_key}.config_key",
+                )
+
+            availability = "conditional"
+
+        control_methods[method_key] = ResolvedSessionControlMethodCapability(
+            method=method_name,
+            declared=declared,
+            availability=availability,
+            enabled_by_default=enabled_by_default,
+            config_key=config_key,
+        )
+
+    return control_methods
+
+
 __all__ = [
     "resolve_canonical_session_query",
     "resolve_legacy_session_query",
+    "resolve_session_query_control_methods",
     "resolve_session_query",
 ]

--- a/backend/app/integrations/a2a_extensions/session_query_runtime_selection.py
+++ b/backend/app/integrations/a2a_extensions/session_query_runtime_selection.py
@@ -13,11 +13,15 @@ from app.integrations.a2a_extensions.errors import (
 from app.integrations.a2a_extensions.session_query import (
     resolve_canonical_session_query,
     resolve_legacy_session_query,
+    resolve_session_query_control_methods,
 )
 from app.integrations.a2a_extensions.session_query_diagnostics import (
     diagnose_session_query,
 )
-from app.integrations.a2a_extensions.types import ResolvedExtension
+from app.integrations.a2a_extensions.types import (
+    ResolvedExtension,
+    ResolvedSessionControlMethodCapability,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,6 +31,7 @@ class ResolvedSessionQueryRuntimeCapability:
     ext: ResolvedExtension
     contract_mode: str
     selection_mode: str
+    control_methods: dict[str, ResolvedSessionControlMethodCapability]
 
 
 def resolve_runtime_session_query(
@@ -35,17 +40,21 @@ def resolve_runtime_session_query(
     diagnostic = diagnose_session_query(card)
 
     if diagnostic.status == "canonical":
+        ext = resolve_canonical_session_query(card)
         return ResolvedSessionQueryRuntimeCapability(
-            ext=resolve_canonical_session_query(card),
+            ext=ext,
             contract_mode="canonical",
             selection_mode="canonical_parser",
+            control_methods=resolve_session_query_control_methods(card, ext=ext),
         )
 
     if diagnostic.status == "legacy":
+        ext = resolve_legacy_session_query(card)
         return ResolvedSessionQueryRuntimeCapability(
-            ext=resolve_legacy_session_query(card),
+            ext=ext,
             contract_mode="legacy",
             selection_mode="legacy_compatibility",
+            control_methods=resolve_session_query_control_methods(card, ext=ext),
         )
 
     if diagnostic.status == "invalid":

--- a/backend/app/integrations/a2a_extensions/types.py
+++ b/backend/app/integrations/a2a_extensions/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, Optional
+from typing import Literal, Mapping, Optional
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +38,15 @@ class ResolvedExtension:
     pagination: PageSizePagination
     business_code_map: Mapping[int, str]
     result_envelope: Optional[ResultEnvelopeMapping]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSessionControlMethodCapability:
+    method: Optional[str]
+    declared: bool
+    availability: Literal["always", "conditional", "unsupported"]
+    enabled_by_default: bool | None = None
+    config_key: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +113,7 @@ __all__ = [
     "ResultEnvelopeMapping",
     "ResolvedModelSelectionExtension",
     "ResolvedProviderDiscoveryExtension",
+    "ResolvedSessionControlMethodCapability",
     "ResolvedExtension",
     "ResolvedInterruptCallbackExtension",
     "ResolvedSessionBindingExtension",

--- a/backend/app/schemas/a2a_extension.py
+++ b/backend/app/schemas/a2a_extension.py
@@ -127,6 +127,46 @@ class A2AModelDiscoveryRequest(BaseModel):
     )
 
 
+class A2ASessionControlMethodResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    declared: bool = Field(
+        ...,
+        description="Whether the upstream extension currently declares this control method",
+    )
+    consumed_by_hub: bool = Field(
+        ...,
+        alias="consumedByHub",
+        description="Whether the hub currently consumes and exposes this control method",
+    )
+    availability: Literal["always", "conditional", "unsupported"] = Field(
+        ...,
+        description="Hub-normalized availability for this control method",
+    )
+    method: Optional[str] = Field(
+        default=None,
+        description="Declared upstream JSON-RPC method name when available",
+    )
+    enabled_by_default: Optional[bool] = Field(
+        default=None,
+        alias="enabledByDefault",
+        description="Whether the deployment-conditional method is enabled by default",
+    )
+    config_key: Optional[str] = Field(
+        default=None,
+        alias="configKey",
+        description="Configuration key that governs deployment-conditional availability",
+    )
+
+
+class A2ASessionControlCapabilitiesResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    prompt_async: A2ASessionControlMethodResponse = Field(..., alias="promptAsync")
+    command: A2ASessionControlMethodResponse
+    shell: A2ASessionControlMethodResponse
+
+
 class A2AExtensionCapabilitiesResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -147,6 +187,11 @@ class A2AExtensionCapabilitiesResponse(BaseModel):
             "Whether the agent advertises shared session-query prompt_async support"
         ),
     )
+    session_control: A2ASessionControlCapabilitiesResponse = Field(
+        ...,
+        alias="sessionControl",
+        description="Hub-stable method-level session control capability contract",
+    )
     runtime_status: A2ARuntimeStatusContractResponse = Field(
         ...,
         alias="runtimeStatus",
@@ -157,6 +202,8 @@ class A2AExtensionCapabilitiesResponse(BaseModel):
 __all__ = [
     "A2AExtensionPromptAsyncRequest",
     "A2AExtensionCapabilitiesResponse",
+    "A2ASessionControlCapabilitiesResponse",
+    "A2ASessionControlMethodResponse",
     "A2AModelDiscoveryRequest",
     "A2AExtensionPermissionReplyRequest",
     "A2ARuntimeStatusContractResponse",

--- a/backend/tests/extensions/test_a2a_extensions_service.py
+++ b/backend/tests/extensions/test_a2a_extensions_service.py
@@ -38,6 +38,7 @@ from app.integrations.a2a_extensions.types import (
     ResolvedInterruptCallbackExtension,
     ResolvedModelSelectionExtension,
     ResolvedProviderDiscoveryExtension,
+    ResolvedSessionControlMethodCapability,
     ResolvedStreamHintsExtension,
     ResultEnvelopeMapping,
 )
@@ -49,12 +50,32 @@ def _session_query_snapshot(
     contract_mode: str = "canonical",
     selection_mode: str = "canonical_parser",
 ) -> SessionQueryCapabilitySnapshot:
+    control_methods = {
+        "prompt_async": ResolvedSessionControlMethodCapability(
+            method=ext.methods.get("prompt_async"),
+            declared=bool(ext.methods.get("prompt_async")),
+            availability="always" if ext.methods.get("prompt_async") else "unsupported",
+        ),
+        "command": ResolvedSessionControlMethodCapability(
+            method=ext.methods.get("command"),
+            declared=bool(ext.methods.get("command")),
+            availability="always" if ext.methods.get("command") else "unsupported",
+        ),
+        "shell": ResolvedSessionControlMethodCapability(
+            method=ext.methods.get("shell"),
+            declared=bool(ext.methods.get("shell")),
+            availability="conditional" if ext.methods.get("shell") else "unsupported",
+            enabled_by_default=False if ext.methods.get("shell") else None,
+            config_key="A2A_ENABLE_SESSION_SHELL" if ext.methods.get("shell") else None,
+        ),
+    }
     return SessionQueryCapabilitySnapshot(
         status="supported",
         capability=ResolvedSessionQueryRuntimeCapability(
             ext=ext,
             contract_mode=contract_mode,
             selection_mode=selection_mode,
+            control_methods=control_methods,
         ),
     )
 

--- a/backend/tests/extensions/test_session_query_extension_discovery.py
+++ b/backend/tests/extensions/test_session_query_extension_discovery.py
@@ -7,7 +7,10 @@ from app.integrations.a2a_extensions.errors import (
     A2AExtensionContractError,
     A2AExtensionNotSupportedError,
 )
-from app.integrations.a2a_extensions.session_query import resolve_session_query
+from app.integrations.a2a_extensions.session_query import (
+    resolve_session_query,
+    resolve_session_query_control_methods,
+)
 from app.integrations.a2a_extensions.shared_contract import (
     LEGACY_SHARED_SESSION_QUERY_URI,
     SHARED_SESSION_QUERY_URI,
@@ -47,6 +50,14 @@ def test_resolve_extracts_methods_pagination_provider_and_interface() -> None:
                     "list_sessions": "shared.sessions.list",
                     "get_session_messages": "shared.sessions.messages.list",
                     "prompt_async": "shared.sessions.prompt_async",
+                    "command": "shared.sessions.command",
+                    "shell": "shared.sessions.shell",
+                },
+                "control_method_flags": {
+                    "shell": {
+                        "enabled_by_default": False,
+                        "config_key": "A2A_ENABLE_SESSION_SHELL",
+                    }
                 },
                 "pagination": {
                     "mode": "page_size",
@@ -78,6 +89,8 @@ def test_resolve_extracts_methods_pagination_provider_and_interface() -> None:
     assert resolved.methods["list_sessions"] == "shared.sessions.list"
     assert resolved.methods["get_session_messages"] == "shared.sessions.messages.list"
     assert resolved.methods["prompt_async"] == "shared.sessions.prompt_async"
+    assert resolved.methods["command"] == "shared.sessions.command"
+    assert resolved.methods["shell"] == "shared.sessions.shell"
     assert resolved.pagination.default_size == 20
     assert resolved.pagination.max_size == 100
     assert resolved.jsonrpc.url == "https://api.example.com/jsonrpc"
@@ -88,6 +101,15 @@ def test_resolve_extracts_methods_pagination_provider_and_interface() -> None:
     assert resolved.pagination.params == ("page", "size")
     assert resolved.pagination.supports_offset is False
     assert resolved.result_envelope == ResultEnvelopeMapping()
+
+    control_methods = resolve_session_query_control_methods(card, ext=resolved)
+    assert control_methods["prompt_async"].declared is True
+    assert control_methods["prompt_async"].availability == "always"
+    assert control_methods["command"].declared is True
+    assert control_methods["command"].availability == "always"
+    assert control_methods["shell"].declared is True
+    assert control_methods["shell"].availability == "conditional"
+    assert control_methods["shell"].config_key == "A2A_ENABLE_SESSION_SHELL"
 
 
 def test_resolve_falls_back_to_card_url_when_interface_missing() -> None:

--- a/backend/tests/extensions/test_session_query_runtime_selection.py
+++ b/backend/tests/extensions/test_session_query_runtime_selection.py
@@ -53,6 +53,14 @@ def _build_card(
                 "methods": {
                     "list_sessions": "shared.sessions.list",
                     "get_session_messages": "shared.sessions.messages.list",
+                    "prompt_async": "shared.sessions.prompt_async",
+                    "command": "shared.sessions.command",
+                },
+                "control_method_flags": {
+                    "shell": {
+                        "enabled_by_default": False,
+                        "config_key": "A2A_ENABLE_SESSION_SHELL",
+                    }
                 },
                 "pagination": pagination
                 or {
@@ -87,6 +95,13 @@ def test_resolve_runtime_session_query_selects_canonical_parser() -> None:
     assert capability.contract_mode == "canonical"
     assert capability.selection_mode == "canonical_parser"
     assert capability.ext.uri == SHARED_SESSION_QUERY_URI
+    assert capability.control_methods["prompt_async"].declared is True
+    assert capability.control_methods["prompt_async"].availability == "always"
+    assert capability.control_methods["command"].declared is True
+    assert capability.control_methods["command"].availability == "always"
+    assert capability.control_methods["shell"].declared is False
+    assert capability.control_methods["shell"].availability == "conditional"
+    assert capability.control_methods["shell"].config_key == "A2A_ENABLE_SESSION_SHELL"
 
 
 def test_resolve_runtime_session_query_selects_legacy_compatibility() -> None:

--- a/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
+++ b/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
@@ -935,9 +935,24 @@ async def test_hub_extension_capabilities_route_returns_model_selection_true(
         session_query=SimpleNamespace(
             status="supported",
             capability=SimpleNamespace(
-                ext=SimpleNamespace(
-                    methods={"prompt_async": "shared.sessions.prompt_async"}
-                )
+                control_methods={
+                    "prompt_async": SimpleNamespace(
+                        declared=True,
+                        availability="always",
+                        method="shared.sessions.prompt_async",
+                    ),
+                    "command": SimpleNamespace(
+                        declared=True,
+                        availability="always",
+                        method="shared.sessions.command",
+                    ),
+                    "shell": SimpleNamespace(
+                        declared=False,
+                        availability="conditional",
+                        config_key="A2A_ENABLE_SESSION_SHELL",
+                        enabled_by_default=False,
+                    ),
+                }
             ),
         ),
     )
@@ -962,6 +977,32 @@ async def test_hub_extension_capabilities_route_returns_model_selection_true(
         "modelSelection": True,
         "providerDiscovery": True,
         "sessionPromptAsync": True,
+        "sessionControl": {
+            "promptAsync": {
+                "declared": True,
+                "consumedByHub": True,
+                "availability": "always",
+                "method": "shared.sessions.prompt_async",
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+            "command": {
+                "declared": True,
+                "consumedByHub": False,
+                "availability": "always",
+                "method": "shared.sessions.command",
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+            "shell": {
+                "declared": False,
+                "consumedByHub": False,
+                "availability": "conditional",
+                "method": None,
+                "enabledByDefault": False,
+                "configKey": "A2A_ENABLE_SESSION_SHELL",
+            },
+        },
         "runtimeStatus": runtime_status_contract_payload(),
     }
     assert response.headers["cache-control"] == "no-store"
@@ -988,7 +1029,23 @@ async def test_hub_extension_capabilities_route_returns_model_selection_false_fo
         session_query=SimpleNamespace(
             status="supported",
             capability=SimpleNamespace(
-                ext=SimpleNamespace(methods={"prompt_async": None})
+                control_methods={
+                    "prompt_async": SimpleNamespace(
+                        declared=False,
+                        availability="unsupported",
+                        method=None,
+                    ),
+                    "command": SimpleNamespace(
+                        declared=False,
+                        availability="unsupported",
+                        method=None,
+                    ),
+                    "shell": SimpleNamespace(
+                        declared=False,
+                        availability="unsupported",
+                        method=None,
+                    ),
+                }
             ),
         ),
     )
@@ -1013,6 +1070,32 @@ async def test_hub_extension_capabilities_route_returns_model_selection_false_fo
         "modelSelection": True,
         "providerDiscovery": False,
         "sessionPromptAsync": False,
+        "sessionControl": {
+            "promptAsync": {
+                "declared": False,
+                "consumedByHub": True,
+                "availability": "unsupported",
+                "method": None,
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+            "command": {
+                "declared": False,
+                "consumedByHub": False,
+                "availability": "unsupported",
+                "method": None,
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+            "shell": {
+                "declared": False,
+                "consumedByHub": False,
+                "availability": "unsupported",
+                "method": None,
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+        },
         "runtimeStatus": runtime_status_contract_payload(),
     }
     assert response.headers["cache-control"] == "no-store"
@@ -1039,9 +1122,24 @@ async def test_hub_extension_capabilities_route_distinguishes_model_selection_fr
         session_query=SimpleNamespace(
             status="supported",
             capability=SimpleNamespace(
-                ext=SimpleNamespace(
-                    methods={"prompt_async": "shared.sessions.prompt_async"}
-                )
+                control_methods={
+                    "prompt_async": SimpleNamespace(
+                        declared=True,
+                        availability="always",
+                        method="shared.sessions.prompt_async",
+                    ),
+                    "command": SimpleNamespace(
+                        declared=True,
+                        availability="always",
+                        method="shared.sessions.command",
+                    ),
+                    "shell": SimpleNamespace(
+                        declared=False,
+                        availability="conditional",
+                        config_key="A2A_ENABLE_SESSION_SHELL",
+                        enabled_by_default=False,
+                    ),
+                }
             ),
         ),
     )
@@ -1066,6 +1164,32 @@ async def test_hub_extension_capabilities_route_distinguishes_model_selection_fr
         "modelSelection": False,
         "providerDiscovery": True,
         "sessionPromptAsync": True,
+        "sessionControl": {
+            "promptAsync": {
+                "declared": True,
+                "consumedByHub": True,
+                "availability": "always",
+                "method": "shared.sessions.prompt_async",
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+            "command": {
+                "declared": True,
+                "consumedByHub": False,
+                "availability": "always",
+                "method": "shared.sessions.command",
+                "enabledByDefault": None,
+                "configKey": None,
+            },
+            "shell": {
+                "declared": False,
+                "consumedByHub": False,
+                "availability": "conditional",
+                "method": None,
+                "enabledByDefault": False,
+                "configKey": "A2A_ENABLE_SESSION_SHELL",
+            },
+        },
         "runtimeStatus": runtime_status_contract_payload(),
     }
 

--- a/frontend/hooks/__tests__/useExtensionCapabilitiesQuery.test.tsx
+++ b/frontend/hooks/__tests__/useExtensionCapabilitiesQuery.test.tsx
@@ -53,6 +53,43 @@ const createRuntimeStatus = (): RuntimeStatusContract => ({
   passthroughUnknown: true,
 });
 
+const createSessionControl = (overrides?: {
+  promptAsync?: Partial<{
+    declared: boolean;
+    consumedByHub: boolean;
+    availability: "always" | "conditional" | "unsupported";
+  }>;
+  command?: Partial<{
+    declared: boolean;
+    consumedByHub: boolean;
+    availability: "always" | "conditional" | "unsupported";
+  }>;
+  shell?: Partial<{
+    declared: boolean;
+    consumedByHub: boolean;
+    availability: "always" | "conditional" | "unsupported";
+  }>;
+}) => ({
+  promptAsync: {
+    declared: true,
+    consumedByHub: true,
+    availability: "always" as const,
+    ...overrides?.promptAsync,
+  },
+  command: {
+    declared: true,
+    consumedByHub: false,
+    availability: "always" as const,
+    ...overrides?.command,
+  },
+  shell: {
+    declared: false,
+    consumedByHub: false,
+    availability: "conditional" as const,
+    ...overrides?.shell,
+  },
+});
+
 describe("useExtensionCapabilitiesQuery", () => {
   let queryClient: QueryClient;
 
@@ -70,6 +107,7 @@ describe("useExtensionCapabilitiesQuery", () => {
       modelSelection: true,
       providerDiscovery: true,
       sessionPromptAsync: true,
+      sessionControl: createSessionControl(),
       runtimeStatus: createRuntimeStatus(),
     });
 
@@ -88,6 +126,8 @@ describe("useExtensionCapabilitiesQuery", () => {
     expect(result.current.providerDiscoveryStatus).toBe("supported");
     expect(result.current.runtimeStatusContract?.version).toBe("v1");
     expect(result.current.sessionPromptAsyncStatus).toBe("supported");
+    expect(result.current.sessionCommandStatus).toBe("unsupported");
+    expect(result.current.sessionShellStatus).toBe("unsupported");
   });
 
   it("returns unsupported when model selection is unavailable", async () => {
@@ -95,6 +135,19 @@ describe("useExtensionCapabilitiesQuery", () => {
       modelSelection: false,
       providerDiscovery: false,
       sessionPromptAsync: false,
+      sessionControl: createSessionControl({
+        promptAsync: { declared: false, availability: "unsupported" },
+        command: {
+          declared: false,
+          consumedByHub: false,
+          availability: "unsupported",
+        },
+        shell: {
+          declared: false,
+          consumedByHub: false,
+          availability: "unsupported",
+        },
+      }),
       runtimeStatus: createRuntimeStatus(),
     });
 
@@ -119,6 +172,9 @@ describe("useExtensionCapabilitiesQuery", () => {
       modelSelection: true,
       providerDiscovery: false,
       sessionPromptAsync: false,
+      sessionControl: createSessionControl({
+        promptAsync: { declared: false, availability: "unsupported" },
+      }),
       runtimeStatus: createRuntimeStatus(),
     });
 
@@ -156,5 +212,7 @@ describe("useExtensionCapabilitiesQuery", () => {
     expect(result.current.modelSelectionStatus).toBe("unknown");
     expect(result.current.providerDiscoveryStatus).toBe("unknown");
     expect(result.current.sessionPromptAsyncStatus).toBe("unknown");
+    expect(result.current.sessionCommandStatus).toBe("unknown");
+    expect(result.current.sessionShellStatus).toBe("unknown");
   });
 });

--- a/frontend/hooks/useExtensionCapabilitiesQuery.ts
+++ b/frontend/hooks/useExtensionCapabilitiesQuery.ts
@@ -5,6 +5,19 @@ import { queryKeys } from "@/lib/queryKeys";
 import { type AgentSource } from "@/store/agents";
 
 export type GenericCapabilityStatus = "unknown" | "supported" | "unsupported";
+type SessionControlMethodCapability = {
+  declared: boolean;
+  consumedByHub: boolean;
+};
+
+const resolveSessionControlStatus = (
+  method?: SessionControlMethodCapability | null,
+): GenericCapabilityStatus => {
+  if (!method) {
+    return "unknown";
+  }
+  return method.declared && method.consumedByHub ? "supported" : "unsupported";
+};
 
 export const useExtensionCapabilitiesQuery = ({
   agentId,
@@ -50,11 +63,21 @@ export const useExtensionCapabilitiesQuery = ({
         ? "unsupported"
         : "unknown";
   const sessionPromptAsyncStatus: GenericCapabilityStatus =
-    query.data?.sessionPromptAsync === true
-      ? "supported"
-      : query.data?.sessionPromptAsync === false
-        ? "unsupported"
-        : "unknown";
+    query.data?.sessionControl?.promptAsync != null
+      ? resolveSessionControlStatus(query.data.sessionControl.promptAsync)
+      : query.data?.sessionPromptAsync === true
+        ? "supported"
+        : query.data?.sessionPromptAsync === false
+          ? "unsupported"
+          : "unknown";
+  const sessionCommandStatus: GenericCapabilityStatus =
+    query.data?.sessionControl?.command != null
+      ? resolveSessionControlStatus(query.data.sessionControl.command)
+      : "unknown";
+  const sessionShellStatus: GenericCapabilityStatus =
+    query.data?.sessionControl?.shell != null
+      ? resolveSessionControlStatus(query.data.sessionControl.shell)
+      : "unknown";
 
   return {
     ...query,
@@ -62,6 +85,9 @@ export const useExtensionCapabilitiesQuery = ({
     modelSelectionStatus,
     providerDiscoveryStatus,
     sessionPromptAsyncStatus,
+    sessionCommandStatus,
+    sessionShellStatus,
+    sessionControl: query.data?.sessionControl ?? null,
     canShowModelPicker: modelSelectionStatus !== "unsupported",
   };
 };

--- a/frontend/lib/__tests__/a2aExtensions.test.ts
+++ b/frontend/lib/__tests__/a2aExtensions.test.ts
@@ -188,6 +188,27 @@ describe("assertExtensionSuccess", () => {
       modelSelection: false,
       providerDiscovery: true,
       sessionPromptAsync: true,
+      sessionControl: {
+        promptAsync: {
+          declared: true,
+          consumedByHub: true,
+          availability: "always",
+          method: "shared.sessions.prompt_async",
+        },
+        command: {
+          declared: true,
+          consumedByHub: false,
+          availability: "always",
+          method: "shared.sessions.command",
+        },
+        shell: {
+          declared: false,
+          consumedByHub: false,
+          availability: "conditional",
+          configKey: "A2A_ENABLE_SESSION_SHELL",
+          enabledByDefault: false,
+        },
+      },
       runtimeStatus: {
         version: "v1",
         canonicalStates: [
@@ -231,6 +252,8 @@ describe("assertExtensionSuccess", () => {
     expect(result.modelSelection).toBe(false);
     expect(result.providerDiscovery).toBe(true);
     expect(result.sessionPromptAsync).toBe(true);
+    expect(result.sessionControl.command.consumedByHub).toBe(false);
+    expect(result.sessionControl.shell.availability).toBe("conditional");
     expect(result.runtimeStatus.version).toBe("v1");
     expect(result.runtimeStatus.aliases.canceled).toBe("cancelled");
   });

--- a/frontend/lib/api/a2aExtensions.ts
+++ b/frontend/lib/api/a2aExtensions.ts
@@ -16,6 +16,32 @@ export type A2AExtensionCapabilities = {
   modelSelection: boolean;
   providerDiscovery: boolean;
   sessionPromptAsync: boolean;
+  sessionControl: {
+    promptAsync: {
+      declared: boolean;
+      consumedByHub: boolean;
+      availability: "always" | "conditional" | "unsupported";
+      method?: string | null;
+      enabledByDefault?: boolean | null;
+      configKey?: string | null;
+    };
+    command: {
+      declared: boolean;
+      consumedByHub: boolean;
+      availability: "always" | "conditional" | "unsupported";
+      method?: string | null;
+      enabledByDefault?: boolean | null;
+      configKey?: string | null;
+    };
+    shell: {
+      declared: boolean;
+      consumedByHub: boolean;
+      availability: "always" | "conditional" | "unsupported";
+      method?: string | null;
+      enabledByDefault?: boolean | null;
+      configKey?: string | null;
+    };
+  };
   runtimeStatus: RuntimeStatusContract;
 };
 


### PR DESCRIPTION
## 背景与范围

- 本 PR 只落实 `#648` 的协议层范围：为 `session-query` 建立方法级 capability 契约，并明确区分 `prompt_async`、`command`、`shell`。
- 不在本 PR 中新增 `command` / `shell` 的执行入口、路由或前端交互。

## Backend

- 扩展 `session-query` resolver，显式解析 `methods.command`、`methods.shell` 与 `control_method_flags`。
- 在 runtime capability 中新增结构化 `control_methods`，把控制方法归一化为本仓协议语义：`declared`、`consumedByHub`、`availability`、`configKey`。
- 更新 `/extensions/capabilities` 响应，新增 `sessionControl`，并继续保留 `sessionPromptAsync` 作为兼容快捷位。
- 增补后端测试，覆盖 resolver、runtime selection、capabilities route。

## Frontend

- 扩展 `a2aExtensions` 能力类型，消费新的 `sessionControl` 稳定协议。
- `useExtensionCapabilitiesQuery` 统一从 `sessionControl` 推导 `sessionPromptAsyncStatus`，并补出 `sessionCommandStatus`、`sessionShellStatus`，但本次不新增 UI 入口。
- 增补前端类型与 hook/API 测试。

## 与 Issues 的关系

- Closes #648
- Related #652
- Related #653

关系说明：
- `#648` 现在聚焦方法级 capability 契约与诊断，这正是本 PR 的实现范围，因此使用 `Closes`。
- `#652` 和 `#653` 分别跟进 `command` / `shell` 的实际消费与暴露边界，本 PR 没有实现这些执行链路，因此只标记 `Related`。

## 验证

- Backend: `cd backend && uv run --locked pre-commit run --files app/features/extension_capabilities/common_router.py app/integrations/a2a_extensions/session_query.py app/integrations/a2a_extensions/session_query_runtime_selection.py app/integrations/a2a_extensions/types.py app/schemas/a2a_extension.py tests/extensions/test_a2a_extensions_service.py tests/extensions/test_session_query_extension_discovery.py tests/extensions/test_session_query_runtime_selection.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py --config ../.pre-commit-config.yaml`
- Backend: `cd backend && uv run --locked pytest tests/extensions/test_a2a_extensions_service.py tests/extensions/test_session_query_extension_discovery.py tests/extensions/test_session_query_runtime_selection.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py`
- Backend 结果：`83 passed in 31.31s`
- Frontend: `cd frontend && npm run lint`
- Frontend: `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- Frontend: `cd frontend && npm test -- --findRelatedTests hooks/useExtensionCapabilitiesQuery.ts hooks/__tests__/useExtensionCapabilitiesQuery.test.tsx lib/api/a2aExtensions.ts lib/__tests__/a2aExtensions.test.ts --maxWorkers=25%`
- Frontend 结果：`6 passed, 44 tests passed`
