### PR TITLE
feat(a2a-extensions): recover pending interrupts for bound sessions (#657)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -184,6 +184,9 @@ Endpoints:
   - `GET /api/v1/me/a2a/agents/{agent_id}/extensions/sessions/{session_id}/messages?page=1&size=50`
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/sessions/{session_id}/messages:query`
 - Reply interrupt callbacks:
+  - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/interrupts:recover`
+    - body: `{ "sessionId": "ses-123" }`
+    - returns: `{ "items": [{ "requestId": "...", "sessionId": "ses-123", "type": "permission|question", "details": { ... }, "expiresAt": 123.0, "source": "recovery" }] }`
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/interrupts/permission:reply`
     - body: `{ "request_id": "...", "reply": "once|always|reject" }`
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/interrupts/question:reply`
@@ -211,6 +214,9 @@ Notes:
 - Interrupt callback payloads intentionally follow the strict upstream contract:
   `request_id` is required; legacy fields such as `requestID`, `decision`,
   `allow` or `deny` are not accepted.
+- Interrupt recovery is exposed as a Hub-stable route. The backend hides the
+  upstream provider-private JSON-RPC methods and merges the recovery views for
+  pending permissions/questions before returning them to the frontend.
 
 Unified error semantics (`error_code` -> HTTP status):
 

--- a/backend/app/features/extension_capabilities/common_router.py
+++ b/backend/app/features/extension_capabilities/common_router.py
@@ -32,6 +32,7 @@ from app.integrations.a2a_runtime_status_contract import (
 )
 from app.schemas.a2a_extension import (
     A2AExtensionCapabilitiesResponse,
+    A2AExtensionInterruptRecoveryRequest,
     A2AExtensionPermissionReplyRequest,
     A2AExtensionPromptAsyncRequest,
     A2AExtensionQueryRequest,
@@ -40,6 +41,7 @@ from app.schemas.a2a_extension import (
     A2AExtensionQuestionReplyRequest,
     A2AExtensionResponse,
     A2AExtensionSessionCommandRequest,
+    A2AInterruptRecoveryResponse,
     A2AModelDiscoveryRequest,
     A2ARuntimeStatusContractResponse,
     A2ASessionControlCapabilitiesResponse,
@@ -205,6 +207,7 @@ def create_extension_capability_router(
         )
         model_selection = snapshot.model_selection.status == "supported"
         provider_discovery = snapshot.provider_discovery.status == "supported"
+        interrupt_recovery = snapshot.interrupt_recovery.status == "supported"
         session_control = _build_session_control_response(snapshot)
         session_prompt_async = (
             session_control.prompt_async.declared
@@ -214,6 +217,7 @@ def create_extension_capability_router(
         return A2AExtensionCapabilitiesResponse(
             modelSelection=model_selection,
             providerDiscovery=provider_discovery,
+            interruptRecovery=interrupt_recovery,
             sessionPromptAsync=session_prompt_async,
             sessionControl=session_control,
             runtimeStatus=A2ARuntimeStatusContractResponse.model_validate(
@@ -527,6 +531,49 @@ def create_extension_capability_router(
                 request_payload=payload.request,
                 metadata=payload.metadata,
             )
+        )
+
+    @router.post(
+        "/{agent_id}/extensions/interrupts:recover",
+        response_model=A2AInterruptRecoveryResponse,
+        status_code=status.HTTP_200_OK,
+        response_model_exclude_none=True,
+    )
+    async def recover_interrupts(
+        *,
+        agent_id: UUID,
+        payload: A2AExtensionInterruptRecoveryRequest,
+        response: Response,
+        db: AsyncSession = Depends(get_async_db),
+        current_user: User = Depends(get_current_user),
+    ) -> A2AInterruptRecoveryResponse | JSONResponse:
+        response.headers["Cache-Control"] = "no-store"
+
+        runtime = await _get_runtime(db, current_user, agent_id)
+        logger.info(
+            _scope_message("Shared extension interrupt recovery requested"),
+            extra={
+                "user_id": str(current_user.id),
+                "agent_id": str(agent_id),
+                "agent_url": redact_url_for_logging(runtime.resolved.url),
+                "session_id": payload.session_id,
+            },
+        )
+
+        result = await _run_extension_call(
+            _extensions_service().recover_interrupts(
+                runtime=runtime,
+                session_id=payload.session_id,
+            )
+        )
+        if isinstance(result, JSONResponse):
+            return result
+        resolved_result = (
+            result.result if isinstance(result.result, dict) else {"items": []}
+        )
+        items = resolved_result.get("items")
+        return A2AInterruptRecoveryResponse.model_validate(
+            {"items": items if isinstance(items, list) else []}
         )
 
     @router.post(

--- a/backend/app/integrations/a2a_extensions/interrupt_recovery.py
+++ b/backend/app/integrations/a2a_extensions/interrupt_recovery.py
@@ -1,0 +1,75 @@
+"""Interrupt recovery extension resolver and helpers."""
+
+from __future__ import annotations
+
+from a2a.types import AgentCard
+
+from app.integrations.a2a_extensions.contract_utils import (
+    as_dict,
+    build_business_code_map,
+    normalize_method_name,
+    require_str,
+    resolve_jsonrpc_interface,
+)
+from app.integrations.a2a_extensions.errors import (
+    A2AExtensionNotSupportedError,
+)
+from app.integrations.a2a_extensions.shared_contract import (
+    INTERRUPT_RECOVERY_URI,
+)
+from app.integrations.a2a_extensions.types import (
+    ResolvedInterruptRecoveryExtension,
+)
+
+
+def resolve_interrupt_recovery(
+    card: AgentCard,
+) -> ResolvedInterruptRecoveryExtension:
+    capabilities = getattr(card, "capabilities", None)
+    extensions = getattr(capabilities, "extensions", None) if capabilities else None
+    if not extensions:
+        raise A2AExtensionNotSupportedError("Agent does not declare any extensions")
+
+    ext = None
+    for candidate in extensions:
+        if getattr(candidate, "uri", None) == INTERRUPT_RECOVERY_URI:
+            ext = candidate
+            break
+    if ext is None:
+        raise A2AExtensionNotSupportedError("Interrupt recovery extension not found")
+
+    required = bool(getattr(ext, "required", False))
+    params = as_dict(getattr(ext, "params", None))
+    raw_provider = params.get("provider")
+    if raw_provider is None:
+        provider = "opencode"
+    else:
+        provider = require_str(raw_provider, field="params.provider").lower()
+
+    methods = as_dict(params.get("methods"))
+    list_permissions_method = normalize_method_name(
+        methods.get("list_permissions"),
+        field="methods.list_permissions",
+    )
+    list_questions_method = normalize_method_name(
+        methods.get("list_questions"),
+        field="methods.list_questions",
+    )
+
+    errors = as_dict(params.get("errors"))
+    code_to_error = build_business_code_map(errors.get("business_codes"))
+
+    return ResolvedInterruptRecoveryExtension(
+        uri=str(getattr(ext, "uri", INTERRUPT_RECOVERY_URI)),
+        required=required,
+        provider=provider,
+        jsonrpc=resolve_jsonrpc_interface(card),
+        methods={
+            "list_permissions": list_permissions_method,
+            "list_questions": list_questions_method,
+        },
+        business_code_map=code_to_error,
+    )
+
+
+__all__ = ["resolve_interrupt_recovery"]

--- a/backend/app/integrations/a2a_extensions/interrupt_recovery_service.py
+++ b/backend/app/integrations/a2a_extensions/interrupt_recovery_service.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from app.features.personal_agents.runtime import A2ARuntime
+from app.integrations.a2a_extensions.errors import A2AExtensionContractError
+from app.integrations.a2a_extensions.service_common import ExtensionCallResult
+from app.integrations.a2a_extensions.shared_support import A2AExtensionSupport
+from app.integrations.a2a_extensions.types import ResolvedInterruptRecoveryExtension
+
+
+class InterruptRecoveryService:
+    def __init__(self, support: A2AExtensionSupport) -> None:
+        self._support = support
+
+    @staticmethod
+    def prepare_recovery_query(
+        *,
+        session_id: str | None = None,
+    ) -> str | None:
+        resolved_session_id = (session_id or "").strip()
+        return resolved_session_id or None
+
+    @staticmethod
+    def _normalize_item(item: Any) -> dict[str, Any]:
+        if not isinstance(item, dict):
+            raise A2AExtensionContractError(
+                "Interrupt recovery result item must be an object"
+            )
+
+        request_id = item.get("request_id")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise A2AExtensionContractError(
+                "Interrupt recovery item missing request_id"
+            )
+
+        session_id = item.get("session_id")
+        if not isinstance(session_id, str) or not session_id.strip():
+            raise A2AExtensionContractError(
+                "Interrupt recovery item missing session_id"
+            )
+
+        interrupt_type = item.get("interrupt_type")
+        if interrupt_type not in {"permission", "question"}:
+            raise A2AExtensionContractError(
+                "Interrupt recovery item has invalid interrupt_type"
+            )
+
+        details = item.get("details")
+        if details is not None and not isinstance(details, dict):
+            raise A2AExtensionContractError(
+                "Interrupt recovery item details must be an object when provided"
+            )
+
+        expires_at = item.get("expires_at")
+        if expires_at is not None and not isinstance(expires_at, (int, float)):
+            raise A2AExtensionContractError(
+                "Interrupt recovery item expires_at must be numeric when provided"
+            )
+
+        normalized: dict[str, Any] = {
+            "request_id": request_id.strip(),
+            "session_id": session_id.strip(),
+            "type": interrupt_type,
+            "details": dict(details) if isinstance(details, dict) else {},
+        }
+
+        task_id = item.get("task_id")
+        if isinstance(task_id, str) and task_id.strip():
+            normalized["task_id"] = task_id.strip()
+
+        context_id = item.get("context_id")
+        if isinstance(context_id, str) and context_id.strip():
+            normalized["context_id"] = context_id.strip()
+
+        if isinstance(expires_at, (int, float)):
+            normalized["expires_at"] = float(expires_at)
+
+        return normalized
+
+    def _normalize_result_items(self, result: Any) -> list[dict[str, Any]]:
+        if not isinstance(result, dict):
+            raise A2AExtensionContractError(
+                "Interrupt recovery result envelope must be an object"
+            )
+
+        items = result.get("items")
+        if not isinstance(items, list):
+            raise A2AExtensionContractError(
+                "Interrupt recovery result envelope missing items"
+            )
+
+        return [self._normalize_item(item) for item in items]
+
+    async def invoke_method(
+        self,
+        *,
+        runtime: A2ARuntime,
+        ext: ResolvedInterruptRecoveryExtension,
+        jsonrpc_url: str,
+        method_key: str,
+    ) -> ExtensionCallResult:
+        method_name = ext.methods.get(method_key)
+        if not method_name:
+            return ExtensionCallResult(
+                success=False,
+                error_code="method_not_supported",
+                upstream_error={
+                    "message": f"Method {method_key} is not supported by upstream"
+                },
+                meta={"extension_uri": ext.uri},
+            )
+
+        resp = await self._support.perform_jsonrpc_call(
+            runtime=runtime,
+            jsonrpc_url=jsonrpc_url,
+            method_name=method_name,
+            params={},
+        )
+
+        meta: Dict[str, Any] = {
+            "extension_uri": ext.uri,
+            "jsonrpc_fallback_used": ext.jsonrpc.fallback_used,
+            "method_key": method_key,
+            "method_name": method_name,
+        }
+        metric_key = f"{ext.uri}:{method_name}"
+
+        if resp.ok:
+            items = self._normalize_result_items(resp.result or {})
+            self._support.record_extension_metric(
+                metric_key,
+                success=True,
+                error_code=None,
+            )
+            return ExtensionCallResult(
+                success=True,
+                result={"items": items},
+                meta=meta,
+            )
+
+        error = resp.error or {}
+        error_details = self._support.build_upstream_error_details(
+            error=error,
+            business_code_map=ext.business_code_map,
+        )
+        self._support.record_extension_metric(
+            metric_key,
+            success=False,
+            error_code=error_details.error_code,
+        )
+        return ExtensionCallResult(
+            success=False,
+            error_code=error_details.error_code,
+            source=error_details.source,
+            jsonrpc_code=error_details.jsonrpc_code,
+            missing_params=list(error_details.missing_params or []) or None,
+            upstream_error=error_details.upstream_error,
+            meta=meta,
+        )
+
+    async def recover_interrupts(
+        self,
+        *,
+        runtime: A2ARuntime,
+        ext: ResolvedInterruptRecoveryExtension,
+        jsonrpc_url: str,
+        session_id: str | None = None,
+    ) -> ExtensionCallResult:
+        resolved_session_id = self.prepare_recovery_query(session_id=session_id)
+        permission_result = await self.invoke_method(
+            runtime=runtime,
+            ext=ext,
+            jsonrpc_url=jsonrpc_url,
+            method_key="list_permissions",
+        )
+        if not permission_result.success:
+            return permission_result
+
+        question_result = await self.invoke_method(
+            runtime=runtime,
+            ext=ext,
+            jsonrpc_url=jsonrpc_url,
+            method_key="list_questions",
+        )
+        if not question_result.success:
+            return question_result
+
+        items: list[dict[str, Any]] = []
+        seen_request_ids: set[str] = set()
+
+        for result in (permission_result, question_result):
+            for item in list((result.result or {}).get("items") or []):
+                if not isinstance(item, dict):
+                    continue
+                item_session_id = item.get("session_id")
+                if (
+                    resolved_session_id is not None
+                    and item_session_id != resolved_session_id
+                ):
+                    continue
+                request_id = item.get("request_id")
+                if not isinstance(request_id, str) or request_id in seen_request_ids:
+                    continue
+                seen_request_ids.add(request_id)
+                items.append(item)
+
+        def _sort_key(item: dict[str, Any]) -> tuple[float, str]:
+            raw_expires_at = item.get("expires_at")
+            expires_at = (
+                float(raw_expires_at)
+                if isinstance(raw_expires_at, (int, float))
+                else float("inf")
+            )
+            return expires_at, str(item.get("request_id") or "")
+
+        items.sort(key=_sort_key)
+
+        return ExtensionCallResult(
+            success=True,
+            result={"items": items},
+            meta={
+                "extension_uri": ext.uri,
+                "jsonrpc_fallback_used": ext.jsonrpc.fallback_used,
+                "session_id": resolved_session_id,
+            },
+        )

--- a/backend/app/integrations/a2a_extensions/service.py
+++ b/backend/app/integrations/a2a_extensions/service.py
@@ -20,6 +20,12 @@ from app.integrations.a2a_extensions.interrupt_callback import (
 from app.integrations.a2a_extensions.interrupt_extension_service import (
     InterruptExtensionService,
 )
+from app.integrations.a2a_extensions.interrupt_recovery import (
+    resolve_interrupt_recovery,
+)
+from app.integrations.a2a_extensions.interrupt_recovery_service import (
+    InterruptRecoveryService,
+)
 from app.integrations.a2a_extensions.model_selection import resolve_model_selection
 from app.integrations.a2a_extensions.opencode_discovery_service import (
     OpencodeDiscoveryService,
@@ -42,6 +48,7 @@ from app.integrations.a2a_extensions.shared_support import (
 from app.integrations.a2a_extensions.stream_hints import resolve_stream_hints
 from app.integrations.a2a_extensions.types import (
     ResolvedInterruptCallbackExtension,
+    ResolvedInterruptRecoveryExtension,
     ResolvedModelSelectionExtension,
     ResolvedProviderDiscoveryExtension,
     ResolvedSessionBindingExtension,
@@ -85,6 +92,14 @@ class InterruptCallbackCapabilitySnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class InterruptRecoveryCapabilitySnapshot:
+    status: Literal["supported", "unsupported", "invalid"]
+    ext: ResolvedInterruptRecoveryExtension | None = None
+    jsonrpc_url: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class ProviderDiscoveryCapabilitySnapshot:
     status: Literal["supported", "unsupported", "invalid"]
     ext: ResolvedProviderDiscoveryExtension | None = None
@@ -113,6 +128,7 @@ class ResolvedCapabilitySnapshot:
     session_query: SessionQueryCapabilitySnapshot
     session_binding: SessionBindingCapabilitySnapshot
     interrupt_callback: InterruptCallbackCapabilitySnapshot
+    interrupt_recovery: InterruptRecoveryCapabilitySnapshot
     model_selection: ModelSelectionCapabilitySnapshot
     provider_discovery: ProviderDiscoveryCapabilitySnapshot
     stream_hints: StreamHintsCapabilitySnapshot
@@ -129,6 +145,7 @@ class A2AExtensionsService:
         self._support = A2AExtensionSupport()
         self._session_extensions = SessionExtensionService(self._support)
         self._interrupt_extensions = InterruptExtensionService(self._support)
+        self._interrupt_recovery = InterruptRecoveryService(self._support)
         self._opencode_discovery = OpencodeDiscoveryService(self._support)
         self._capability_snapshot_cache_lock = asyncio.Lock()
         self._capability_snapshot_cache: dict[
@@ -225,6 +242,30 @@ class A2AExtensionsService:
             )
 
         return InterruptCallbackCapabilitySnapshot(
+            status="supported",
+            ext=ext,
+            jsonrpc_url=self._support.ensure_outbound_allowed(
+                ext.jsonrpc.url, purpose="JSON-RPC interface URL"
+            ),
+        )
+
+    def _build_interrupt_recovery_snapshot(
+        self, card: Any
+    ) -> InterruptRecoveryCapabilitySnapshot:
+        try:
+            ext = resolve_interrupt_recovery(card)
+        except A2AExtensionNotSupportedError as exc:
+            return InterruptRecoveryCapabilitySnapshot(
+                status="unsupported",
+                error=str(exc),
+            )
+        except A2AExtensionContractError as exc:
+            return InterruptRecoveryCapabilitySnapshot(
+                status="invalid",
+                error=str(exc),
+            )
+
+        return InterruptRecoveryCapabilitySnapshot(
             status="supported",
             ext=ext,
             jsonrpc_url=self._support.ensure_outbound_allowed(
@@ -347,6 +388,7 @@ class A2AExtensionsService:
             session_query=self._build_session_query_snapshot(card),
             session_binding=self._build_session_binding_snapshot(card),
             interrupt_callback=self._build_interrupt_callback_snapshot(card),
+            interrupt_recovery=self._build_interrupt_recovery_snapshot(card),
             model_selection=self._build_model_selection_snapshot(card),
             provider_discovery=self._build_provider_discovery_snapshot(card),
             stream_hints=self._build_stream_hints_snapshot(card),
@@ -384,6 +426,20 @@ class A2AExtensionsService:
             )
         raise A2AExtensionNotSupportedError(
             snapshot.error or "Shared interrupt callback extension not found"
+        )
+
+    @staticmethod
+    def _require_interrupt_recovery_capability(
+        snapshot: InterruptRecoveryCapabilitySnapshot,
+    ) -> tuple[ResolvedInterruptRecoveryExtension, str]:
+        if snapshot.ext is not None and snapshot.jsonrpc_url is not None:
+            return snapshot.ext, snapshot.jsonrpc_url
+        if snapshot.status == "invalid":
+            raise A2AExtensionContractError(
+                snapshot.error or "Interrupt recovery contract is invalid"
+            )
+        raise A2AExtensionNotSupportedError(
+            snapshot.error or "Interrupt recovery extension not found"
         )
 
     @staticmethod
@@ -648,6 +704,23 @@ class A2AExtensionsService:
             metadata=normalized_metadata,
         )
 
+    async def recover_interrupts(
+        self,
+        *,
+        runtime: A2ARuntime,
+        session_id: str | None = None,
+    ) -> ExtensionCallResult:
+        snapshot = await self.resolve_capability_snapshot(runtime=runtime)
+        ext, jsonrpc_url = self._require_interrupt_recovery_capability(
+            snapshot.interrupt_recovery
+        )
+        return await self._interrupt_recovery.recover_interrupts(
+            runtime=runtime,
+            ext=ext,
+            jsonrpc_url=jsonrpc_url,
+            session_id=session_id,
+        )
+
 
 _service_instance: Optional[A2AExtensionsService] = None
 
@@ -672,6 +745,7 @@ __all__ = [
     "A2AExtensionsService",
     "ExtensionCallResult",
     "InterruptCallbackCapabilitySnapshot",
+    "InterruptRecoveryCapabilitySnapshot",
     "ModelSelectionCapabilitySnapshot",
     "ProviderDiscoveryCapabilitySnapshot",
     "ResolvedCapabilitySnapshot",

--- a/backend/app/integrations/a2a_extensions/shared_contract.py
+++ b/backend/app/integrations/a2a_extensions/shared_contract.py
@@ -22,6 +22,7 @@ SUPPORTED_SESSION_QUERY_URIS = (
 
 MODEL_SELECTION_URI = "urn:a2a:model-selection/v1"
 PROVIDER_DISCOVERY_URI = "urn:opencode-a2a:provider-discovery/v1"
+INTERRUPT_RECOVERY_URI = "urn:opencode-a2a:interrupt-recovery/v1"
 
 SHARED_INTERRUPT_CALLBACK_URI = "urn:a2a:interactive-interrupt/v1"
 LEGACY_SHARED_INTERRUPT_CALLBACK_URI = "urn:shared-a2a:interrupt-callback:v1"
@@ -49,6 +50,7 @@ SHARED_MODEL_FIELD = "metadata.shared.model"
 __all__ = [
     "CANONICAL_EXTERNAL_SESSION_ID_KEY",
     "CANONICAL_PROVIDER_KEY",
+    "INTERRUPT_RECOVERY_URI",
     "LEGACY_SHARED_INTERRUPT_CALLBACK_URI",
     "LEGACY_SHARED_SESSION_BINDING_URI",
     "LEGACY_SHARED_SESSION_QUERY_URI",

--- a/backend/app/integrations/a2a_extensions/types.py
+++ b/backend/app/integrations/a2a_extensions/types.py
@@ -60,6 +60,16 @@ class ResolvedInterruptCallbackExtension:
 
 
 @dataclass(frozen=True, slots=True)
+class ResolvedInterruptRecoveryExtension:
+    uri: str
+    required: bool
+    provider: str
+    jsonrpc: JsonRpcInterface
+    methods: Mapping[str, Optional[str]]
+    business_code_map: Mapping[int, str]
+
+
+@dataclass(frozen=True, slots=True)
 class ResolvedSessionBindingExtension:
     uri: str
     required: bool
@@ -116,6 +126,7 @@ __all__ = [
     "ResolvedSessionControlMethodCapability",
     "ResolvedExtension",
     "ResolvedInterruptCallbackExtension",
+    "ResolvedInterruptRecoveryExtension",
     "ResolvedSessionBindingExtension",
     "ResolvedStreamHintsExtension",
 ]

--- a/backend/app/schemas/a2a_extension.py
+++ b/backend/app/schemas/a2a_extension.py
@@ -112,6 +112,20 @@ class A2AExtensionPromptAsyncRequest(BaseModel):
     )
 
 
+class A2AExtensionInterruptRecoveryRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    session_id: Optional[str] = Field(
+        default=None,
+        alias="sessionId",
+        min_length=1,
+        description=(
+            "Optional upstream external session id used by the hub to narrow "
+            "recovered interrupts to the current session"
+        ),
+    )
+
+
 class A2AExtensionSessionCommandRequest(BaseModel):
     request: Dict[str, Any] = Field(
         ...,
@@ -178,6 +192,25 @@ class A2ASessionControlCapabilitiesResponse(BaseModel):
     shell: A2ASessionControlMethodResponse
 
 
+class A2AInterruptRecoveryItemResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    request_id: str = Field(..., alias="requestId")
+    session_id: str = Field(..., alias="sessionId")
+    type: Literal["permission", "question"]
+    details: Dict[str, Any] = Field(default_factory=dict)
+    task_id: Optional[str] = Field(default=None, alias="taskId")
+    context_id: Optional[str] = Field(default=None, alias="contextId")
+    expires_at: Optional[float] = Field(default=None, alias="expiresAt")
+    source: Literal["recovery"] = "recovery"
+
+
+class A2AInterruptRecoveryResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    items: List[A2AInterruptRecoveryItemResponse] = Field(default_factory=list)
+
+
 class A2AExtensionCapabilitiesResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
@@ -190,6 +223,11 @@ class A2AExtensionCapabilitiesResponse(BaseModel):
         ...,
         alias="providerDiscovery",
         description="Whether the agent exposes OpenCode provider/model discovery",
+    )
+    interrupt_recovery: bool = Field(
+        ...,
+        alias="interruptRecovery",
+        description="Whether the agent exposes Hub-consumed interrupt recovery support",
     )
     session_prompt_async: bool = Field(
         ...,
@@ -211,9 +249,12 @@ class A2AExtensionCapabilitiesResponse(BaseModel):
 
 
 __all__ = [
+    "A2AExtensionInterruptRecoveryRequest",
     "A2AExtensionPromptAsyncRequest",
     "A2AExtensionSessionCommandRequest",
     "A2AExtensionCapabilitiesResponse",
+    "A2AInterruptRecoveryItemResponse",
+    "A2AInterruptRecoveryResponse",
     "A2ASessionControlCapabilitiesResponse",
     "A2ASessionControlMethodResponse",
     "A2AModelDiscoveryRequest",

--- a/backend/tests/extensions/test_a2a_extensions_service.py
+++ b/backend/tests/extensions/test_a2a_extensions_service.py
@@ -9,6 +9,7 @@ from app.integrations.a2a_extensions.service import (
     A2AExtensionsService,
     ExtensionCallResult,
     InterruptCallbackCapabilitySnapshot,
+    InterruptRecoveryCapabilitySnapshot,
     ModelSelectionCapabilitySnapshot,
     ProviderDiscoveryCapabilitySnapshot,
     ResolvedCapabilitySnapshot,
@@ -23,6 +24,7 @@ from app.integrations.a2a_extensions.session_query_runtime_selection import (
     ResolvedSessionQueryRuntimeCapability,
 )
 from app.integrations.a2a_extensions.shared_contract import (
+    INTERRUPT_RECOVERY_URI,
     PROVIDER_DISCOVERY_URI,
     SHARED_INTERRUPT_CALLBACK_URI,
     SHARED_SESSION_BINDING_URI,
@@ -36,6 +38,7 @@ from app.integrations.a2a_extensions.types import (
     PageSizePagination,
     ResolvedExtension,
     ResolvedInterruptCallbackExtension,
+    ResolvedInterruptRecoveryExtension,
     ResolvedModelSelectionExtension,
     ResolvedProviderDiscoveryExtension,
     ResolvedSessionControlMethodCapability,
@@ -125,6 +128,21 @@ def _provider_discovery_snapshot(
     )
 
 
+def _interrupt_recovery_snapshot(
+    *,
+    status: str = "unsupported",
+    ext: ResolvedInterruptRecoveryExtension | None = None,
+    jsonrpc_url: str | None = None,
+    error: str | None = None,
+) -> InterruptRecoveryCapabilitySnapshot:
+    return InterruptRecoveryCapabilitySnapshot(
+        status=status,
+        ext=ext,
+        jsonrpc_url=jsonrpc_url,
+        error=error,
+    )
+
+
 def _model_selection_snapshot(
     *,
     status: str = "unsupported",
@@ -145,6 +163,7 @@ def _capability_snapshot(
     session_query: SessionQueryCapabilitySnapshot,
     session_binding: SessionBindingCapabilitySnapshot | None = None,
     interrupt_callback: InterruptCallbackCapabilitySnapshot | None = None,
+    interrupt_recovery: InterruptRecoveryCapabilitySnapshot | None = None,
     model_selection: ModelSelectionCapabilitySnapshot | None = None,
     provider_discovery: ProviderDiscoveryCapabilitySnapshot | None = None,
     stream_hints: StreamHintsCapabilitySnapshot | None = None,
@@ -153,6 +172,7 @@ def _capability_snapshot(
         session_query=session_query,
         session_binding=session_binding or _binding_snapshot(status="unsupported"),
         interrupt_callback=interrupt_callback or _interrupt_snapshot(),
+        interrupt_recovery=interrupt_recovery or _interrupt_recovery_snapshot(),
         model_selection=model_selection or _model_selection_snapshot(),
         provider_discovery=provider_discovery or _provider_discovery_snapshot(),
         stream_hints=stream_hints
@@ -220,6 +240,22 @@ def _provider_discovery_extension_fixture() -> ResolvedProviderDiscoveryExtensio
         methods={
             "list_providers": "providers.list",
             "list_models": "models.list",
+        },
+        business_code_map={},
+    )
+
+
+def _interrupt_recovery_extension_fixture() -> ResolvedInterruptRecoveryExtension:
+    return ResolvedInterruptRecoveryExtension(
+        uri=INTERRUPT_RECOVERY_URI,
+        required=False,
+        provider="opencode",
+        jsonrpc=JsonRpcInterface(
+            url="https://example.com/jsonrpc", fallback_used=False
+        ),
+        methods={
+            "list_permissions": "opencode.permissions.list",
+            "list_questions": "opencode.questions.list",
         },
         business_code_map={},
     )
@@ -1582,3 +1618,147 @@ async def test_provider_and_interrupt_share_single_card_fetch(
     assert providers.success is True
     assert interrupt.success is True
     assert fetch_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_recover_interrupts_merges_and_filters_by_session_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = A2AExtensionsService()
+    runtime = SimpleNamespace(resolved=SimpleNamespace(url="https://example.com"))
+    ext = _interrupt_recovery_extension_fixture()
+    calls: list[str] = []
+
+    async def _fake_snapshot(*, runtime):
+        return _capability_snapshot(
+            session_query=_session_query_snapshot(_resolved_extension()),
+            interrupt_recovery=_interrupt_recovery_snapshot(
+                status="supported",
+                ext=ext,
+                jsonrpc_url="https://example.com/jsonrpc",
+            ),
+        )
+
+    async def _fake_invoke(**kwargs):
+        calls.append(kwargs["method_key"])
+        if kwargs["method_key"] == "list_permissions":
+            return ExtensionCallResult(
+                success=True,
+                result={
+                    "items": [
+                        {
+                            "request_id": "perm-1",
+                            "session_id": "sess-1",
+                            "type": "permission",
+                            "details": {"permission": "write"},
+                            "expires_at": 20,
+                        },
+                        {
+                            "request_id": "perm-2",
+                            "session_id": "sess-2",
+                            "type": "permission",
+                            "details": {"permission": "read"},
+                            "expires_at": 25,
+                        },
+                    ]
+                },
+                meta={},
+            )
+        return ExtensionCallResult(
+            success=True,
+            result={
+                "items": [
+                    {
+                        "request_id": "perm-1",
+                        "session_id": "sess-1",
+                        "type": "permission",
+                        "details": {"permission": "write"},
+                        "expires_at": 20,
+                    },
+                    {
+                        "request_id": "q-1",
+                        "session_id": "sess-1",
+                        "type": "question",
+                        "details": {"questions": []},
+                        "expires_at": 10,
+                    },
+                ]
+            },
+            meta={},
+        )
+
+    monkeypatch.setattr(service, "resolve_capability_snapshot", _fake_snapshot)
+    monkeypatch.setattr(service._interrupt_recovery, "invoke_method", _fake_invoke)
+
+    result = await service.recover_interrupts(runtime=runtime, session_id="sess-1")
+
+    assert result.success is True
+    assert calls == ["list_permissions", "list_questions"]
+    assert result.result == {
+        "items": [
+            {
+                "request_id": "q-1",
+                "session_id": "sess-1",
+                "type": "question",
+                "details": {"questions": []},
+                "expires_at": 10,
+            },
+            {
+                "request_id": "perm-1",
+                "session_id": "sess-1",
+                "type": "permission",
+                "details": {"permission": "write"},
+                "expires_at": 20,
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_recover_interrupts_returns_method_not_supported_when_upstream_missing_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = A2AExtensionsService()
+    runtime = SimpleNamespace(resolved=SimpleNamespace(url="https://example.com"))
+    ext = ResolvedInterruptRecoveryExtension(
+        uri=INTERRUPT_RECOVERY_URI,
+        required=False,
+        provider="opencode",
+        jsonrpc=JsonRpcInterface(
+            url="https://example.com/jsonrpc", fallback_used=False
+        ),
+        methods={
+            "list_permissions": "opencode.permissions.list",
+            "list_questions": None,
+        },
+        business_code_map={},
+    )
+
+    async def _fake_snapshot(*, runtime):
+        return _capability_snapshot(
+            session_query=_session_query_snapshot(_resolved_extension()),
+            interrupt_recovery=_interrupt_recovery_snapshot(
+                status="supported",
+                ext=ext,
+                jsonrpc_url="https://example.com/jsonrpc",
+            ),
+        )
+
+    async def _fake_invoke(**kwargs):
+        if kwargs["method_key"] == "list_permissions":
+            return ExtensionCallResult(success=True, result={"items": []}, meta={})
+        assert kwargs["method_key"] == "list_questions"
+        return ExtensionCallResult(
+            success=False,
+            error_code="method_not_supported",
+            upstream_error={"message": "Method list_questions is not supported"},
+            meta={},
+        )
+
+    monkeypatch.setattr(service, "resolve_capability_snapshot", _fake_snapshot)
+    monkeypatch.setattr(service._interrupt_recovery, "invoke_method", _fake_invoke)
+
+    result = await service.recover_interrupts(runtime=runtime, session_id="sess-1")
+
+    assert result.success is False
+    assert result.error_code == "method_not_supported"

--- a/backend/tests/extensions/test_interrupt_recovery_extension_discovery.py
+++ b/backend/tests/extensions/test_interrupt_recovery_extension_discovery.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+from a2a.types import AgentCard
+
+from app.integrations.a2a_extensions.errors import (
+    A2AExtensionNotSupportedError,
+)
+from app.integrations.a2a_extensions.interrupt_recovery import (
+    resolve_interrupt_recovery,
+)
+from app.integrations.a2a_extensions.shared_contract import (
+    INTERRUPT_RECOVERY_URI,
+)
+
+
+def _base_card_payload() -> dict:
+    return {
+        "name": "example",
+        "description": "example",
+        "url": "https://example.com",
+        "version": "1.0",
+        "capabilities": {"extensions": []},
+        "defaultInputModes": [],
+        "defaultOutputModes": [],
+        "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+    }
+
+
+def test_resolve_requires_interrupt_recovery_extension_present() -> None:
+    payload = _base_card_payload()
+    card = AgentCard.model_validate(payload)
+    with pytest.raises(A2AExtensionNotSupportedError):
+        resolve_interrupt_recovery(card)
+
+
+def test_resolve_extracts_interrupt_recovery_methods_and_provider() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": INTERRUPT_RECOVERY_URI,
+            "required": False,
+            "params": {
+                "provider": "OpenCode",
+                "methods": {
+                    "list_permissions": "opencode.permissions.list",
+                    "list_questions": "opencode.questions.list",
+                },
+                "errors": {
+                    "business_codes": {
+                        "INTERRUPT_QUERY_FORBIDDEN": -32011,
+                    }
+                },
+            },
+        }
+    ]
+    payload["additionalInterfaces"] = [
+        {"transport": "jsonrpc", "url": "https://api.example.com/jsonrpc"}
+    ]
+
+    card = AgentCard.model_validate(payload)
+    resolved = resolve_interrupt_recovery(card)
+
+    assert resolved.provider == "opencode"
+    assert resolved.methods["list_permissions"] == "opencode.permissions.list"
+    assert resolved.methods["list_questions"] == "opencode.questions.list"
+    assert resolved.business_code_map[-32011] == "interrupt_query_forbidden"
+    assert resolved.jsonrpc.url == "https://api.example.com/jsonrpc"
+    assert resolved.jsonrpc.fallback_used is False
+
+
+def test_resolve_defaults_provider_to_opencode_when_missing() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": INTERRUPT_RECOVERY_URI,
+            "required": False,
+            "params": {
+                "methods": {
+                    "list_permissions": "opencode.permissions.list",
+                    "list_questions": "opencode.questions.list",
+                },
+            },
+        }
+    ]
+
+    card = AgentCard.model_validate(payload)
+    resolved = resolve_interrupt_recovery(card)
+    assert resolved.provider == "opencode"
+
+
+def test_resolve_treats_blank_interrupt_recovery_methods_as_missing() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": INTERRUPT_RECOVERY_URI,
+            "required": False,
+            "params": {
+                "methods": {
+                    "list_permissions": "   ",
+                    "list_questions": "",
+                },
+            },
+        }
+    ]
+
+    card = AgentCard.model_validate(payload)
+    resolved = resolve_interrupt_recovery(card)
+    assert resolved.methods["list_permissions"] is None
+    assert resolved.methods["list_questions"] is None

--- a/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
+++ b/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
@@ -92,6 +92,7 @@ class _FakeExtensionsService:
         self.capability_snapshot: Any = SimpleNamespace(
             model_selection=SimpleNamespace(status="unsupported"),
             provider_discovery=SimpleNamespace(status="unsupported"),
+            interrupt_recovery=SimpleNamespace(status="unsupported"),
             session_query=SimpleNamespace(status="unsupported", capability=None),
         )
 
@@ -233,6 +234,25 @@ class _FakeExtensionsService:
             result={"ok": True, "request_id": request_id},
             meta={},
         )
+
+    async def recover_interrupts(self, *, runtime, session_id: str | None = None):
+        self.calls.append(
+            {
+                "fn": "recover_interrupts",
+                "runtime": runtime,
+                "session_id": session_id,
+            }
+        )
+        items = [
+            {
+                "request_id": "perm-1",
+                "session_id": session_id or "sess-1",
+                "type": "permission",
+                "details": {"permission": "write"},
+                "expires_at": 123.0,
+            }
+        ]
+        return _FakeExtensionResult(success=True, result={"items": items}, meta={})
 
     async def prompt_session_async(
         self,
@@ -828,6 +848,24 @@ async def test_hub_opencode_routes_use_hub_runtime_and_remain_non_enumerable(
             "request_id": "q-2",
         }
 
+        interrupt_recovery_resp = await user_client.post(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/extensions/interrupts:recover",
+            json={"sessionId": "sess-1"},
+        )
+        assert interrupt_recovery_resp.status_code == 200
+        assert interrupt_recovery_resp.json() == {
+            "items": [
+                {
+                    "requestId": "perm-1",
+                    "sessionId": "sess-1",
+                    "type": "permission",
+                    "details": {"permission": "write"},
+                    "expiresAt": 123.0,
+                    "source": "recovery",
+                }
+            ]
+        }
+
         prompt_async_resp = await user_client.post(
             f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/extensions/sessions/sess-1:prompt-async",
             json={
@@ -864,7 +902,7 @@ async def test_hub_opencode_routes_use_hub_runtime_and_remain_non_enumerable(
             }
         }
 
-    assert len(fake_extensions.calls) == 8
+    assert len(fake_extensions.calls) == 9
     prompt_calls = [
         c for c in fake_extensions.calls if c["fn"] == "prompt_session_async"
     ]
@@ -903,6 +941,10 @@ async def test_hub_opencode_routes_use_hub_runtime_and_remain_non_enumerable(
         "provider": "opencode",
         "requestScope": "shared",
     }
+    recovery_calls = [
+        c for c in fake_extensions.calls if c["fn"] == "recover_interrupts"
+    ]
+    assert recovery_calls[0]["session_id"] == "sess-1"
     for call in fake_extensions.calls:
         resolved = call["runtime"].resolved
         assert resolved.headers["Authorization"].endswith("secret-token-opencode")
@@ -989,6 +1031,7 @@ async def test_hub_extension_capabilities_route_returns_model_selection_true(
     fake_extensions.capability_snapshot = SimpleNamespace(
         model_selection=SimpleNamespace(status="supported"),
         provider_discovery=SimpleNamespace(status="supported"),
+        interrupt_recovery=SimpleNamespace(status="supported"),
         session_query=SimpleNamespace(
             status="supported",
             capability=SimpleNamespace(
@@ -1033,6 +1076,7 @@ async def test_hub_extension_capabilities_route_returns_model_selection_true(
     assert response.json() == {
         "modelSelection": True,
         "providerDiscovery": True,
+        "interruptRecovery": True,
         "sessionPromptAsync": True,
         "sessionControl": {
             "promptAsync": {
@@ -1083,6 +1127,7 @@ async def test_hub_extension_capabilities_route_returns_model_selection_false_fo
     fake_extensions.capability_snapshot = SimpleNamespace(
         model_selection=SimpleNamespace(status="supported"),
         provider_discovery=SimpleNamespace(status="unsupported"),
+        interrupt_recovery=SimpleNamespace(status="unsupported"),
         session_query=SimpleNamespace(
             status="supported",
             capability=SimpleNamespace(
@@ -1126,6 +1171,7 @@ async def test_hub_extension_capabilities_route_returns_model_selection_false_fo
     assert response.json() == {
         "modelSelection": True,
         "providerDiscovery": False,
+        "interruptRecovery": False,
         "sessionPromptAsync": False,
         "sessionControl": {
             "promptAsync": {
@@ -1176,6 +1222,7 @@ async def test_hub_extension_capabilities_route_distinguishes_model_selection_fr
     fake_extensions.capability_snapshot = SimpleNamespace(
         model_selection=SimpleNamespace(status="unsupported"),
         provider_discovery=SimpleNamespace(status="supported"),
+        interrupt_recovery=SimpleNamespace(status="unsupported"),
         session_query=SimpleNamespace(
             status="supported",
             capability=SimpleNamespace(
@@ -1220,6 +1267,7 @@ async def test_hub_extension_capabilities_route_distinguishes_model_selection_fr
     assert response.json() == {
         "modelSelection": False,
         "providerDiscovery": True,
+        "interruptRecovery": False,
         "sessionPromptAsync": True,
         "sessionControl": {
             "promptAsync": {

--- a/frontend/hooks/__tests__/useExtensionCapabilitiesQuery.test.tsx
+++ b/frontend/hooks/__tests__/useExtensionCapabilitiesQuery.test.tsx
@@ -106,6 +106,7 @@ describe("useExtensionCapabilitiesQuery", () => {
     mockedGetExtensionCapabilities.mockResolvedValue({
       modelSelection: true,
       providerDiscovery: true,
+      interruptRecovery: true,
       sessionPromptAsync: true,
       sessionControl: createSessionControl(),
       runtimeStatus: createRuntimeStatus(),
@@ -124,6 +125,7 @@ describe("useExtensionCapabilitiesQuery", () => {
       expect(result.current.modelSelectionStatus).toBe("supported");
     });
     expect(result.current.providerDiscoveryStatus).toBe("supported");
+    expect(result.current.interruptRecoveryStatus).toBe("supported");
     expect(result.current.runtimeStatusContract?.version).toBe("v1");
     expect(result.current.sessionPromptAsyncStatus).toBe("supported");
     expect(result.current.sessionCommandStatus).toBe("supported");
@@ -134,6 +136,7 @@ describe("useExtensionCapabilitiesQuery", () => {
     mockedGetExtensionCapabilities.mockResolvedValue({
       modelSelection: false,
       providerDiscovery: false,
+      interruptRecovery: false,
       sessionPromptAsync: false,
       sessionControl: createSessionControl({
         promptAsync: { declared: false, availability: "unsupported" },
@@ -164,6 +167,7 @@ describe("useExtensionCapabilitiesQuery", () => {
       expect(result.current.modelSelectionStatus).toBe("unsupported");
     });
     expect(result.current.providerDiscoveryStatus).toBe("unsupported");
+    expect(result.current.interruptRecoveryStatus).toBe("unsupported");
     expect(result.current.sessionPromptAsyncStatus).toBe("unsupported");
   });
 
@@ -171,6 +175,7 @@ describe("useExtensionCapabilitiesQuery", () => {
     mockedGetExtensionCapabilities.mockResolvedValue({
       modelSelection: true,
       providerDiscovery: false,
+      interruptRecovery: false,
       sessionPromptAsync: false,
       sessionControl: createSessionControl({
         promptAsync: { declared: false, availability: "unsupported" },
@@ -191,6 +196,7 @@ describe("useExtensionCapabilitiesQuery", () => {
       expect(result.current.modelSelectionStatus).toBe("supported");
     });
     expect(result.current.providerDiscoveryStatus).toBe("unsupported");
+    expect(result.current.interruptRecoveryStatus).toBe("unsupported");
   });
 
   it("returns unknown when capability lookup fails", async () => {
@@ -211,6 +217,7 @@ describe("useExtensionCapabilitiesQuery", () => {
 
     expect(result.current.modelSelectionStatus).toBe("unknown");
     expect(result.current.providerDiscoveryStatus).toBe("unknown");
+    expect(result.current.interruptRecoveryStatus).toBe("unknown");
     expect(result.current.sessionPromptAsyncStatus).toBe("unknown");
     expect(result.current.sessionCommandStatus).toBe("unknown");
     expect(result.current.sessionShellStatus).toBe("unknown");

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -27,6 +27,7 @@ import {
   A2AExtensionCallError,
   commandSession,
   promptSessionAsync,
+  recoverInterrupts,
 } from "@/lib/api/a2aExtensions";
 import type { ChatMessage } from "@/lib/api/chat-utils";
 import { continueSession } from "@/lib/api/sessions";
@@ -58,6 +59,7 @@ import { useChatStore } from "@/store/chat";
 
 const HISTORY_AUTOLOAD_THRESHOLD = 72;
 const SEND_SCROLL_SETTLE_MS = Platform.OS === "ios" ? 120 : 60;
+const INTERRUPT_RECOVERY_THROTTLE_MS = 5_000;
 
 export function useChatScreenController({
   routeAgentId,
@@ -86,6 +88,9 @@ export function useChatScreenController({
   const cancelMessage = useChatStore((state) => state.cancelMessage);
   const clearPendingInterrupt = useChatStore(
     (state) => state.clearPendingInterrupt,
+  );
+  const replaceRecoveredInterrupts = useChatStore(
+    (state) => state.replaceRecoveredInterrupts,
   );
   const setOpencodeDirectory = useChatStore(
     (state) => state.setOpencodeDirectory,
@@ -118,6 +123,10 @@ export function useChatScreenController({
     offset: number;
     contentHeight: number;
   } | null>(null);
+  const lastInterruptRecoveryRef = useRef<{
+    key: string;
+    triggeredAt: number;
+  } | null>(null);
   const loadingEarlierRef = useRef(false);
   const isInitialLoadRef = useRef(true);
   const historyPaused = session?.streamState === "streaming";
@@ -143,6 +152,8 @@ export function useChatScreenController({
   const pendingInterrupt = getPendingInterrupt(session);
   const pendingInterruptCount = pendingInterrupts.length;
   const lastResolvedInterrupt = session?.lastResolvedInterrupt ?? null;
+  const boundExternalSessionId =
+    session?.externalSessionRef?.externalSessionId?.trim() ?? "";
   const selectedModel = getSharedModelSelection(session?.metadata);
   const opencodeDirectory = getOpencodeDirectory(session?.metadata);
   const extensionCapabilitiesQuery = useExtensionCapabilitiesQuery({
@@ -160,6 +171,10 @@ export function useChatScreenController({
     !activeAgentId || !agent?.source
       ? "unsupported"
       : extensionCapabilitiesQuery.providerDiscoveryStatus;
+  const interruptRecoveryStatus: GenericCapabilityStatus =
+    !activeAgentId || !agent?.source
+      ? "unsupported"
+      : extensionCapabilitiesQuery.interruptRecoveryStatus;
   const sessionCommandStatus: GenericCapabilityStatus =
     !activeAgentId || !agent?.source
       ? "unsupported"
@@ -413,6 +428,70 @@ export function useChatScreenController({
     ],
   );
 
+  const recoverPendingInterrupts = useCallback(
+    async ({
+      nextConversationId,
+      nextAgentId,
+      nextAgentSource,
+      nextSessionId,
+    }: {
+      nextConversationId: string;
+      nextAgentId: string;
+      nextAgentSource: AgentSource;
+      nextSessionId: string;
+    }) => {
+      if (interruptRecoveryStatus !== "supported") {
+        return;
+      }
+      const resolvedSessionId = nextSessionId.trim();
+      if (!resolvedSessionId) {
+        return;
+      }
+
+      const recoveryKey = `${nextConversationId}:${resolvedSessionId}`;
+      const lastRecovery = lastInterruptRecoveryRef.current;
+      if (
+        lastRecovery &&
+        lastRecovery.key === recoveryKey &&
+        Date.now() - lastRecovery.triggeredAt < INTERRUPT_RECOVERY_THROTTLE_MS
+      ) {
+        return;
+      }
+      lastInterruptRecoveryRef.current = {
+        key: recoveryKey,
+        triggeredAt: Date.now(),
+      };
+
+      try {
+        const result = await recoverInterrupts({
+          source: nextAgentSource,
+          agentId: nextAgentId,
+          sessionId: resolvedSessionId,
+        });
+        replaceRecoveredInterrupts(nextConversationId, result.items, {
+          sessionId: resolvedSessionId,
+        });
+      } catch (error) {
+        if (
+          error instanceof A2AExtensionCallError &&
+          error.errorCode === "not_supported"
+        ) {
+          return;
+        }
+        console.warn("[Chat] interrupt recovery failed", {
+          conversationId: nextConversationId,
+          agentId: nextAgentId,
+          sessionId: resolvedSessionId,
+          error:
+            error instanceof Error
+              ? error.message
+              : "interrupt_recovery_failed",
+        });
+      }
+    },
+    [interruptRecoveryStatus, replaceRecoveredInterrupts],
+  );
+
   const {
     interruptAction,
     questionAnswers,
@@ -544,6 +623,58 @@ export function useChatScreenController({
   ]);
 
   useEffect(() => {
+    if (
+      !conversationId ||
+      !activeAgentId ||
+      !agent?.source ||
+      !boundExternalSessionId
+    ) {
+      return;
+    }
+    if (interruptRecoveryStatus !== "supported") {
+      return;
+    }
+    recoverPendingInterrupts({
+      nextConversationId: conversationId,
+      nextAgentId: activeAgentId,
+      nextAgentSource: agent.source,
+      nextSessionId: boundExternalSessionId,
+    });
+  }, [
+    activeAgentId,
+    agent?.source,
+    boundExternalSessionId,
+    conversationId,
+    interruptRecoveryStatus,
+    recoverPendingInterrupts,
+  ]);
+
+  useEffect(() => {
+    if (
+      session?.streamState !== "recoverable" ||
+      !conversationId ||
+      !activeAgentId ||
+      !agent?.source ||
+      !boundExternalSessionId
+    ) {
+      return;
+    }
+    recoverPendingInterrupts({
+      nextConversationId: conversationId,
+      nextAgentId: activeAgentId,
+      nextAgentSource: agent.source,
+      nextSessionId: boundExternalSessionId,
+    });
+  }, [
+    activeAgentId,
+    agent?.source,
+    boundExternalSessionId,
+    conversationId,
+    recoverPendingInterrupts,
+    session?.streamState,
+  ]);
+
+  useEffect(() => {
     if (!pendingInterrupt) {
       return;
     }
@@ -588,10 +719,31 @@ export function useChatScreenController({
       if (!conversationId) {
         return;
       }
+      if (
+        activeAgentId &&
+        agent?.source &&
+        boundExternalSessionId &&
+        interruptRecoveryStatus === "supported"
+      ) {
+        recoverPendingInterrupts({
+          nextConversationId: conversationId,
+          nextAgentId: activeAgentId,
+          nextAgentSource: agent.source,
+          nextSessionId: boundExternalSessionId,
+        });
+      }
       forceScrollToBottomRef.current = true;
       shouldStickToBottomRef.current = true;
       scheduleStickToBottom(true);
-    }, [conversationId, scheduleStickToBottom]),
+    }, [
+      activeAgentId,
+      agent?.source,
+      boundExternalSessionId,
+      conversationId,
+      interruptRecoveryStatus,
+      recoverPendingInterrupts,
+      scheduleStickToBottom,
+    ]),
   );
 
   useEffect(() => {

--- a/frontend/hooks/useExtensionCapabilitiesQuery.ts
+++ b/frontend/hooks/useExtensionCapabilitiesQuery.ts
@@ -62,6 +62,12 @@ export const useExtensionCapabilitiesQuery = ({
       : query.data?.providerDiscovery === false
         ? "unsupported"
         : "unknown";
+  const interruptRecoveryStatus: GenericCapabilityStatus =
+    query.data?.interruptRecovery === true
+      ? "supported"
+      : query.data?.interruptRecovery === false
+        ? "unsupported"
+        : "unknown";
   const sessionPromptAsyncStatus: GenericCapabilityStatus =
     query.data?.sessionControl?.promptAsync != null
       ? resolveSessionControlStatus(query.data.sessionControl.promptAsync)
@@ -84,6 +90,7 @@ export const useExtensionCapabilitiesQuery = ({
     runtimeStatusContract: query.data?.runtimeStatus ?? null,
     modelSelectionStatus,
     providerDiscoveryStatus,
+    interruptRecoveryStatus,
     sessionPromptAsyncStatus,
     sessionCommandStatus,
     sessionShellStatus,

--- a/frontend/lib/__tests__/a2aExtensions.test.ts
+++ b/frontend/lib/__tests__/a2aExtensions.test.ts
@@ -6,6 +6,7 @@ import {
   listModelProviders,
   listModels,
   promptSessionAsync,
+  recoverInterrupts,
   replyPermissionInterrupt,
 } from "@/lib/api/a2aExtensions";
 import { apiRequest } from "@/lib/api/client";
@@ -233,6 +234,7 @@ describe("assertExtensionSuccess", () => {
     mockedApiRequest.mockResolvedValue({
       modelSelection: false,
       providerDiscovery: true,
+      interruptRecovery: true,
       sessionPromptAsync: true,
       sessionControl: {
         promptAsync: {
@@ -297,6 +299,7 @@ describe("assertExtensionSuccess", () => {
     );
     expect(result.modelSelection).toBe(false);
     expect(result.providerDiscovery).toBe(true);
+    expect(result.interruptRecovery).toBe(true);
     expect(result.sessionPromptAsync).toBe(true);
     expect(result.sessionControl.command.consumedByHub).toBe(true);
     expect(result.sessionControl.shell.availability).toBe("conditional");
@@ -344,5 +347,92 @@ describe("assertExtensionSuccess", () => {
       },
     );
     expect(result.items[0]?.model_id).toBe("gpt-5");
+  });
+
+  it("calls interrupt recovery endpoint and maps pending interrupts", async () => {
+    mockedApiRequest.mockResolvedValue({
+      items: [
+        {
+          requestId: "perm-1",
+          sessionId: "sess-1",
+          type: "permission",
+          details: {
+            permission: "write",
+            patterns: ["src/**"],
+            displayMessage: "Approve write access",
+          },
+          expiresAt: 120,
+          source: "recovery",
+        },
+        {
+          requestId: "q-1",
+          sessionId: "sess-1",
+          type: "question",
+          details: {
+            displayMessage: "Need an answer",
+            questions: [
+              {
+                header: "Scope",
+                question: "Which files?",
+                options: [{ label: "All", description: null, value: "all" }],
+              },
+            ],
+          },
+          source: "recovery",
+        },
+      ],
+    });
+
+    const result = await recoverInterrupts({
+      source: "shared",
+      agentId: "agent-1",
+      sessionId: "sess-1",
+    });
+
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      "/a2a/agents/agent-1/extensions/interrupts:recover",
+      {
+        method: "POST",
+        body: { sessionId: "sess-1" },
+      },
+    );
+    expect(result.items).toEqual([
+      {
+        requestId: "perm-1",
+        sessionId: "sess-1",
+        type: "permission",
+        phase: "asked",
+        source: "recovery",
+        taskId: null,
+        contextId: null,
+        expiresAt: 120,
+        details: {
+          permission: "write",
+          patterns: ["src/**"],
+          displayMessage: "Approve write access",
+        },
+      },
+      {
+        requestId: "q-1",
+        sessionId: "sess-1",
+        type: "question",
+        phase: "asked",
+        source: "recovery",
+        taskId: null,
+        contextId: null,
+        expiresAt: null,
+        details: {
+          displayMessage: "Need an answer",
+          questions: [
+            {
+              header: "Scope",
+              description: null,
+              question: "Which files?",
+              options: [{ label: "All", description: null, value: "all" }],
+            },
+          ],
+        },
+      },
+    ]);
   });
 });

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -1136,6 +1136,7 @@ describe("block-based stream parser and reducer", () => {
         requestId: "perm-1",
         type: "permission",
         phase: "asked",
+        source: "stream",
         details: {
           permission: "read",
           patterns: ["/repo/.env"],
@@ -1172,6 +1173,7 @@ describe("block-based stream parser and reducer", () => {
       requestId: "perm-2",
       type: "permission",
       phase: "asked",
+      source: "stream",
       details: {
         permission: "approval",
         patterns: ["/repo/.env"],
@@ -1209,6 +1211,7 @@ describe("block-based stream parser and reducer", () => {
         requestId: "q-1",
         type: "question",
         phase: "asked",
+        source: "stream",
         details: {
           displayMessage: null,
           questions: [
@@ -1255,6 +1258,7 @@ describe("block-based stream parser and reducer", () => {
       requestId: "q-2",
       type: "question",
       phase: "asked",
+      source: "stream",
       details: {
         displayMessage: "Please confirm how the agent should continue.",
         questions: [
@@ -1291,6 +1295,7 @@ describe("block-based stream parser and reducer", () => {
         requestId: "q-1",
         type: "question",
         phase: "resolved",
+        source: "stream",
         resolution: "rejected",
       },
       seq: null,
@@ -1400,6 +1405,7 @@ describe("block-based stream parser and reducer", () => {
       requestId: "perm-legacy-1",
       type: "permission",
       phase: "asked",
+      source: "stream",
       details: {
         permission: "read",
         patterns: ["/repo/.env"],

--- a/frontend/lib/api/a2aExtensions.ts
+++ b/frontend/lib/api/a2aExtensions.ts
@@ -1,4 +1,7 @@
-import type { RuntimeStatusContract } from "@/lib/api/chat-utils";
+import type {
+  PendingRuntimeInterrupt,
+  RuntimeStatusContract,
+} from "@/lib/api/chat-utils";
 import { apiRequest } from "@/lib/api/client";
 
 export type A2AExtensionResponse = {
@@ -15,6 +18,7 @@ export type A2AExtensionResponse = {
 export type A2AExtensionCapabilities = {
   modelSelection: boolean;
   providerDiscovery: boolean;
+  interruptRecovery: boolean;
   sessionPromptAsync: boolean;
   sessionControl: {
     promptAsync: {
@@ -289,6 +293,27 @@ type SessionCommandResult = {
   item: SessionCommandResultItem | null;
 };
 
+type InterruptRecoveryResponseItem = {
+  requestId: string;
+  sessionId: string;
+  type: "permission" | "question";
+  details?: Record<string, unknown> | null;
+  taskId?: string | null;
+  contextId?: string | null;
+  expiresAt?: number | null;
+  source: "recovery";
+};
+
+type InterruptRecoveryResult = {
+  items: PendingRuntimeInterrupt[];
+};
+
+type RecoveryInterruptQuestion = NonNullable<
+  PendingRuntimeInterrupt["details"]["questions"]
+>[number];
+type RecoveryInterruptQuestionOption =
+  RecoveryInterruptQuestion["options"][number];
+
 const assertPromptAsyncResult = (
   response: A2AExtensionResponse,
   sessionId: string,
@@ -391,6 +416,116 @@ const asRecord = (value: unknown): Record<string, unknown> | null =>
     ? (value as Record<string, unknown>)
     : null;
 
+const asInterruptQuestions = (
+  value: unknown,
+): PendingRuntimeInterrupt["details"]["questions"] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const questions: RecoveryInterruptQuestion[] = [];
+  value.forEach((item) => {
+    const candidate = asRecord(item);
+    if (!candidate || typeof candidate.question !== "string") {
+      return;
+    }
+
+    const options: RecoveryInterruptQuestionOption[] = [];
+    if (Array.isArray(candidate.options)) {
+      candidate.options.forEach((option) => {
+        const resolved = asRecord(option);
+        if (!resolved || typeof resolved.label !== "string") {
+          return;
+        }
+        options.push({
+          label: resolved.label,
+          description:
+            typeof resolved.description === "string"
+              ? resolved.description
+              : null,
+          value: typeof resolved.value === "string" ? resolved.value : null,
+        });
+      });
+    }
+
+    questions.push({
+      header: typeof candidate.header === "string" ? candidate.header : null,
+      description:
+        typeof candidate.description === "string"
+          ? candidate.description
+          : null,
+      question: candidate.question,
+      options,
+    });
+  });
+  return questions;
+};
+
+const asRecoveryInterruptItem = (
+  value: unknown,
+): PendingRuntimeInterrupt | null => {
+  const item = asRecord(value);
+  if (!item) {
+    return null;
+  }
+  const requestId =
+    typeof item.requestId === "string" ? item.requestId.trim() : "";
+  const sessionId =
+    typeof item.sessionId === "string" ? item.sessionId.trim() : "";
+  const interruptType = item.type;
+  if (
+    !requestId ||
+    !sessionId ||
+    (interruptType !== "permission" && interruptType !== "question")
+  ) {
+    return null;
+  }
+
+  const details = asRecord(item.details) ?? {};
+  const base: Omit<PendingRuntimeInterrupt, "details"> = {
+    requestId,
+    sessionId,
+    type: interruptType,
+    phase: "asked",
+    source: "recovery",
+    taskId: typeof item.taskId === "string" ? item.taskId : null,
+    contextId: typeof item.contextId === "string" ? item.contextId : null,
+    expiresAt: typeof item.expiresAt === "number" ? item.expiresAt : null,
+  };
+
+  if (interruptType === "permission") {
+    return {
+      ...base,
+      details: {
+        ...details,
+        permission:
+          typeof details.permission === "string" ? details.permission : null,
+        patterns: Array.isArray(details.patterns)
+          ? details.patterns.filter(
+              (pattern): pattern is string =>
+                typeof pattern === "string" && pattern.trim().length > 0,
+            )
+          : [],
+        displayMessage:
+          typeof details.displayMessage === "string"
+            ? details.displayMessage
+            : null,
+      },
+    };
+  }
+
+  return {
+    ...base,
+    details: {
+      ...details,
+      displayMessage:
+        typeof details.displayMessage === "string"
+          ? details.displayMessage
+          : null,
+      questions: asInterruptQuestions(details.questions),
+    },
+  };
+};
+
 const asProviderItems = (value: unknown): ModelProviderSummary[] => {
   if (!Array.isArray(value)) {
     return [];
@@ -427,6 +562,27 @@ export const getExtensionCapabilities = async (input: {
     },
   );
   return response;
+};
+
+export const recoverInterrupts = async (input: {
+  source: ExtensionAgentSource;
+  agentId: string;
+  sessionId?: string | null;
+}): Promise<InterruptRecoveryResult> => {
+  const response = await apiRequest<
+    { items?: InterruptRecoveryResponseItem[] },
+    { sessionId?: string }
+  >(buildExtensionPath(input.source, input.agentId, "interrupts:recover"), {
+    method: "POST",
+    body: input.sessionId?.trim() ? { sessionId: input.sessionId.trim() } : {},
+  });
+  return {
+    items: Array.isArray(response.items)
+      ? response.items
+          .map((item) => asRecoveryInterruptItem(item))
+          .filter((item): item is PendingRuntimeInterrupt => Boolean(item))
+      : [],
+  };
 };
 
 export const listModelProviders = async (input: {

--- a/frontend/lib/api/chat-utils.ts
+++ b/frontend/lib/api/chat-utils.ts
@@ -206,6 +206,11 @@ type InterruptQuestion = {
 type RuntimeInterruptBase = {
   requestId: string;
   type: "permission" | "question";
+  source?: "stream" | "recovery";
+  sessionId?: string | null;
+  taskId?: string | null;
+  contextId?: string | null;
+  expiresAt?: number | null;
 };
 
 export type PendingRuntimeInterrupt = RuntimeInterruptBase & {
@@ -869,6 +874,7 @@ const extractRuntimeInterrupt = (
       type: interruptType,
       phase: "resolved",
       resolution,
+      source: "stream",
     };
   }
   if (phase !== "asked") {
@@ -881,6 +887,7 @@ const extractRuntimeInterrupt = (
       requestId,
       type: "permission",
       phase: "asked",
+      source: "stream",
       details: {
         permission: pickRawString(details, ["permission"]) ?? null,
         patterns: coerceStringArray(details?.patterns) ?? [],
@@ -901,6 +908,7 @@ const extractRuntimeInterrupt = (
       requestId,
       type: "question",
       phase: "asked",
+      source: "stream",
       details: {
         displayMessage: extractInterruptDisplayMessage(details),
         questions,

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -8,6 +8,7 @@ const mockReplyQuestion = jest.fn();
 const mockRejectQuestion = jest.fn();
 const mockPromptSessionAsync = jest.fn();
 const mockCommandSession = jest.fn();
+const mockRecoverInterrupts = jest.fn();
 const mockAddConversationOverlayMessage = jest.fn();
 const mockToastInfo = jest.fn();
 const mockToastSuccess = jest.fn();
@@ -24,6 +25,7 @@ type MockCapabilityStatus = "supported" | "unsupported" | "unknown";
 const mockExtensionCapabilitiesState = {
   modelSelectionStatus: "supported" as MockCapabilityStatus,
   providerDiscoveryStatus: "supported" as MockCapabilityStatus,
+  interruptRecoveryStatus: "supported" as MockCapabilityStatus,
   sessionPromptAsyncStatus: "supported" as MockCapabilityStatus,
   sessionCommandStatus: "supported" as MockCapabilityStatus,
   canShowModelPicker: true,
@@ -228,6 +230,7 @@ const mockChatState: {
   sendMessage: jest.Mock;
   cancelMessage: jest.Mock;
   clearPendingInterrupt: jest.Mock;
+  replaceRecoveredInterrupts: jest.Mock;
   bindExternalSession: jest.Mock;
   setOpencodeDirectory: jest.Mock;
   getSessionsByAgentId: jest.Mock;
@@ -238,6 +241,7 @@ const mockChatState: {
   sendMessage: jest.fn(),
   cancelMessage: jest.fn(),
   clearPendingInterrupt: jest.fn(),
+  replaceRecoveredInterrupts: jest.fn(),
   bindExternalSession: jest.fn(),
   setOpencodeDirectory: jest.fn(),
   getSessionsByAgentId: jest.fn(() => []),
@@ -371,6 +375,7 @@ jest.mock("@/lib/api/a2aExtensions", () => ({
   },
   commandSession: (...args: unknown[]) => mockCommandSession(...args),
   promptSessionAsync: (...args: unknown[]) => mockPromptSessionAsync(...args),
+  recoverInterrupts: (...args: unknown[]) => mockRecoverInterrupts(...args),
   replyPermissionInterrupt: (...args: unknown[]) =>
     mockReplyPermission(...args),
   replyQuestionInterrupt: (...args: unknown[]) => mockReplyQuestion(...args),
@@ -421,6 +426,7 @@ describe("ChatScreen interrupt handling", () => {
     mockChatState.sendMessage.mockReset();
     mockChatState.cancelMessage.mockReset();
     mockChatState.clearPendingInterrupt.mockReset();
+    mockChatState.replaceRecoveredInterrupts.mockReset();
     mockChatState.bindExternalSession.mockReset();
     mockChatState.setOpencodeDirectory.mockReset();
     mockPromptSessionAsync.mockReset().mockResolvedValue({
@@ -434,8 +440,10 @@ describe("ChatScreen interrupt handling", () => {
         parts: [{ type: "text", text: "Review complete." }],
       },
     });
+    mockRecoverInterrupts.mockReset().mockResolvedValue({ items: [] });
     mockAddConversationOverlayMessage.mockReset();
     mockExtensionCapabilitiesState.modelSelectionStatus = "supported";
+    mockExtensionCapabilitiesState.interruptRecoveryStatus = "supported";
     mockExtensionCapabilitiesState.sessionPromptAsyncStatus = "supported";
     mockExtensionCapabilitiesState.sessionCommandStatus = "supported";
     mockExtensionCapabilitiesState.canShowModelPicker = true;
@@ -470,6 +478,68 @@ describe("ChatScreen interrupt handling", () => {
       callback(0);
       return 0;
     }) as unknown as (callback: FrameRequestCallback) => number;
+  });
+
+  it("recovers pending interrupts for a bound upstream session", async () => {
+    mockChatState.sessions[conversationId] = {
+      ...baseSession(),
+      externalSessionRef: {
+        provider: "opencode",
+        externalSessionId: "sess-1",
+      },
+    };
+    mockRecoverInterrupts.mockResolvedValue({
+      items: [
+        {
+          requestId: "perm-1",
+          sessionId: "sess-1",
+          type: "permission",
+          phase: "asked",
+          source: "recovery",
+          taskId: null,
+          contextId: null,
+          expiresAt: 120,
+          details: {
+            permission: "write",
+            patterns: ["src/**"],
+            displayMessage: "Approve write access",
+          },
+        },
+      ],
+    });
+
+    renderChatScreen(conversationId);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockRecoverInterrupts).toHaveBeenCalledWith({
+      source: "personal",
+      agentId: "agent-1",
+      sessionId: "sess-1",
+    });
+    expect(mockChatState.replaceRecoveredInterrupts).toHaveBeenCalledWith(
+      conversationId,
+      [
+        {
+          requestId: "perm-1",
+          sessionId: "sess-1",
+          type: "permission",
+          phase: "asked",
+          source: "recovery",
+          taskId: null,
+          contextId: null,
+          expiresAt: 120,
+          details: {
+            permission: "write",
+            patterns: ["src/**"],
+            displayMessage: "Approve write access",
+          },
+        },
+      ],
+      { sessionId: "sess-1" },
+    );
   });
 
   it("disables sending and shows prompt when pending permission interrupt exists", () => {

--- a/frontend/store/__tests__/chatStoreIdempotency.test.ts
+++ b/frontend/store/__tests__/chatStoreIdempotency.test.ts
@@ -354,4 +354,104 @@ describe("chat store idempotency semantics", () => {
     expect(runtimeCall?.[4]).toBe(agentMessageId);
     expect(chatConnectionService.cancelSession).not.toHaveBeenCalled();
   });
+
+  it("replaceRecoveredInterrupts reconciles recovery items without dropping live stream items", () => {
+    useChatStore.getState().ensureSession("conv-recovery", "agent-1");
+    useChatStore.setState((state) => ({
+      sessions: {
+        ...state.sessions,
+        "conv-recovery": {
+          ...state.sessions["conv-recovery"],
+          pendingInterrupts: [
+            {
+              requestId: "stream-1",
+              sessionId: "sess-1",
+              type: "permission",
+              phase: "asked",
+              source: "stream",
+              details: {
+                permission: "tool.exec",
+                patterns: ["src/**"],
+              },
+            },
+            {
+              requestId: "recovery-stale-1",
+              sessionId: "sess-1",
+              type: "question",
+              phase: "asked",
+              source: "recovery",
+              details: {
+                questions: [],
+              },
+            },
+          ],
+          pendingInterrupt: {
+            requestId: "stream-1",
+            sessionId: "sess-1",
+            type: "permission",
+            phase: "asked",
+            source: "stream",
+            details: {
+              permission: "tool.exec",
+              patterns: ["src/**"],
+            },
+          },
+        },
+      },
+    }));
+
+    useChatStore.getState().replaceRecoveredInterrupts(
+      "conv-recovery",
+      [
+        {
+          requestId: "stream-1",
+          sessionId: "sess-1",
+          type: "permission",
+          phase: "asked",
+          source: "recovery",
+          details: {
+            permission: "tool.exec",
+            patterns: ["src/**"],
+          },
+        },
+        {
+          requestId: "recovery-fresh-1",
+          sessionId: "sess-1",
+          type: "question",
+          phase: "asked",
+          source: "recovery",
+          details: {
+            questions: [],
+          },
+        },
+      ],
+      { sessionId: "sess-1" },
+    );
+
+    const session = useChatStore.getState().sessions["conv-recovery"];
+    expect(session?.pendingInterrupts).toEqual([
+      {
+        requestId: "stream-1",
+        sessionId: "sess-1",
+        type: "permission",
+        phase: "asked",
+        source: "stream",
+        details: {
+          permission: "tool.exec",
+          patterns: ["src/**"],
+        },
+      },
+      {
+        requestId: "recovery-fresh-1",
+        sessionId: "sess-1",
+        type: "question",
+        phase: "asked",
+        source: "recovery",
+        details: {
+          questions: [],
+        },
+      },
+    ]);
+    expect(session?.pendingInterrupt?.requestId).toBe("stream-1");
+  });
 });

--- a/frontend/store/chat.ts
+++ b/frontend/store/chat.ts
@@ -1,7 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
-import { type RuntimeStatusContract } from "@/lib/api/chat-utils";
+import {
+  type PendingRuntimeInterrupt,
+  type RuntimeStatusContract,
+} from "@/lib/api/chat-utils";
 import {
   buildPendingInterruptState,
   buildPersistedSessions,
@@ -137,6 +140,11 @@ type ChatState = {
     selection: SharedModelSelection | null,
   ) => void;
   clearPendingInterrupt: (conversationId: string, requestId?: string) => void;
+  replaceRecoveredInterrupts: (
+    conversationId: string,
+    interrupts: PendingRuntimeInterrupt[],
+    options?: { sessionId?: string | null },
+  ) => void;
   getLatestConversationIdByAgentId: (agentId: string) => string | undefined;
   cleanupSessions: () => void;
   generateConversationId: () => string;
@@ -285,6 +293,52 @@ export const useChatStore = create<ChatState>()(
           if (nextQueue.length === currentQueue.length) {
             return state;
           }
+          return {
+            sessions: {
+              ...state.sessions,
+              [conversationId]: {
+                ...current,
+                ...buildPendingInterruptState(nextQueue),
+              },
+            },
+          };
+        });
+      },
+      replaceRecoveredInterrupts: (conversationId, interrupts, options) => {
+        set((state) => {
+          const current = state.sessions[conversationId];
+          if (!current) {
+            return state;
+          }
+          const targetSessionId = options?.sessionId?.trim() || null;
+          const currentQueue = getPendingInterruptQueue(current);
+          const retainedQueue = currentQueue.filter((interrupt) => {
+            if (interrupt.source !== "recovery") {
+              return true;
+            }
+            if (!targetSessionId) {
+              return false;
+            }
+            return interrupt.sessionId !== targetSessionId;
+          });
+
+          const seenRequestIds = new Set(
+            retainedQueue.map((interrupt) => interrupt.requestId),
+          );
+          const nextQueue = [...retainedQueue];
+
+          interrupts.forEach((interrupt) => {
+            if (seenRequestIds.has(interrupt.requestId)) {
+              return;
+            }
+            seenRequestIds.add(interrupt.requestId);
+            nextQueue.push(interrupt);
+          });
+
+          if (JSON.stringify(currentQueue) === JSON.stringify(nextQueue)) {
+            return state;
+          }
+
           return {
             sessions: {
               ...state.sessions,


### PR DESCRIPTION
## 概要

本 PR 实现 `#657`：为已绑定上游 session 的聊天会话补齐 interrupt recovery 能力。

本次收敛后的边界是：
- backend 兼容上游 `urn:opencode-a2a:interrupt-recovery/v1` 及其 provider-private methods
- frontend 只消费 Hub 自己稳定的 capability 与 recovery 查询接口
- 继续复用现有 interrupt action card 与 shared callback methods

不混入以下议题：
- `#634` stream transport 级 recovery / resubscribe
- `#564` interrupt 历史与事实持久化扩展
- `#420` 主动中断反馈文案与 UX 分流

## 模块说明

### Backend
- 识别并解析 `interrupt-recovery` extension
- 在 capabilities API 中新增稳定的 `interruptRecovery` 状态
- 新增 Hub 自己的 recovery 查询接口：`POST /extensions/interrupts:recover`
- backend 内部合并上游 permission / question 列表、按 `requestId` 去重，并支持按 `externalSessionId` 过滤
- runtime 不支持该扩展时保持静默兼容，不影响主聊天链路

### Frontend
- 扩展 capabilities 消费，识别 `interruptRecoveryStatus`
- 在聊天页恢复时机触发 recovery 查询：
  - 当前会话已绑定 upstream session
  - 流状态进入 `recoverable`
  - 聊天页重新聚焦
- 将恢复结果并入现有 `pendingInterrupts` 队列，并保留 `source = recovery` 与实时流来源区分
- 继续复用现有 interrupt UI 与 shared callback methods，不引入新的回答协议

### Tests
- 补齐 backend extension discovery、service 合并/过滤、route 集成测试
- 补齐 frontend capability、API 映射、chat store 幂等合并、聊天页恢复消费测试
- 更新 stream contract 断言以覆盖 `source` 字段

## 审查结论

### 需求有效性
- `#657` 仍然有效，上游 `opencode-a2a` 已将 recovery extension 合入主线
- 当前 Hub 已支持实时 interrupt 消费和 reply callback，但仍缺少断线 / 刷新后的 pending interrupt 恢复查询链路

### 实施方案
- 当前方案符合最新最佳实践：后端负责兼容不同上游，前后端之间保持 Hub 自己稳定协议
- 没有把上游两个 provider-private methods 直接泄漏给前端
- 没有把其它更大的 recovery / history / UX 议题混入本 PR

### 高度相关 open issues
- 未建议与其它 open issues 合并开发
- `#564`、`#634`、`#420` 与本议题邻接，但层次不同，继续分开跟进更稳妥

## 验证

### Backend
- `cd backend && uv run --locked pre-commit run --files app/features/extension_capabilities/common_router.py app/integrations/a2a_extensions/service.py app/integrations/a2a_extensions/shared_contract.py app/integrations/a2a_extensions/types.py app/integrations/a2a_extensions/interrupt_recovery.py app/integrations/a2a_extensions/interrupt_recovery_service.py app/schemas/a2a_extension.py tests/extensions/test_a2a_extensions_service.py tests/extensions/test_interrupt_recovery_extension_discovery.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/extensions/test_a2a_extensions_service.py tests/extensions/test_interrupt_recovery_extension_discovery.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py`
- 结果：`78 passed in 30.47s`

### Frontend
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/useChatScreenController.ts hooks/useExtensionCapabilitiesQuery.ts lib/api/a2aExtensions.ts lib/api/chat-utils.ts lib/__tests__/streamContract.test.ts store/chat.ts hooks/__tests__/useExtensionCapabilitiesQuery.test.tsx lib/__tests__/a2aExtensions.test.ts screens/__tests__/ChatScreen.interrupt.test.tsx store/__tests__/chatStoreIdempotency.test.ts --maxWorkers=25%`
- 结果：`54 passed, 310 tests passed`

## 关联

- Closes #657
