### PR TITLE
feat(a2a-extensions): add stable session list filters contract (#660)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -173,7 +173,11 @@ Endpoints:
       `{ "provider_id": "openai", "session_metadata": { "shared": { "model": { "providerID": "openai", "modelID": "gpt-5" } } } }`
 - List sessions:
   - `GET /api/v1/me/a2a/agents/{agent_id}/extensions/sessions?page=1&size=20`
+  - `GET /api/v1/me/a2a/agents/{agent_id}/extensions/sessions?page=1&size=20&directory=services/api&roots=true&start=40&search=planner`
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/sessions:query`
+    - body example:
+      `{"page":1,"size":20,"filters":{"directory":"services/api","roots":true,"start":40,"search":"planner"},"query":{"status":"open"}}`
+    - the Hub contract keeps `filters.directory`, `filters.roots`, `filters.start`, and `filters.search` stable, then maps them to the upstream session-query contract declared by the runtime
 - Continue a session:
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/sessions/{session_id}:continue`
 - Trigger async prompt for an existing upstream session:

--- a/backend/app/features/extension_capabilities/common_router.py
+++ b/backend/app/features/extension_capabilities/common_router.py
@@ -35,12 +35,12 @@ from app.schemas.a2a_extension import (
     A2AExtensionInterruptRecoveryRequest,
     A2AExtensionPermissionReplyRequest,
     A2AExtensionPromptAsyncRequest,
-    A2AExtensionQueryRequest,
     A2AExtensionQueryResponse,
     A2AExtensionQuestionRejectRequest,
     A2AExtensionQuestionReplyRequest,
     A2AExtensionResponse,
     A2AExtensionSessionCommandRequest,
+    A2AExtensionSessionListQueryRequest,
     A2AExtensionSessionMessagesQueryRequest,
     A2AInterruptRecoveryResponse,
     A2AModelDiscoveryRequest,
@@ -83,6 +83,36 @@ def _summarize_metadata_keys(metadata: Optional[Dict[str, Any]]) -> list[str]:
     if not metadata:
         return []
     return sorted(str(k) for k in metadata.keys())[:20]
+
+
+def _build_session_list_filters(
+    *,
+    directory: Optional[str] = None,
+    roots: Optional[bool] = None,
+    start: Optional[int] = None,
+    search: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    filters: Dict[str, Any] = {}
+    if directory is not None:
+        filters["directory"] = directory
+    if roots is not None:
+        filters["roots"] = roots
+    if start is not None:
+        filters["start"] = start
+    if search is not None:
+        filters["search"] = search
+    return filters or None
+
+
+def _summarize_session_list_filters(
+    filters: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not filters:
+        return {"keys": [], "size": 0}
+    return {
+        "keys": sorted(str(key) for key in filters.keys())[:20],
+        "size": len(filters),
+    }
 
 
 _SESSION_CONTROL_HUB_CONSUMPTION = {
@@ -385,6 +415,25 @@ def create_extension_capability_router(
             False,
             description="Whether to include the upstream raw payload in the response",
         ),
+        directory: Optional[str] = Query(
+            None,
+            min_length=1,
+            description="Optional Hub session list directory filter",
+        ),
+        roots: Optional[bool] = Query(
+            None,
+            description="Optional Hub roots-only filter for session list",
+        ),
+        start: Optional[int] = Query(
+            None,
+            ge=0,
+            description="Optional Hub session list start offset filter",
+        ),
+        search: Optional[str] = Query(
+            None,
+            min_length=1,
+            description="Optional Hub session list search filter",
+        ),
         query: Optional[str] = Query(
             None, description="Optional JSON object encoded as a string"
         ),
@@ -393,6 +442,12 @@ def create_extension_capability_router(
 
         runtime = await _get_runtime(db, current_user, agent_id)
         query_obj = _parse_query_param(query)
+        filter_obj = _build_session_list_filters(
+            directory=directory,
+            roots=roots,
+            start=start,
+            search=search,
+        )
         logger.info(
             _scope_message("Shared extension sessions list requested"),
             extra={
@@ -402,6 +457,7 @@ def create_extension_capability_router(
                 "page": page,
                 "size": size,
                 "include_raw": include_raw,
+                "filter_meta": _summarize_session_list_filters(filter_obj),
                 "query_meta": _summarize_query_object(query_obj),
             },
         )
@@ -413,6 +469,7 @@ def create_extension_capability_router(
                 size=size,
                 include_raw=include_raw,
                 query=query_obj,
+                filters=filter_obj,
             )
         )
 
@@ -692,7 +749,7 @@ def create_extension_capability_router(
     async def query_external_sessions(
         *,
         agent_id: UUID,
-        payload: A2AExtensionQueryRequest,
+        payload: A2AExtensionSessionListQueryRequest,
         response: Response,
         db: AsyncSession = Depends(get_async_db),
         current_user: User = Depends(get_current_user),
@@ -700,6 +757,11 @@ def create_extension_capability_router(
         response.headers["Cache-Control"] = "no-store"
 
         runtime = await _get_runtime(db, current_user, agent_id)
+        filters = (
+            payload.filters.model_dump(exclude_none=True)
+            if payload.filters is not None
+            else None
+        )
         logger.info(
             _scope_message("Shared extension sessions list requested (POST)"),
             extra={
@@ -709,6 +771,7 @@ def create_extension_capability_router(
                 "page": payload.page,
                 "size": payload.size,
                 "include_raw": payload.include_raw,
+                "filter_meta": _summarize_session_list_filters(filters),
                 "query_meta": _summarize_query_object(payload.query),
             },
         )
@@ -720,6 +783,7 @@ def create_extension_capability_router(
                 size=payload.size,
                 include_raw=payload.include_raw,
                 query=payload.query,
+                filters=filters,
             )
         )
 

--- a/backend/app/integrations/a2a_extensions/service.py
+++ b/backend/app/integrations/a2a_extensions/service.py
@@ -481,6 +481,7 @@ class A2AExtensionsService:
         page: int,
         size: Optional[int],
         query: Optional[Dict[str, Any]],
+        filters: Optional[Dict[str, Any]] = None,
         include_raw: bool = False,
     ) -> ExtensionCallResult:
         snapshot = await self.resolve_capability_snapshot(runtime=runtime)
@@ -492,6 +493,7 @@ class A2AExtensionsService:
             page=page,
             size=size,
             query=query,
+            filters=filters,
             include_raw=include_raw,
         )
 

--- a/backend/app/integrations/a2a_extensions/session_extension_service.py
+++ b/backend/app/integrations/a2a_extensions/session_extension_service.py
@@ -12,6 +12,7 @@ from app.integrations.a2a_extensions.shared_support import A2AExtensionSupport
 from app.integrations.a2a_extensions.types import (
     ResolvedExtension,
     ResultEnvelopeMapping,
+    SessionListFilterFieldContract,
 )
 from app.schemas.a2a_extension import A2AExtensionQueryResult
 
@@ -284,6 +285,71 @@ class SessionExtensionService:
         raise ValueError(f"unsupported pagination mode: {mode}")
 
     @staticmethod
+    def _apply_session_list_filter(
+        *,
+        params: Dict[str, Any],
+        query: Dict[str, Any] | None,
+        field_name: str,
+        value: Any,
+        contract: SessionListFilterFieldContract,
+    ) -> tuple[Dict[str, Any] | None, str]:
+        if query is not None and field_name in query:
+            raise ValueError(f"filters.{field_name} conflicts with query.{field_name}")
+
+        if contract.top_level_param:
+            params[contract.top_level_param] = value
+            return query, "top_level"
+
+        if contract.query_param:
+            resolved_query = dict(query or {})
+            resolved_query[contract.query_param] = value
+            return resolved_query, "query"
+
+        raise ValueError(f"{field_name} filter is not supported by this runtime")
+
+    @staticmethod
+    def _build_session_list_params(
+        *,
+        ext: ResolvedExtension,
+        page: int,
+        size: int,
+        query: Optional[Dict[str, Any]],
+        filters: Optional[Dict[str, Any]],
+    ) -> tuple[Dict[str, Any], Dict[str, str]]:
+        params: Dict[str, Any] = SessionExtensionService._build_pagination_params(
+            mode=ext.pagination.mode,
+            page=page,
+            size=size,
+            supports_offset=ext.pagination.supports_offset,
+        )
+
+        normalized_query = dict(query) if query is not None else None
+        filter_meta: Dict[str, str] = {}
+
+        if filters:
+            for field_name in ("directory", "roots", "start", "search"):
+                if field_name not in filters:
+                    continue
+                value = filters[field_name]
+                if value is None:
+                    continue
+                contract = getattr(ext.session_list_filters, field_name)
+                normalized_query, location = (
+                    SessionExtensionService._apply_session_list_filter(
+                        params=params,
+                        query=normalized_query,
+                        field_name=field_name,
+                        value=value,
+                        contract=contract,
+                    )
+                )
+                filter_meta[field_name] = location
+
+        if normalized_query is not None:
+            params["query"] = normalized_query
+        return params, filter_meta
+
+    @staticmethod
     def _resolve_message_next_before(
         *,
         result: Any,
@@ -421,6 +487,7 @@ class SessionExtensionService:
         page: int,
         size: Optional[int],
         query: Optional[Dict[str, Any]],
+        filters: Optional[Dict[str, Any]],
         include_raw: bool = False,
     ) -> ExtensionCallResult:
         jsonrpc_url = self._support.ensure_outbound_allowed(
@@ -455,14 +522,13 @@ class SessionExtensionService:
                 ),
             )
 
-        params: Dict[str, Any] = self._build_pagination_params(
-            mode=ext.pagination.mode,
+        params, filter_meta = self._build_session_list_params(
+            ext=ext,
             page=resolved_page,
             size=resolved_size,
-            supports_offset=ext.pagination.supports_offset,
+            query=query,
+            filters=filters,
         )
-        if query is not None:
-            params["query"] = query
 
         return await self.invoke_method(
             runtime=runtime,
@@ -474,6 +540,7 @@ class SessionExtensionService:
             page=resolved_page,
             size=resolved_size,
             include_raw=include_raw,
+            meta_extra={"session_list_filters": filter_meta} if filter_meta else None,
         )
 
     async def get_session_messages(

--- a/backend/app/integrations/a2a_extensions/session_query.py
+++ b/backend/app/integrations/a2a_extensions/session_query.py
@@ -28,6 +28,8 @@ from app.integrations.a2a_extensions.types import (
     ResolvedExtension,
     ResolvedSessionControlMethodCapability,
     ResultEnvelopeMapping,
+    SessionListFilterFieldContract,
+    SessionListFiltersContract,
 )
 
 
@@ -163,6 +165,81 @@ def _resolve_message_cursor_pagination(
     )
 
 
+def _resolve_method_contract_optional_params(
+    params: Dict[str, Any],
+    *,
+    method_name: str,
+) -> set[str]:
+    raw_method_contracts = params.get("method_contracts")
+    if raw_method_contracts is None:
+        return set()
+
+    method_contracts = as_dict(raw_method_contracts)
+    raw_method_contract = method_contracts.get(method_name)
+    if raw_method_contract is None:
+        return set()
+
+    method_contract = as_dict(raw_method_contract)
+    raw_params_contract = method_contract.get("params")
+    if raw_params_contract is None:
+        return set()
+
+    params_contract = as_dict(raw_params_contract)
+    raw_optional_params = params_contract.get("optional_params")
+    if raw_optional_params is None:
+        return set()
+    if not isinstance(raw_optional_params, list):
+        raise A2AExtensionContractError(
+            f"Extension method_contracts.{method_name}.params.optional_params must be an array if provided"
+        )
+
+    optional_params: set[str] = set()
+    for item in raw_optional_params:
+        if not isinstance(item, str):
+            raise A2AExtensionContractError(
+                f"Extension method_contracts.{method_name}.params.optional_params must contain only strings"
+            )
+        token = item.strip()
+        if token:
+            optional_params.add(token)
+    return optional_params
+
+
+def _resolve_session_list_filter_field(
+    optional_params: set[str],
+    *,
+    field_name: str,
+) -> SessionListFilterFieldContract:
+    top_level_param = field_name if field_name in optional_params else None
+    query_param = field_name if f"query.{field_name}" in optional_params else None
+    return SessionListFilterFieldContract(
+        top_level_param=top_level_param,
+        query_param=query_param,
+    )
+
+
+def _resolve_session_list_filters(
+    params: Dict[str, Any],
+    *,
+    list_sessions_method: str,
+) -> SessionListFiltersContract:
+    optional_params = _resolve_method_contract_optional_params(
+        params,
+        method_name=list_sessions_method,
+    )
+    if not optional_params:
+        return SessionListFiltersContract()
+
+    return SessionListFiltersContract(
+        directory=_resolve_session_list_filter_field(
+            optional_params, field_name="directory"
+        ),
+        roots=_resolve_session_list_filter_field(optional_params, field_name="roots"),
+        start=_resolve_session_list_filter_field(optional_params, field_name="start"),
+        search=_resolve_session_list_filter_field(optional_params, field_name="search"),
+    )
+
+
 def _find_session_query_extension(
     card: AgentCard,
     *,
@@ -288,6 +365,10 @@ def _resolve_extension(
         pagination,
         get_messages_method=get_messages_method,
     )
+    session_list_filters = _resolve_session_list_filters(
+        params,
+        list_sessions_method=list_sessions_method,
+    )
 
     return ResolvedExtension(
         uri=str(getattr(ext, "uri", SHARED_SESSION_QUERY_URI)),
@@ -311,6 +392,7 @@ def _resolve_extension(
         business_code_map=code_to_error,
         result_envelope=envelope_mapping,
         message_cursor_pagination=message_cursor_pagination,
+        session_list_filters=session_list_filters,
     )
 
 

--- a/backend/app/integrations/a2a_extensions/types.py
+++ b/backend/app/integrations/a2a_extensions/types.py
@@ -35,6 +35,20 @@ class MessageCursorPaginationContract:
 
 
 @dataclass(frozen=True, slots=True)
+class SessionListFilterFieldContract:
+    top_level_param: str | None = None
+    query_param: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SessionListFiltersContract:
+    directory: SessionListFilterFieldContract = SessionListFilterFieldContract()
+    roots: SessionListFilterFieldContract = SessionListFilterFieldContract()
+    start: SessionListFilterFieldContract = SessionListFilterFieldContract()
+    search: SessionListFilterFieldContract = SessionListFilterFieldContract()
+
+
+@dataclass(frozen=True, slots=True)
 class ResolvedExtension:
     uri: str
     required: bool
@@ -47,6 +61,7 @@ class ResolvedExtension:
     message_cursor_pagination: MessageCursorPaginationContract = (
         MessageCursorPaginationContract()
     )
+    session_list_filters: SessionListFiltersContract = SessionListFiltersContract()
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,4 +154,6 @@ __all__ = [
     "ResolvedInterruptRecoveryExtension",
     "ResolvedSessionBindingExtension",
     "ResolvedStreamHintsExtension",
+    "SessionListFilterFieldContract",
+    "SessionListFiltersContract",
 ]

--- a/backend/app/schemas/a2a_extension.py
+++ b/backend/app/schemas/a2a_extension.py
@@ -24,6 +24,28 @@ class A2AExtensionQueryRequest(BaseModel):
     )
 
 
+class A2AExtensionSessionListFilters(BaseModel):
+    directory: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Optional session directory filter under the Hub contract",
+    )
+    roots: Optional[bool] = Field(
+        default=None,
+        description="Optional roots-only filter under the Hub contract",
+    )
+    start: Optional[int] = Field(
+        default=None,
+        ge=0,
+        description="Optional non-negative start offset under the Hub contract",
+    )
+    search: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description="Optional search text filter under the Hub contract",
+    )
+
+
 class A2AExtensionResponse(BaseModel):
     success: bool
     result: Optional[Any] = None
@@ -88,6 +110,13 @@ class A2AExtensionSessionMessagesQueryRequest(A2AExtensionQueryRequest):
             "Opaque cursor for loading older session messages when the runtime "
             "declares cursor pagination support"
         ),
+    )
+
+
+class A2AExtensionSessionListQueryRequest(A2AExtensionQueryRequest):
+    filters: Optional[A2AExtensionSessionListFilters] = Field(
+        default=None,
+        description="Optional typed session list filters under the Hub contract",
     )
 
 
@@ -274,6 +303,8 @@ __all__ = [
     "A2AExtensionInterruptRecoveryRequest",
     "A2AExtensionPromptAsyncRequest",
     "A2AExtensionSessionCommandRequest",
+    "A2AExtensionSessionListFilters",
+    "A2AExtensionSessionListQueryRequest",
     "A2AExtensionSessionMessagesQueryRequest",
     "A2AExtensionCapabilitiesResponse",
     "A2AInterruptRecoveryItemResponse",

--- a/backend/tests/extensions/test_a2a_extensions_service.py
+++ b/backend/tests/extensions/test_a2a_extensions_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -45,6 +46,8 @@ from app.integrations.a2a_extensions.types import (
     ResolvedSessionControlMethodCapability,
     ResolvedStreamHintsExtension,
     ResultEnvelopeMapping,
+    SessionListFilterFieldContract,
+    SessionListFiltersContract,
 )
 
 
@@ -185,6 +188,7 @@ def _resolved_extension(
     *,
     supports_offset: bool = False,
     supports_cursor: bool = False,
+    session_list_filters: SessionListFiltersContract | None = None,
 ) -> ResolvedExtension:
     return ResolvedExtension(
         uri=SHARED_SESSION_QUERY_URI,
@@ -217,6 +221,7 @@ def _resolved_extension(
             cursor_param="before" if supports_cursor else None,
             result_cursor_field="next_cursor" if supports_cursor else None,
         ),
+        session_list_filters=session_list_filters or SessionListFiltersContract(),
     )
 
 
@@ -757,6 +762,158 @@ async def test_get_session_messages_short_circuits_when_limit_has_no_offset(
     }
     assert result.meta["session_id"] == "ses_123"
     assert result.meta["short_circuit_reason"] == "limit_without_offset"
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_routes_typed_filters_using_runtime_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = A2AExtensionsService()
+    ext = _resolved_extension(
+        supports_offset=True,
+        session_list_filters=SessionListFiltersContract(
+            directory=SessionListFilterFieldContract(top_level_param="directory"),
+            roots=SessionListFilterFieldContract(query_param="roots"),
+            start=SessionListFilterFieldContract(query_param="start"),
+            search=SessionListFilterFieldContract(top_level_param="search"),
+        ),
+    )
+    runtime = SimpleNamespace(
+        resolved=SimpleNamespace(url="https://example.com/.well-known/agent-card.json")
+    )
+    captured_meta_extra: dict[str, Any] | None = None
+
+    async def _fake_snapshot(*, runtime):
+        assert runtime is not None
+        return _capability_snapshot(
+            session_query=_session_query_snapshot(ext),
+            session_binding=_binding_snapshot(status="unsupported"),
+        )
+
+    async def _fake_invoke(**kwargs):
+        assert kwargs["method_key"] == "list_sessions"
+        assert kwargs["params"]["offset"] == 20
+        assert kwargs["params"]["limit"] == 20
+        assert kwargs["params"]["directory"] == "services/api"
+        assert kwargs["params"]["search"] == "planner"
+        assert kwargs["params"]["query"] == {
+            "status": "open",
+            "roots": True,
+            "start": 40,
+        }
+        nonlocal captured_meta_extra
+        captured_meta_extra = kwargs.get("meta_extra")
+        return ExtensionCallResult(success=True, result={"items": []}, meta={})
+
+    monkeypatch.setattr(service, "resolve_capability_snapshot", _fake_snapshot)
+    monkeypatch.setattr(service._session_extensions, "invoke_method", _fake_invoke)
+    monkeypatch.setattr(
+        service._support,
+        "ensure_outbound_allowed",
+        lambda url, *, purpose: url,
+    )
+
+    result = await service.list_sessions(
+        runtime=runtime,
+        page=2,
+        size=20,
+        query={"status": "open"},
+        filters={
+            "directory": "services/api",
+            "roots": True,
+            "start": 40,
+            "search": "planner",
+        },
+        include_raw=False,
+    )
+
+    assert result.success is True
+    assert captured_meta_extra == {
+        "session_list_filters": {
+            "directory": "top_level",
+            "roots": "query",
+            "start": "query",
+            "search": "top_level",
+        }
+    }
+    assert result.meta == {}
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_rejects_unsupported_typed_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = A2AExtensionsService()
+    ext = _resolved_extension(supports_offset=True)
+    runtime = SimpleNamespace(
+        resolved=SimpleNamespace(url="https://example.com/.well-known/agent-card.json")
+    )
+
+    async def _fake_snapshot(*, runtime):
+        assert runtime is not None
+        return _capability_snapshot(
+            session_query=_session_query_snapshot(ext),
+            session_binding=_binding_snapshot(status="unsupported"),
+        )
+
+    monkeypatch.setattr(service, "resolve_capability_snapshot", _fake_snapshot)
+    monkeypatch.setattr(
+        service._support,
+        "ensure_outbound_allowed",
+        lambda url, *, purpose: url,
+    )
+
+    with pytest.raises(ValueError, match="directory filter is not supported"):
+        await service.list_sessions(
+            runtime=runtime,
+            page=1,
+            size=20,
+            query=None,
+            filters={"directory": "services/api"},
+            include_raw=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_rejects_conflicting_filter_and_query_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = A2AExtensionsService()
+    ext = _resolved_extension(
+        supports_offset=True,
+        session_list_filters=SessionListFiltersContract(
+            directory=SessionListFilterFieldContract(top_level_param="directory"),
+        ),
+    )
+    runtime = SimpleNamespace(
+        resolved=SimpleNamespace(url="https://example.com/.well-known/agent-card.json")
+    )
+
+    async def _fake_snapshot(*, runtime):
+        assert runtime is not None
+        return _capability_snapshot(
+            session_query=_session_query_snapshot(ext),
+            session_binding=_binding_snapshot(status="unsupported"),
+        )
+
+    monkeypatch.setattr(service, "resolve_capability_snapshot", _fake_snapshot)
+    monkeypatch.setattr(
+        service._support,
+        "ensure_outbound_allowed",
+        lambda url, *, purpose: url,
+    )
+
+    with pytest.raises(
+        ValueError, match="filters.directory conflicts with query.directory"
+    ):
+        await service.list_sessions(
+            runtime=runtime,
+            page=1,
+            size=20,
+            query={"directory": "legacy"},
+            filters={"directory": "services/api"},
+            include_raw=False,
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/extensions/test_session_query_extension_discovery.py
+++ b/backend/tests/extensions/test_session_query_extension_discovery.py
@@ -101,6 +101,8 @@ def test_resolve_extracts_methods_pagination_provider_and_interface() -> None:
     assert resolved.pagination.params == ("page", "size")
     assert resolved.pagination.supports_offset is False
     assert resolved.result_envelope == ResultEnvelopeMapping()
+    assert resolved.session_list_filters.directory.top_level_param is None
+    assert resolved.session_list_filters.directory.query_param is None
 
     control_methods = resolve_session_query_control_methods(card, ext=resolved)
     assert control_methods["prompt_async"].declared is True
@@ -249,6 +251,55 @@ def test_resolve_extracts_message_cursor_pagination_contract() -> None:
 
     assert resolved.message_cursor_pagination.cursor_param == "before"
     assert resolved.message_cursor_pagination.result_cursor_field == "next_cursor"
+
+
+def test_resolve_extracts_session_list_filter_contract() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": SHARED_SESSION_QUERY_URI,
+            "required": False,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "shared.sessions.list",
+                    "get_session_messages": "shared.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "limit",
+                    "default_limit": 20,
+                    "max_limit": 100,
+                },
+                "method_contracts": {
+                    "shared.sessions.list": {
+                        "params": {
+                            "optional_params": [
+                                "limit",
+                                "directory",
+                                "query.roots",
+                                "query.start",
+                                "search",
+                            ]
+                        }
+                    }
+                },
+                "errors": {"business_codes": {}},
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+
+    card = AgentCard.model_validate(payload)
+    resolved = resolve_session_query(card)
+
+    assert resolved.session_list_filters.directory.top_level_param == "directory"
+    assert resolved.session_list_filters.directory.query_param is None
+    assert resolved.session_list_filters.roots.top_level_param is None
+    assert resolved.session_list_filters.roots.query_param == "roots"
+    assert resolved.session_list_filters.start.top_level_param is None
+    assert resolved.session_list_filters.start.query_param == "start"
+    assert resolved.session_list_filters.search.top_level_param == "search"
+    assert resolved.session_list_filters.search.query_param is None
 
 
 def test_resolve_accepts_result_envelope_field_aliases() -> None:

--- a/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
+++ b/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
@@ -128,7 +128,7 @@ class _FakeExtensionsService:
         )
 
     async def list_sessions(
-        self, *, runtime, page: int, size, query, include_raw=False
+        self, *, runtime, page: int, size, query, filters=None, include_raw=False
     ):
         raw_items = [{"id": "sess-1", "title": "One", "provider": "opencode"}]
         self.calls.append(
@@ -139,6 +139,7 @@ class _FakeExtensionsService:
                 "size": size,
                 "include_raw": include_raw,
                 "query": query,
+                "filters": filters,
             }
         )
         result = {
@@ -1027,6 +1028,77 @@ async def test_hub_session_query_routes_exclude_raw_by_default_and_allow_include
     ]
     assert [call["include_raw"] for call in message_calls] == [True]
     assert [call["before"] for call in message_calls] == ["cursor-1"]
+
+
+@pytest.mark.asyncio
+async def test_hub_session_query_routes_forward_typed_session_list_filters(
+    async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "a2a_proxy_allowed_hosts", ["example.com"])
+
+    agent_id, user = await _create_allowlisted_hub_agent(
+        async_session_maker=async_session_maker,
+        async_db_session=async_db_session,
+        admin_email="admin_opencode_filters@example.com",
+        user_email="alice_opencode_filters@example.com",
+        token="secret-token-opencode-filters",
+    )
+
+    fake_extensions = _FakeExtensionsService()
+    monkeypatch.setattr(
+        extension_router_common,
+        "get_a2a_extensions_service",
+        lambda: fake_extensions,
+    )
+
+    async with create_test_client(
+        hub_extension_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as user_client:
+        post_resp = await user_client.post(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/extensions/sessions:query",
+            json={
+                "page": 1,
+                "size": 20,
+                "filters": {
+                    "directory": "services/api",
+                    "roots": True,
+                    "start": 40,
+                    "search": "planner",
+                },
+                "query": {"status": "open"},
+            },
+        )
+        assert post_resp.status_code == 200
+        assert post_resp.json()["success"] is True
+
+        get_resp = await user_client.get(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/extensions/sessions"
+            "?page=1&size=20&directory=services/api&roots=true&start=40&search=planner"
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json()["success"] is True
+
+    session_calls = [
+        call for call in fake_extensions.calls if call["fn"] == "list_sessions"
+    ]
+    assert len(session_calls) == 2
+    assert session_calls[0]["query"] == {"status": "open"}
+    assert session_calls[0]["filters"] == {
+        "directory": "services/api",
+        "roots": True,
+        "start": 40,
+        "search": "planner",
+    }
+    assert session_calls[1]["query"] is None
+    assert session_calls[1]["filters"] == {
+        "directory": "services/api",
+        "roots": True,
+        "start": 40,
+        "search": "planner",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联 issues

- Closes #660
- Related #658

## 审查结论

`#660` 在当前主干上仍然有效，但最佳实践边界应保持为 backend-only：
- backend 根据上游 `session-query` extension contract 识别 session list filters 支持情况；
- Hub 对前端 / 调用方暴露稳定的 typed filters 协议；
- 不把本次实现与消息历史 cursor pagination、聊天页历史 UI、或其它 session control 子协议混做。

本次没有发现需要和其它 open issues 合并开发的项，`Closes #660` / `Related #658` 关系保持准确。

## Backend Contract

- 在 `session_query` resolver 中新增 `session list filters` contract 解析。
- 根据上游 `method_contracts` 识别 `directory / roots / start / search` 是否支持，以及参数落点是顶层还是 `query.*`。
- 保持老 runtime 兼容；缺少相关声明时，Hub 不会假定 runtime 一定支持这些 filters。

## Backend API

- 为 extension session list surface 增加稳定的 typed filters schema。
- `POST /extensions/sessions:query` 现在支持 `filters.directory / roots / start / search`。
- `GET /extensions/sessions` 现在支持同名 query params。
- backend 会把稳定 filters 映射到 runtime 实际声明的参数位置，而不是要求调用方理解 provider-private 参数细节。
- 当调用方显式传入 runtime 未声明支持的 filter，返回清晰错误；默认 `page / size` 行为保持不变。

## Frontend

- 无前端代码改动。
- frontend / 调用方继续消费 Hub 稳定协议，不需要理解上游参数落点。

## Tests

- 补齐 resolver 测试，验证从 `method_contracts` 提取 session list filter contract。
- 补齐 service 测试，验证 typed filters 到 top-level / `query.*` 的映射、冲突检测、以及 unsupported runtime 错误。
- 补齐 route 测试，验证 GET / POST 两条 session list 路由都能消费稳定 filters。

## Docs

- 更新 `backend/README.md`，补充 GET / POST 的 session list filter 示例。

## 验证

```bash
cd backend && uv run --locked pre-commit run --files README.md app/features/extension_capabilities/common_router.py app/integrations/a2a_extensions/service.py app/integrations/a2a_extensions/session_extension_service.py app/integrations/a2a_extensions/session_query.py app/integrations/a2a_extensions/types.py app/schemas/a2a_extension.py tests/extensions/test_a2a_extensions_service.py tests/extensions/test_session_query_extension_discovery.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py --config ../.pre-commit-config.yaml
cd backend && uv run --locked pytest tests/extensions/test_a2a_extensions_service.py tests/extensions/test_session_query_extension_discovery.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
```

结果：
- `pre-commit` 通过
- `pytest` 通过：`92 passed in 32.87s`
