### PR TITLE
fix(backend): accept session-query cursor pagination (#669)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -245,8 +245,8 @@ Notes:
   runtime does not expose cursor pagination.
 
 - The backend discovers the JSON-RPC interface URL and method names via the Agent
-  Card extension contract, and enforces the declared `page/size` pagination
-  constraints (default size / max size).
+  Card extension contract, and enforces the declared pagination constraints
+  (`page/size`, `limit`, or `limit + cursor`, including default/max bounds).
 - Responses include a stable envelope with `success`, `result` (upstream
   envelope), `error_code`, and `upstream_error`.
 - Non-2xx HTTP errors are normalized under `detail`, for example:

--- a/backend/app/integrations/a2a_extensions/session_query.py
+++ b/backend/app/integrations/a2a_extensions/session_query.py
@@ -32,6 +32,8 @@ from app.integrations.a2a_extensions.types import (
     SessionListFiltersContract,
 )
 
+LIMIT_WITH_OPTIONAL_CURSOR_MODE = "limit_and_optional_cursor"
+
 
 def _resolve_pagination_size(
     pagination: Dict[str, Any],
@@ -56,7 +58,7 @@ def _resolve_pagination_size(
 
 
 def _parse_pagination_params(
-    pagination: Dict[str, Any], *, mode: str
+    pagination: Dict[str, Any], *, mode: str, declared_mode: str
 ) -> tuple[tuple[str, ...], bool]:
     raw_params = pagination.get("params")
     params: list[str] = []
@@ -70,7 +72,12 @@ def _parse_pagination_params(
             params.append(token)
 
     if not params:
-        params = ["page", "size"] if mode == "page_size" else ["limit"]
+        if mode == "page_size":
+            params = ["page", "size"]
+        elif declared_mode == LIMIT_WITH_OPTIONAL_CURSOR_MODE:
+            params = ["limit", "before"]
+        else:
+            params = ["limit"]
 
     if mode == "page_size":
         if "page" not in params or "size" not in params:
@@ -82,6 +89,11 @@ def _parse_pagination_params(
     if "limit" not in params:
         raise A2AExtensionContractError(
             "Extension pagination.params must include limit for mode 'limit'"
+        )
+    if declared_mode == LIMIT_WITH_OPTIONAL_CURSOR_MODE and "offset" in params:
+        raise A2AExtensionContractError(
+            "Extension pagination.params must not include offset for mode "
+            "'limit_and_optional_cursor'"
         )
     return tuple(params), "offset" in params
 
@@ -132,6 +144,7 @@ def _resolve_result_envelope(value: Any) -> Optional[ResultEnvelopeMapping]:
 def _resolve_message_cursor_pagination(
     pagination: Dict[str, Any],
     *,
+    pagination_mode: str,
     get_messages_method: str,
 ) -> MessageCursorPaginationContract:
     raw_cursor_applies_to = pagination.get("cursor_applies_to")
@@ -147,6 +160,11 @@ def _resolve_message_cursor_pagination(
     raw_cursor_param = pagination.get("cursor_param")
     raw_result_cursor_field = pagination.get("result_cursor_field")
     if raw_cursor_param is None and raw_result_cursor_field is None:
+        if pagination_mode == LIMIT_WITH_OPTIONAL_CURSOR_MODE:
+            raise A2AExtensionContractError(
+                "Extension contract missing/invalid cursor pagination fields for mode "
+                "'limit_and_optional_cursor'"
+            )
         return MessageCursorPaginationContract()
     if not isinstance(raw_cursor_param, str) or not raw_cursor_param.strip():
         raise A2AExtensionContractError(
@@ -309,7 +327,10 @@ def _resolve_extension(
     )
 
     pagination = as_dict(params.get("pagination"))
-    mode = require_str(pagination.get("mode"), field="pagination.mode")
+    declared_mode = require_str(pagination.get("mode"), field="pagination.mode")
+    mode = (
+        "limit" if declared_mode == LIMIT_WITH_OPTIONAL_CURSOR_MODE else declared_mode
+    )
     uses_legacy_limit_fields = _uses_legacy_limit_fields(pagination)
     is_legacy_variant = (
         getattr(ext, "uri", None) == LEGACY_SHARED_SESSION_QUERY_URI
@@ -351,11 +372,16 @@ def _resolve_extension(
         )
     else:
         raise A2AExtensionContractError(
-            "Extension pagination.mode must be one of 'page_size' or 'limit'"
+            "Extension pagination.mode must be one of 'page_size', 'limit', or "
+            "'limit_and_optional_cursor'"
         )
     if default_size <= 0 or max_size <= 0 or default_size > max_size:
         raise A2AExtensionContractError("Extension pagination sizes are invalid")
-    pagination_params, supports_offset = _parse_pagination_params(pagination, mode=mode)
+    pagination_params, supports_offset = _parse_pagination_params(
+        pagination,
+        mode=mode,
+        declared_mode=declared_mode,
+    )
 
     errors = as_dict(params.get("errors"))
     code_to_error = build_business_code_map(errors.get("business_codes"))
@@ -363,6 +389,7 @@ def _resolve_extension(
     envelope_mapping = _resolve_result_envelope(params.get("result_envelope"))
     message_cursor_pagination = _resolve_message_cursor_pagination(
         pagination,
+        pagination_mode=declared_mode,
         get_messages_method=get_messages_method,
     )
     session_list_filters = _resolve_session_list_filters(

--- a/backend/app/integrations/a2a_extensions/session_query_diagnostics.py
+++ b/backend/app/integrations/a2a_extensions/session_query_diagnostics.py
@@ -106,7 +106,11 @@ def diagnose_session_query(card: AgentCard) -> SharedSessionQueryDiagnostic:
         uri=resolved.uri,
         provider=resolved.provider,
         methods=sorted(key for key, value in resolved.methods.items() if value),
-        pagination_mode=resolved.pagination.mode,
+        pagination_mode=(
+            str(raw_pagination.get("mode")).strip()
+            if raw_pagination and raw_pagination.get("mode") is not None
+            else resolved.pagination.mode
+        ),
         pagination_params=list(resolved.pagination.params),
         result_envelope_declared=resolved.result_envelope is not None,
         jsonrpc_interface_fallback_used=resolved.jsonrpc.fallback_used,

--- a/backend/tests/extensions/test_session_query_diagnostics.py
+++ b/backend/tests/extensions/test_session_query_diagnostics.py
@@ -111,6 +111,40 @@ def test_diagnose_session_query_returns_legacy_status_for_legacy_limit_fields() 
     assert diagnostic.pagination_mode == "limit"
 
 
+def test_diagnose_session_query_accepts_limit_and_optional_cursor_mode() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": SHARED_SESSION_QUERY_URI,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "opencode.sessions.list",
+                    "get_session_messages": "opencode.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "limit_and_optional_cursor",
+                    "default_limit": 20,
+                    "max_limit": 100,
+                    "params": ["limit", "before"],
+                    "cursor_param": "before",
+                    "result_cursor_field": "next_cursor",
+                    "cursor_applies_to": ["opencode.sessions.messages.list"],
+                },
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+
+    diagnostic = diagnose_session_query(AgentCard.model_validate(payload))
+
+    assert diagnostic.declared is True
+    assert diagnostic.status == "canonical"
+    assert diagnostic.uses_legacy_contract_fields is False
+    assert diagnostic.pagination_mode == "limit_and_optional_cursor"
+    assert diagnostic.pagination_params == ["limit", "before"]
+
+
 def test_diagnose_session_query_returns_unsupported_when_not_declared() -> None:
     diagnostic = diagnose_session_query(AgentCard.model_validate(_base_card_payload()))
 

--- a/backend/tests/extensions/test_session_query_extension_discovery.py
+++ b/backend/tests/extensions/test_session_query_extension_discovery.py
@@ -253,6 +253,45 @@ def test_resolve_extracts_message_cursor_pagination_contract() -> None:
     assert resolved.message_cursor_pagination.result_cursor_field == "next_cursor"
 
 
+def test_resolve_accepts_limit_and_optional_cursor_mode() -> None:
+    payload = _base_card_payload()
+    payload["capabilities"]["extensions"] = [
+        {
+            "uri": SHARED_SESSION_QUERY_URI,
+            "required": False,
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "opencode.sessions.list",
+                    "get_session_messages": "opencode.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "limit_and_optional_cursor",
+                    "default_limit": 20,
+                    "max_limit": 100,
+                    "params": ["limit", "before"],
+                    "cursor_param": "before",
+                    "result_cursor_field": "next_cursor",
+                    "cursor_applies_to": ["opencode.sessions.messages.list"],
+                },
+                "errors": {"business_codes": {}},
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+
+    card = AgentCard.model_validate(payload)
+    resolved = resolve_session_query(card)
+
+    assert resolved.pagination.mode == "limit"
+    assert resolved.pagination.default_size == 20
+    assert resolved.pagination.max_size == 100
+    assert resolved.pagination.params == ("limit", "before")
+    assert resolved.pagination.supports_offset is False
+    assert resolved.message_cursor_pagination.cursor_param == "before"
+    assert resolved.message_cursor_pagination.result_cursor_field == "next_cursor"
+
+
 def test_resolve_extracts_session_list_filter_contract() -> None:
     payload = _base_card_payload()
     payload["capabilities"]["extensions"] = [

--- a/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
+++ b/backend/tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py
@@ -886,6 +886,68 @@ async def test_hub_card_validate_reports_shared_session_query_diagnostics(
 
 
 @pytest.mark.asyncio
+async def test_hub_card_validate_accepts_limit_and_optional_cursor_session_query(
+    async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "a2a_proxy_allowed_hosts", ["example.com"])
+
+    agent_id, user = await _create_allowlisted_hub_agent(
+        async_session_maker=async_session_maker,
+        async_db_session=async_db_session,
+        admin_email="admin_validate_cursor@example.com",
+        user_email="alice_validate_cursor@example.com",
+        token="secret-token-validate-cursor",
+    )
+
+    fake_gateway = _FakeGateway()
+    fake_gateway.card_payload["capabilities"]["extensions"] = [
+        {
+            "uri": "urn:opencode-a2a:session-query/v1",
+            "params": {
+                "provider": "opencode",
+                "methods": {
+                    "list_sessions": "opencode.sessions.list",
+                    "get_session_messages": "opencode.sessions.messages.list",
+                },
+                "pagination": {
+                    "mode": "limit_and_optional_cursor",
+                    "default_limit": 20,
+                    "max_limit": 100,
+                    "params": ["limit", "before"],
+                    "cursor_param": "before",
+                    "result_cursor_field": "next_cursor",
+                    "cursor_applies_to": ["opencode.sessions.messages.list"],
+                },
+                "result_envelope": {"raw": True, "items": True, "pagination": True},
+            },
+        }
+    ]
+    monkeypatch.setattr(
+        hub_router, "get_a2a_service", lambda: _FakeA2AService(fake_gateway)
+    )
+
+    async with create_test_client(
+        hub_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as user_client:
+        resp = await user_client.post(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/card:validate"
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["success"] is True
+    assert payload["message"] == "Agent card validated"
+    assert payload["shared_session_query"]["status"] == "canonical"
+    assert payload["shared_session_query"]["pagination_mode"] == (
+        "limit_and_optional_cursor"
+    )
+    assert payload["shared_session_query"]["pagination_params"] == ["limit", "before"]
+
+
+@pytest.mark.asyncio
 async def test_hub_card_validate_reports_compatibility_profile_diagnostics(
     async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/invoke/test_validation_errors_debug_mode.py
+++ b/backend/tests/invoke/test_validation_errors_debug_mode.py
@@ -117,6 +117,66 @@ async def test_fetch_and_validate_agent_card_exposes_invalid_session_query_contr
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_validate_agent_card_accepts_limit_and_optional_cursor_mode() -> (
+    None
+):
+    class _ExtensionCard:
+        def model_dump(self, **kwargs):
+            return {
+                "name": "dummy",
+                "description": "dummy",
+                "url": "https://example.com",
+                "version": "1.0",
+                "capabilities": {
+                    "extensions": [
+                        {
+                            "uri": "urn:opencode-a2a:session-query/v1",
+                            "params": {
+                                "provider": "opencode",
+                                "methods": {
+                                    "list_sessions": "opencode.sessions.list",
+                                    "get_session_messages": (
+                                        "opencode.sessions.messages.list"
+                                    ),
+                                },
+                                "pagination": {
+                                    "mode": "limit_and_optional_cursor",
+                                    "default_limit": 20,
+                                    "max_limit": 100,
+                                    "params": ["limit", "before"],
+                                    "cursor_param": "before",
+                                    "result_cursor_field": "next_cursor",
+                                    "cursor_applies_to": [
+                                        "opencode.sessions.messages.list"
+                                    ],
+                                },
+                            },
+                        }
+                    ]
+                },
+                "defaultInputModes": [],
+                "defaultOutputModes": [],
+                "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+            }
+
+    class _ExtensionGateway:
+        async def fetch_agent_card_detail(self, **kwargs):
+            from a2a.types import AgentCard
+
+            return AgentCard.model_validate(_ExtensionCard().model_dump())
+
+    resp = await fetch_and_validate_agent_card(
+        gateway=_ExtensionGateway(), resolved=object()
+    )
+
+    assert resp.success is True
+    assert resp.shared_session_query is not None
+    assert resp.shared_session_query.status == "canonical"
+    assert resp.shared_session_query.pagination_mode == "limit_and_optional_cursor"
+    assert resp.message == "Agent card validated"
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_validate_agent_card_exposes_invalid_compatibility_profile() -> (
     None
 ):

--- a/docs/contracts/shared-session-query-canonical-contract.md
+++ b/docs/contracts/shared-session-query-canonical-contract.md
@@ -66,10 +66,11 @@ Method names must be non-empty strings.
 
 ## Pagination
 
-Hub accepts two canonical pagination modes:
+Hub accepts three canonical pagination declarations:
 
 - `page_size`
 - `limit`
+- `limit_and_optional_cursor`
 
 ### `page_size`
 
@@ -100,12 +101,35 @@ Optional:
 
 - `offset`
 
+### `limit_and_optional_cursor`
+
+Required fields:
+
+- `pagination.mode = "limit_and_optional_cursor"`
+- `pagination.default_limit`
+- `pagination.max_limit`
+- `pagination.cursor_param`
+- `pagination.result_cursor_field`
+
+Allowed parameter names must include:
+
+- `limit`
+
+Optional:
+
+- `before`
+
+Hub normalizes this declaration into its internal `limit` pagination baseline
+plus cursor capability metadata. This mode is therefore an additive `v1`
+enhancement, not a breaking protocol fork.
+
 ### Shared pagination rules
 
 - size values must be positive integers
 - `default_size` / `default_limit` must be less than or equal to the matching
   max value
 - missing defaults or max values are invalid
+- `limit_and_optional_cursor` declarations must not advertise `offset`
 - unsupported pagination modes are invalid
 
 ## Result Envelope

--- a/docs/contracts/shared-session-query-reference-payloads.json
+++ b/docs/contracts/shared-session-query-reference-payloads.json
@@ -65,6 +65,39 @@
       }
     },
     {
+      "name": "canonical_limit_with_optional_cursor_extension",
+      "description": "Canonical limit contract with backward cursor pagination metadata.",
+      "extension": {
+        "uri": "urn:opencode-a2a:session-query/v1",
+        "params": {
+          "provider": "opencode",
+          "methods": {
+            "list_sessions": "opencode.sessions.list",
+            "get_session_messages": "opencode.sessions.messages.list"
+          },
+          "pagination": {
+            "mode": "limit_and_optional_cursor",
+            "default_limit": 20,
+            "max_limit": 100,
+            "params": [
+              "limit",
+              "before"
+            ],
+            "cursor_param": "before",
+            "result_cursor_field": "next_cursor",
+            "cursor_applies_to": [
+              "opencode.sessions.messages.list"
+            ]
+          },
+          "result_envelope": {
+            "items": true,
+            "pagination": true,
+            "raw": true
+          }
+        }
+      }
+    },
+    {
       "name": "canonical_alias_mapping_extension",
       "description": "Canonical contract using explicit field-path aliases for the result envelope.",
       "extension": {


### PR DESCRIPTION
## 关联 issue

- Closes #669

## 改动说明

### Backend session-query
- 让 Hub 接受 `pagination.mode = limit_and_optional_cursor`
- 将该声明归一化为内部稳定的 `limit` 分页基线加 cursor capability
- 保持现有 `before` / `nextBefore` 消费路径不变，避免把加性演进误判为 invalid

### 验证与诊断
- 更新 shared session query diagnostics，保留上游声明的原始 `pagination_mode`
- 修复 `card:validate` 对最新 `opencode-a2a-serve` Agent Card 的兼容性
- 补充路由级回归，覆盖 `card:validate` 的真实入口场景

### 文档与夹具
- 更新 session-query canonical contract 文档，明确 `limit_and_optional_cursor` 属于 `v1` 下的兼容性增强
- 更新 reference payloads，新增 cursor 分页的 canonical case
- 调整 backend README 中对分页约束的说明

## 验证结果

- `cd backend && uv run --locked pre-commit run --files app/integrations/a2a_extensions/session_query.py app/integrations/a2a_extensions/session_query_diagnostics.py tests/extensions/test_session_query_extension_discovery.py tests/extensions/test_session_query_diagnostics.py tests/invoke/test_validation_errors_debug_mode.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py README.md ../docs/contracts/shared-session-query-canonical-contract.md ../docs/contracts/shared-session-query-reference-payloads.json --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/extensions/test_session_query_extension_discovery.py tests/extensions/test_session_query_diagnostics.py tests/extensions/test_session_query_runtime_selection.py tests/extensions/test_a2a_extensions_pagination.py tests/invoke/test_validation_errors_debug_mode.py tests/hub_agents/test_hub_a2a_extensions_and_validate_routes.py -k 'shared_session_query or limit_and_optional_cursor or validation_errors_debug_mode or session_query'`
  - 结果：`36 passed, 50 deselected`
