### PR TITLE
fix(ci): complete node24 workflow runtime cleanup (#674)

### DIFF
--- a/.github/workflows/dependency-audit-dev.yml
+++ b/.github/workflows/dependency-audit-dev.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload backend dev dependency audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: backend-dev-pip-audit
           path: /tmp/backend-dev-pip-audit.md

--- a/.github/workflows/frontend-dependency-audit.yml
+++ b/.github/workflows/frontend-dependency-audit.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload frontend dependency audit report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-npm-audit
           path: /tmp/frontend-npm-audit.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    env:
+      # Upstream softprops/action-gh-release@v2 still declares node20.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## 变更概览
本 PR 是已合并 workflow runtime 清理后的补充修复，目标是把仓库中仍可能触发 Node.js 20 JavaScript action deprecation warning 的位置一次性处理到位。

### 模块一：Artifact Upload Runtime
- 将 `.github/workflows/frontend-dependency-audit.yml` 中的 `actions/upload-artifact` 从 `@v4` 升级到 `@v6`
- 将 `.github/workflows/dependency-audit-dev.yml` 中的 `actions/upload-artifact` 从 `@v4` 升级到 `@v6`
- `@v6` 已声明 `runs.using: node24`，用于消除当前 audit 工作流中的 Node 20 warning

### 模块二：Release Workflow Runtime
- 保留 `.github/workflows/release.yml` 中的 `softprops/action-gh-release@v2`
- 在 `github-release` job 级别增加 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`
- 原因是 upstream 最新 `softprops/action-gh-release@v2.6.1` 仍声明 `runs.using: node20`，当前没有可直接切换的 node24 版本，因此采用 GitHub 官方建议的 Node 24 opt-in 方式处理

## 全量排查结论
已逐项核对当前仓库 workflow 中使用的 action：
- `actions/checkout@v5`: node24
- `actions/setup-node@v5`: node24
- `actions/setup-python@v6`: node24
- `astral-sh/setup-uv@v7`: node24
- `peter-evans/create-pull-request@v8`: node24
- `actions/upload-artifact@v6`: node24
- `softprops/action-gh-release@v2`: upstream 仍为 node20，本 PR 通过 job env 强制切换到 node24

## 验证
- `git diff --check`
- 本地全文扫描 `.github/workflows` 中所有 `uses:` 引用
- 核对相关 action 官方 `action.yml` 的 `runs.using` 声明

## 关联
- Related: #674
- Related: #676
