### PR TITLE
fix(frontend): 修复 Agent 列表空分页导致的 422 并补充部署诊断 (#689)

### DIFF
--- a/frontend/screens/AgentListScreen.tsx
+++ b/frontend/screens/AgentListScreen.tsx
@@ -25,6 +25,13 @@ import { useSessionStore } from "@/store/session";
 const PERSONAL_PAGE_SIZE = 12;
 const SHARED_PAGE_SIZE = 8;
 
+const clampPageWithinBounds = (page: number, totalPages: number) => {
+  if (!Number.isFinite(totalPages) || totalPages <= 0) {
+    return 1;
+  }
+  return Math.max(1, Math.min(page, totalPages));
+};
+
 const HEALTH_BADGE_STYLES: Record<
   A2AAgentResponse["health_status"],
   { label: string; className: string }
@@ -96,7 +103,7 @@ export function AgentListScreen() {
     if (typeof totalPages !== "number" || !Number.isFinite(totalPages)) {
       return;
     }
-    setPersonalPage((value) => Math.min(value, totalPages));
+    setPersonalPage((value) => clampPageWithinBounds(value, totalPages));
   }, [personalQuery.data?.pagination.pages]);
 
   useEffect(() => {
@@ -108,7 +115,7 @@ export function AgentListScreen() {
     if (typeof totalPages !== "number" || !Number.isFinite(totalPages)) {
       return;
     }
-    setAttentionPage((value) => Math.min(value, totalPages));
+    setAttentionPage((value) => clampPageWithinBounds(value, totalPages));
   }, [attentionCount, attentionQuery.data?.pagination.pages]);
 
   useEffect(() => {
@@ -116,7 +123,7 @@ export function AgentListScreen() {
     if (typeof totalPages !== "number" || !Number.isFinite(totalPages)) {
       return;
     }
-    setSharedPage((value) => Math.min(value, totalPages));
+    setSharedPage((value) => clampPageWithinBounds(value, totalPages));
   }, [sharedQuery.data?.pagination.pages]);
 
   const invalidateAgentQueries = async () => {

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -9,9 +9,13 @@ const mockInvalidateQueries = jest.fn(() => Promise.resolve());
 const mockBatchMutate = jest.fn();
 const mockBlurActiveElement = jest.fn();
 const mockSharedPageCalls: number[] = [];
+const mockPersonalHealthyPageCalls: number[] = [];
+const mockAttentionPageCalls: number[] = [];
 
 let mockButtons: Record<string, unknown>[] = [];
 let mockSharedPageLoading = false;
+let mockPersonalHealthyTotalPages = 1;
+let mockAttentionTotalPages = 1;
 
 jest.mock("@tanstack/react-query", () => ({
   useMutation: () => ({
@@ -30,8 +34,15 @@ jest.mock("expo-router", () => ({
 }));
 
 jest.mock("@/hooks/useAgentListQueries", () => ({
-  usePersonalAgentsListQuery: ({ healthBucket }: { healthBucket: string }) => {
+  usePersonalAgentsListQuery: ({
+    healthBucket,
+    page,
+  }: {
+    healthBucket: string;
+    page: number;
+  }) => {
     if (healthBucket === "attention") {
+      mockAttentionPageCalls.push(page);
       return {
         data: {
           items: [
@@ -52,7 +63,12 @@ jest.mock("@/hooks/useAgentListQueries", () => ({
               updated_at: "2026-03-25T09:00:00.000Z",
             },
           ],
-          pagination: { page: 1, size: 12, total: 1, pages: 1 },
+          pagination: {
+            page,
+            size: 12,
+            total: mockAttentionTotalPages > 0 ? 1 : 0,
+            pages: mockAttentionTotalPages,
+          },
           meta: {
             counts: { healthy: 1, degraded: 1, unavailable: 0, unknown: 1 },
           },
@@ -62,6 +78,7 @@ jest.mock("@/hooks/useAgentListQueries", () => ({
       };
     }
 
+    mockPersonalHealthyPageCalls.push(page);
     return {
       data: {
         items: [
@@ -82,7 +99,12 @@ jest.mock("@/hooks/useAgentListQueries", () => ({
             updated_at: "2026-03-25T08:00:00.000Z",
           },
         ],
-        pagination: { page: 1, size: 12, total: 1, pages: 1 },
+        pagination: {
+          page,
+          size: 12,
+          total: mockPersonalHealthyTotalPages > 0 ? 1 : 0,
+          pages: mockPersonalHealthyTotalPages,
+        },
         meta: {
           counts: { healthy: 1, degraded: 1, unavailable: 0, unknown: 1 },
         },
@@ -174,7 +196,11 @@ describe("AgentListScreen", () => {
   beforeEach(() => {
     mockButtons = [];
     mockSharedPageCalls.length = 0;
+    mockPersonalHealthyPageCalls.length = 0;
+    mockAttentionPageCalls.length = 0;
     mockSharedPageLoading = false;
+    mockPersonalHealthyTotalPages = 1;
+    mockAttentionTotalPages = 1;
     jest.clearAllMocks();
   });
 
@@ -335,5 +361,24 @@ describe("AgentListScreen", () => {
       .join(" ");
 
     expect(textContent).toContain("SHARED");
+  });
+
+  it("keeps page at 1 when the server reports zero available pages", async () => {
+    mockPersonalHealthyTotalPages = 0;
+
+    let tree: ReturnType<typeof create>;
+
+    await act(async () => {
+      tree = create(<AgentListScreen />);
+    });
+
+    expect(mockPersonalHealthyPageCalls).toEqual([1]);
+
+    await act(async () => {
+      tree!.update(<AgentListScreen />);
+    });
+
+    expect(mockPersonalHealthyPageCalls).toEqual([1, 1]);
+    expect(mockPersonalHealthyPageCalls).not.toContain(0);
   });
 });


### PR DESCRIPTION
## 关联问题
- Closes #689

## 本次变更
- 修复 Agent 列表分页收敛逻辑：当后端返回 `pagination.pages = 0` 时，前端不再把页码收敛成 `0`
- 为 AgentListScreen 补充回归测试，覆盖“空分页结果仍保持请求页码为 1”的场景

## 根因诊断
- `422`：前端在 [AgentListScreen] 中将当前页执行 `Math.min(value, totalPages)`；当后端返回 `pages = 0` 时，页码被写成 `0`，随后请求 `/api/v1/a2a/agents?page=0&size=8`，而后端要求 `page >= 1`，因此返回 `422`
- `manifest.json` CORS：前端页面固定输出 `<link rel="manifest" href="/manifest.json" />`，但部署环境对 `/manifest.json` 施加了 Cloudflare Access 保护；实际请求会 `302` 到 `https://schellingai.cloudflareaccess.com/...`，浏览器将其视为跨域 manifest 重定向并拦截
- `cdn-cgi/rum` CSP report-only：仓库中未发现对应脚本或 CSP 配置，结合 Cloudflare 官方文档可判断这是边缘侧附加的 `Content-Security-Policy-Report-Only` 与 Cloudflare RUM / client-side security 采样冲突产生的噪音日志，不是应用代码主动发出的业务请求

## 部署侧建议
- 若需要保留 PWA manifest：将 `/manifest.json` 与相关图标路径从 Cloudflare Access 保护中豁免，或改为可匿名访问的静态资源路径
- 若当前不需要 PWA：移除或条件化输出 `<link rel="manifest">`
- 检查 Cloudflare Browser Insights / client-side security / Page Shield 等功能是否同时开启；若保留 report-only 策略，需要为 `connect-src` 放通 Cloudflare 自身 RUM 上报端点，否则 console 会持续出现噪音

## 验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests screens/AgentListScreen.tsx screens/__tests__/AgentListScreen.test.tsx --maxWorkers=25%`
- `curl -I https://a2a-dev.ii.inc/manifest.json` 返回 `302`，目标为 `https://schellingai.cloudflareaccess.com/...&redirect_url=%2Fmanifest.json`
