### PR TITLE
chore: add Dependabot baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      backend-all-updates:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      frontend-all-updates:
+        patterns:
+          - "*"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ You can observe these via `/health` under `a2a.ops_metrics`:
 
 ## Key docs
 
+- Dependency automation
+  - Dependabot opens at most one weekly grouped version-update PR for `backend/` (`uv`) and at most one for `frontend/` (`npm`).
+  - Existing audit workflows remain in place for explicit vulnerability review and do not replace human triage.
 - Documentation index: [docs/README.md](docs/README.md)
 - Contributor guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Automation protocol: [AGENTS.md](AGENTS.md)

--- a/backend/tests/runtime/test_repository_dependabot_contract.py
+++ b/backend/tests/runtime/test_repository_dependabot_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_dependabot_limits_backend_and_frontend_to_one_grouped_pr() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    dependabot_config = (repo_root / ".github" / "dependabot.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'package-ecosystem: "uv"' in dependabot_config
+    assert 'directory: "/backend"' in dependabot_config
+    assert "backend-all-updates" in dependabot_config
+
+    assert 'package-ecosystem: "npm"' in dependabot_config
+    assert 'directory: "/frontend"' in dependabot_config
+    assert "frontend-all-updates" in dependabot_config
+
+    assert dependabot_config.count("open-pull-requests-limit: 1") == 2
+
+
+def test_readme_documents_dependabot_and_audit_split() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
+
+    assert "Dependabot opens at most one weekly grouped version-update PR" in readme_text
+    assert "Existing audit workflows remain in place" in readme_text

--- a/backend/tests/runtime/test_repository_dependabot_contract.py
+++ b/backend/tests/runtime/test_repository_dependabot_contract.py
@@ -24,5 +24,7 @@ def test_readme_documents_dependabot_and_audit_split() -> None:
     repo_root = Path(__file__).resolve().parents[3]
     readme_text = (repo_root / "README.md").read_text(encoding="utf-8")
 
-    assert "Dependabot opens at most one weekly grouped version-update PR" in readme_text
+    assert (
+        "Dependabot opens at most one weekly grouped version-update PR" in readme_text
+    )
     assert "Existing audit workflows remain in place" in readme_text


### PR DESCRIPTION
## 概要

为仓库引入克制版 Dependabot 基线：后端与前端分别独立维护版本升级节奏，各自最多只保留 1 个打开中的 Dependabot 版本升级 PR，以降低依赖升级审阅噪声，同时保留现有依赖审计 workflow 作为显式安全巡检入口。

## 变更

### `.github`

- 新增 `.github/dependabot.yml`
- 为 `backend/` 配置 `uv` ecosystem，每周检查一次，并将全部更新聚合到 `backend-all-updates`
- 为 `frontend/` 配置 `npm` ecosystem，每周检查一次，并将全部更新聚合到 `frontend-all-updates`
- 后端与前端都将 `open-pull-requests-limit` 收敛为 `1`

### `README`

- 在仓库级 README 中补充依赖自动化说明
- 说明 Dependabot 负责分生态聚合版本升级
- 说明现有 dependency audit workflows 继续保留，用于显式漏洞审计与人工分诊

### `backend/tests`

- 新增 `backend/tests/runtime/test_repository_dependabot_contract.py`
- 约束 Dependabot 配置必须同时覆盖 `backend` 与 `frontend`
- 约束两侧都仅允许 1 个打开中的 grouped version-update PR
- 约束 README 中保留 Dependabot 与 audit workflow 的职责说明

## 验证

- `cd backend && uv run --locked pre-commit run --files tests/runtime/test_repository_dependabot_contract.py --config ../.pre-commit-config.yaml`
- `cd backend && uv sync --extra dev --locked`
- `cd backend && uv run --locked pytest tests/runtime/test_repository_dependabot_contract.py`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`

## 备注

- 当前“前后端各最多 1 个 PR”仅作用于 Dependabot version updates
- 仓库现有 `frontend-dependency-audit.yml` 仍可能在 `npm audit fix --package-lock-only` 有结果时额外创建审计修复 PR；本次未调整该流程

## 关联

- Closes #760
