### PR TITLE
chore(dependabot): gate frontend framework upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,34 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Framework-coupled frontend minor bumps are planned manually.
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "react-dom"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "react-native"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "react-native-gesture-handler"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "react-native-safe-area-context"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "react-native-screens"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "react-test-renderer"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "@types/react"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "@types/react-test-renderer"
+        update-types:
+          - "version-update:semver-minor"
     groups:
       # Keep Expo SDK updates together, but only for patch/minor changes.
       frontend-expo-sdk:
@@ -42,10 +70,12 @@ updates:
           - "react"
           - "react-dom"
           - "react-native"
-          - "react-native-*"
-        exclude-patterns:
-          - "@react-native-async-storage/async-storage"
-          - "react-native-mmkv"
+          - "react-native-gesture-handler"
+          - "react-native-safe-area-context"
+          - "react-native-screens"
+          - "react-test-renderer"
+          - "@types/react"
+          - "@types/react-test-renderer"
         update-types:
           - "patch"
           - "minor"
@@ -71,6 +101,15 @@ updates:
           - "expo-*"
           - "babel-preset-expo"
           - "jest-expo"
+          - "react"
+          - "react-dom"
+          - "react-native"
+          - "react-native-gesture-handler"
+          - "react-native-safe-area-context"
+          - "react-native-screens"
+          - "react-test-renderer"
+          - "@types/react"
+          - "@types/react-test-renderer"
         update-types:
           - "patch"
           - "minor"
@@ -87,7 +126,9 @@ updates:
           - "react"
           - "react-dom"
           - "react-native"
-          - "react-native-*"
+          - "react-native-gesture-handler"
+          - "react-native-safe-area-context"
+          - "react-native-screens"
           - "@react-native-async-storage/async-storage"
           - "react-native-mmkv"
           - "zustand"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ Notes:
 - Dependabot keeps backend updates grouped weekly for `backend/` (`uv`).
 - Frontend npm updates are split into smaller patch/minor review lanes for Expo SDK, React Native core, state/storage, development tooling, and miscellaneous runtime packages.
 - Semver-major frontend updates are intentionally ignored for automatic PR creation and are expected to be planned manually.
+- React / React Native core and renderer-aligned minor upgrades are planned manually because they require coordinated Expo SDK, test preset, and peer dependency review.
 - Existing audit workflows remain in place for explicit vulnerability review and do not replace human triage.
 
 ## Security

--- a/backend/tests/runtime/test_repository_dependabot_contract.py
+++ b/backend/tests/runtime/test_repository_dependabot_contract.py
@@ -18,6 +18,15 @@ def test_dependabot_keeps_backend_grouped_and_frontend_split_by_risk() -> None:
     assert "open-pull-requests-limit: 3" in dependabot_config
     assert 'dependency-name: "*"' in dependabot_config
     assert "version-update:semver-major" in dependabot_config
+    assert 'dependency-name: "react"' in dependabot_config
+    assert 'dependency-name: "react-dom"' in dependabot_config
+    assert 'dependency-name: "react-native"' in dependabot_config
+    assert 'dependency-name: "react-native-gesture-handler"' in dependabot_config
+    assert 'dependency-name: "react-native-safe-area-context"' in dependabot_config
+    assert 'dependency-name: "react-native-screens"' in dependabot_config
+    assert 'dependency-name: "react-test-renderer"' in dependabot_config
+    assert 'dependency-name: "@types/react"' in dependabot_config
+    assert 'dependency-name: "@types/react-test-renderer"' in dependabot_config
     assert "frontend-expo-sdk" in dependabot_config
     assert "frontend-react-native-core" in dependabot_config
     assert "frontend-state-storage" in dependabot_config
@@ -25,6 +34,10 @@ def test_dependabot_keeps_backend_grouped_and_frontend_split_by_risk() -> None:
     assert "frontend-runtime-misc" in dependabot_config
     assert 'dependency-type: "development"' in dependabot_config
     assert 'dependency-type: "production"' in dependabot_config
+    assert '  - "react-test-renderer"' in dependabot_config
+    assert '  - "@types/react"' in dependabot_config
+    assert '  - "@types/react-test-renderer"' in dependabot_config
+    assert '  - "react-native-*"' not in dependabot_config
     assert "labels:" not in dependabot_config
 
 
@@ -39,5 +52,9 @@ def test_contributing_documents_dependabot_and_audit_split() -> None:
     )
     assert (
         "Semver-major frontend updates are intentionally ignored" in contributing_text
+    )
+    assert (
+        "React / React Native core and renderer-aligned minor upgrades are planned manually"
+        in contributing_text
     )
     assert "Existing audit workflows remain in place" in contributing_text


### PR DESCRIPTION
## 概述

本 PR 收紧前端 Dependabot 的框架升级通道，避免 React / React Native 相关小版本更新继续自动产出高噪音 PR。

## 配置

- 为 React / React Native 框架联动包添加 `semver-minor` ignore 规则：
  - `react`
  - `react-dom`
  - `react-native`
  - `react-native-gesture-handler`
  - `react-native-safe-area-context`
  - `react-native-screens`
  - `react-test-renderer`
  - `@types/react`
  - `@types/react-test-renderer`
- 将 `frontend-react-native-core` 从宽泛的 `react-native-*` 模式收紧为精确名单。
- 将 `frontend-dev-tooling` 排除 `react-test-renderer` 与 React 类型包，避免它们误落到普通工具链更新通道。
- 将 `frontend-runtime-misc` 的 `react-native-*` 宽泛排除收紧为精确名单，避免普通运行时包掉出分组并退化成零散 PR。

## 测试与文档

- 更新后端契约测试，固定新的 ignore / grouping 规则。
- 更新 `CONTRIBUTING.md`，明确 React / React Native 栈与 renderer 对齐升级需要人工规划。

## 仓库维护

- 已对 PR #768、#769 追加中文说明评论，并关闭这两个不适合继续保留的 Dependabot PR。

## 验证

- `npx --yes js-yaml .github/dependabot.yml >/dev/null`
- `git diff --check`
- `cd backend && uv run --locked pre-commit run --files ../.github/dependabot.yml ../CONTRIBUTING.md tests/runtime/test_repository_dependabot_contract.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_repository_dependabot_contract.py`

## 关联

- Closes #770
- Related: #768
- Related: #769
