### PR TITLE
fix(self-management): harden built-in runtime flows

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -900,7 +900,7 @@ class Settings(BaseSettings):
         description="Maximum output tokens allowed for one built-in self-management agent run.",
     )
     self_management_swival_delegated_token_ttl_seconds: int = Field(
-        default=300,
+        default=30 * 60,
         alias="SELF_MANAGEMENT_SWIVAL_DELEGATED_TOKEN_TTL_SECONDS",
         description="Maximum lifetime in seconds for delegated built-in agent access tokens used against the internal MCP adapter.",
     )

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -166,6 +166,7 @@ class _ConversationRuntimeState:
     session: Any | None = None
     write_tools_enabled: bool = False
     auto_approve_writes: bool = False
+    delegated_token_expires_at_monotonic: float = 0.0
     last_accessed_monotonic: float = 0.0
     lock: asyncio.Lock | None = None
 
@@ -184,6 +185,61 @@ class SelfManagementBuiltInAgentService:
         ] = {}
         self._registry_lock = threading.Lock()
         self._session_support = SessionHubSupport()
+
+    def _delegated_token_ttl_seconds(self) -> int:
+        return min(
+            settings.jwt_access_token_ttl_seconds,
+            settings.self_management_swival_delegated_token_ttl_seconds,
+        )
+
+    def _delegated_token_refresh_skew_seconds(self) -> int:
+        ttl_seconds = self._delegated_token_ttl_seconds()
+        return max(5, min(30, ttl_seconds // 10 or 1))
+
+    def _runtime_session_needs_refresh(
+        self,
+        *,
+        runtime_state: _ConversationRuntimeState,
+        write_tools_enabled: bool,
+    ) -> bool:
+        if runtime_state.session is None:
+            return True
+        if runtime_state.write_tools_enabled != write_tools_enabled:
+            return True
+        expires_at = runtime_state.delegated_token_expires_at_monotonic
+        if expires_at <= 0:
+            return False
+        refresh_cutoff = expires_at - self._delegated_token_refresh_skew_seconds()
+        return time.monotonic() >= refresh_cutoff
+
+    async def _invalidate_runtime_session(
+        self,
+        runtime_state: _ConversationRuntimeState,
+    ) -> None:
+        session = runtime_state.session
+        runtime_state.session = None
+        runtime_state.delegated_token_expires_at_monotonic = 0.0
+        runtime_state.write_tools_enabled = False
+        runtime_state.last_accessed_monotonic = time.monotonic()
+        if session is not None:
+            await asyncio.to_thread(self._close_swival_session, session)
+
+    def _extract_mcp_runtime_error(self, result: Any) -> str | None:
+        raw_messages = getattr(result, "messages", None)
+        if not isinstance(raw_messages, list):
+            return None
+        for raw_message in reversed(raw_messages):
+            if not isinstance(raw_message, dict):
+                continue
+            if raw_message.get("role") != "tool":
+                continue
+            content = raw_message.get("content")
+            if not isinstance(content, str):
+                continue
+            normalized = content.strip()
+            if normalized.startswith("error: MCP server "):
+                return normalized
+        return None
 
     def get_profile(self) -> SelfManagementBuiltInAgentProfile:
         tool_definitions = list_self_management_mcp_tool_definitions()
@@ -357,9 +413,16 @@ class SelfManagementBuiltInAgentService:
             try:
                 result = await asyncio.to_thread(session.ask, message)
             except Exception as exc:  # pragma: no cover - exercised with integration
+                await self._invalidate_runtime_session(runtime_state)
                 raise SelfManagementBuiltInAgentUnavailableError(
                     f"swival built-in agent run failed: {exc}"
                 ) from exc
+            mcp_runtime_error = self._extract_mcp_runtime_error(result)
+            if mcp_runtime_error is not None:
+                await self._invalidate_runtime_session(runtime_state)
+                raise SelfManagementBuiltInAgentUnavailableError(
+                    f"swival built-in agent MCP call failed: {mcp_runtime_error}"
+                )
             runtime_state.last_accessed_monotonic = time.monotonic()
         answer = cast(str | None, getattr(result, "answer", None))
         exhausted = bool(getattr(result, "exhausted", False))
@@ -387,6 +450,12 @@ class SelfManagementBuiltInAgentService:
                 local_session=local_session,
                 local_session_id=local_session_id,
                 local_source=local_source,
+            )
+        if effective_write_tools and self._answer_requests_write_approval(answer):
+            await self._invalidate_runtime_session(runtime_state)
+            raise SelfManagementBuiltInAgentUnavailableError(
+                "swival built-in agent requested write approval after write "
+                "tools were enabled"
             )
         return _ExecutedBuiltInRun(
             result=SelfManagementBuiltInAgentRunResult(
@@ -805,9 +874,9 @@ class SelfManagementBuiltInAgentService:
         conversation_id: str,
         write_tools_enabled: bool,
     ) -> Any:
-        if (
-            runtime_state.session is not None
-            and runtime_state.write_tools_enabled == write_tools_enabled
+        if not self._runtime_session_needs_refresh(
+            runtime_state=runtime_state,
+            write_tools_enabled=write_tools_enabled,
         ):
             runtime_state.last_accessed_monotonic = time.monotonic()
             return runtime_state.session
@@ -831,6 +900,13 @@ class SelfManagementBuiltInAgentService:
 
         runtime_state.session = new_session
         runtime_state.write_tools_enabled = write_tools_enabled
+        runtime_state.delegated_token_expires_at_monotonic = float(
+            getattr(
+                new_session,
+                "_self_management_delegated_token_expires_at_monotonic",
+                0.0,
+            )
+        )
         runtime_state.last_accessed_monotonic = time.monotonic()
         return new_session
 
@@ -968,6 +1044,7 @@ class SelfManagementBuiltInAgentService:
         tool_definitions = self._select_run_tool_definitions(
             allow_write_tools=write_tools_enabled
         )
+        delegated_token_ttl_seconds = self._delegated_token_ttl_seconds()
         token = create_self_management_access_token(
             cast(Any, current_user.id),
             allowed_operations=[
@@ -1000,6 +1077,11 @@ class SelfManagementBuiltInAgentService:
                     "headers": {"Authorization": f"Bearer {token}"},
                 }
             },
+        )
+        setattr(
+            session,
+            "_self_management_delegated_token_expires_at_monotonic",
+            time.monotonic() + delegated_token_ttl_seconds,
         )
         return session
 

--- a/backend/app/features/sessions/router.py
+++ b/backend/app/features/sessions/router.py
@@ -12,6 +12,10 @@ from app.api.deps import get_async_db, get_current_user
 from app.api.routing import StrictAPIRouter
 from app.db.models.user import User
 from app.db.transaction import commit_safely
+from app.features.self_management_shared.constants import (
+    SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID,
+    SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+)
 from app.features.sessions.schemas import (
     SessionCancelResponse,
     SessionContinueResponse,
@@ -65,6 +69,14 @@ def _status_code_for_session_error(detail: str) -> int:
     return 400
 
 
+def _resolve_session_query_agent_id(agent_id: str | None) -> UUID | None:
+    if agent_id is None:
+        return None
+    if agent_id == SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID:
+        return SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID
+    return UUID(agent_id)
+
+
 @router.post(":query", response_model=SessionListResponse)
 async def list_unified_sessions(
     *,
@@ -79,7 +91,7 @@ async def list_unified_sessions(
         page=payload.page,
         size=payload.size,
         source=payload.source,
-        agent_id=payload.agent_id,
+        agent_id=_resolve_session_query_agent_id(payload.agent_id),
     )
     if db_mutated:
         await commit_safely(db)

--- a/backend/app/features/sessions/schemas.py
+++ b/backend/app/features/sessions/schemas.py
@@ -6,8 +6,11 @@ from datetime import datetime
 from typing import Any, Dict, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from app.features.self_management_shared.constants import (
+    SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+)
 from app.schemas.pagination import Pagination
 
 SessionSource = Literal["manual", "scheduled"]
@@ -21,10 +24,29 @@ class SessionQueryRequest(BaseModel):
         None,
         description="Filter by source (manual/scheduled)",
     )
-    agent_id: Optional[UUID] = Field(
+    agent_id: Optional[str] = Field(
         None,
-        description="Filter by agent id.",
+        description=(
+            "Filter by agent id. Accepts a UUID or the built-in self-management "
+            "assistant public id."
+        ),
     )
+
+    @field_validator("agent_id")
+    @classmethod
+    def validate_agent_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value == SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID:
+            return value
+        try:
+            UUID(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Input should be a valid UUID or the built-in self-management "
+                "assistant id."
+            ) from exc
+        return value
 
 
 class SessionViewItem(BaseModel):

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -18,8 +19,12 @@ from app.core.security import (
 )
 from app.db.models.agent_message import AgentMessage
 from app.features.self_management_agent import router as self_management_agent_router
+from app.features.self_management_agent import (
+    service as self_management_agent_service_module,
+)
 from app.features.self_management_agent.service import (
     _WRITE_APPROVAL_SENTINEL,
+    SelfManagementBuiltInAgentUnavailableError,
     self_management_built_in_agent_service,
 )
 from app.features.sessions.service import session_hub_service
@@ -33,6 +38,8 @@ class _FakeSwivalSession:
     last_init_kwargs: dict[str, object] | None = None
     last_message: str | None = None
     next_answer: str = "Built-in agent reply"
+    next_messages: list[dict[str, object]] | None = None
+    next_error: Exception | None = None
     ask_call_count: int = 0
     instance_count: int = 0
     instances: list["_FakeSwivalSession"] = []
@@ -45,6 +52,10 @@ class _FakeSwivalSession:
         self.closed = False
 
     def ask(self, message: str) -> object:
+        if type(self).next_error is not None:
+            exc = type(self).next_error
+            type(self).next_error = None
+            raise exc
         type(self).last_message = message
         type(self).ask_call_count += 1
         if self._conv_state is None:
@@ -52,7 +63,17 @@ class _FakeSwivalSession:
         messages = cast(list[dict[str, str]], self._conv_state["messages"])
         messages.append({"role": "user", "content": message})
         messages.append({"role": "assistant", "content": type(self).next_answer})
-        return SimpleNamespace(answer=type(self).next_answer, exhausted=False)
+        result_messages = (
+            copy.deepcopy(type(self).next_messages)
+            if type(self).next_messages is not None
+            else copy.deepcopy(messages)
+        )
+        type(self).next_messages = None
+        return SimpleNamespace(
+            answer=type(self).next_answer,
+            exhausted=False,
+            messages=result_messages,
+        )
 
     def close(self) -> None:
         self.closed = True
@@ -62,6 +83,8 @@ def _install_fake_swival(monkeypatch: pytest.MonkeyPatch) -> None:
     _FakeSwivalSession.last_init_kwargs = None
     _FakeSwivalSession.last_message = None
     _FakeSwivalSession.next_answer = "Built-in agent reply"
+    _FakeSwivalSession.next_messages = None
+    _FakeSwivalSession.next_error = None
     _FakeSwivalSession.ask_call_count = 0
     _FakeSwivalSession.instance_count = 0
     _FakeSwivalSession.instances = []
@@ -286,6 +309,93 @@ async def test_built_in_agent_run_uses_swival_with_authenticated_mcp_server(
     assert get_self_management_allowed_operations(claims) == frozenset(
         result.tool_names
     )
+
+
+async def test_built_in_agent_rebuilds_session_when_delegated_token_expires(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    monkeypatch.setattr(settings, "jwt_access_token_ttl_seconds", 5)
+    monkeypatch.setattr(
+        settings, "self_management_swival_delegated_token_ttl_seconds", 5
+    )
+    monotonic_time = {"value": 100.0}
+    monkeypatch.setattr(
+        self_management_agent_service_module.time,
+        "monotonic",
+        lambda: monotonic_time["value"],
+    )
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+
+    first = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="List my jobs",
+        allow_write_tools=False,
+    )
+    assert first.answer == "Built-in agent reply"
+    assert _FakeSwivalSession.instance_count == 1
+
+    monotonic_time["value"] += 10.0
+    _FakeSwivalSession.next_answer = "Second built-in agent reply"
+    second = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="List my agents",
+        allow_write_tools=False,
+    )
+
+    assert second.answer == "Second built-in agent reply"
+    assert _FakeSwivalSession.instance_count == 2
+    assert _FakeSwivalSession.instances[0].closed is True
+    assert _FakeSwivalSession.instances[1]._conv_state is not None
+    assert cast(
+        list[dict[str, str]], _FakeSwivalSession.instances[1]._conv_state["messages"]
+    )[:2] == [
+        {"role": "user", "content": "List my jobs"},
+        {"role": "assistant", "content": "Built-in agent reply"},
+    ]
+
+
+async def test_built_in_agent_raises_when_mcp_runtime_returns_transport_error(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+
+    _FakeSwivalSession.next_answer = "Backend appears unavailable."
+    _FakeSwivalSession.next_messages = [
+        {"role": "user", "content": "List my agents"},
+        {
+            "role": "tool",
+            "content": (
+                "error: MCP server 'a2a-client-hub' failed: "
+                "Client error '401 Unauthorized'"
+            ),
+        },
+        {"role": "assistant", "content": "Backend appears unavailable."},
+    ]
+
+    with pytest.raises(SelfManagementBuiltInAgentUnavailableError) as excinfo:
+        await self_management_built_in_agent_service.run(
+            db=async_db_session,
+            current_user=user,
+            conversation_id=_new_conversation_id(),
+            message="List my agents",
+            allow_write_tools=False,
+        )
+
+    assert "MCP call failed" in str(excinfo.value)
+    assert "401 Unauthorized" in str(excinfo.value)
 
 
 async def test_built_in_agent_reuses_same_swival_base_dir_for_same_user(
@@ -904,6 +1014,66 @@ async def test_built_in_agent_permission_reply_once_resumes_with_write_tools(
         "url"
     ] == ("http://internal-mcp/mcp-write/")
     assert _FakeSwivalSession.instance_count == 1
+
+
+async def test_built_in_agent_permission_reply_rejects_repeated_write_approval(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+    _FakeSwivalSession.next_answer = (
+        "I can pause the requested job after you approve write access.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    interrupt_result = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Pause my job",
+        allow_write_tools=False,
+    )
+    assert interrupt_result.interrupt is not None
+
+    _FakeSwivalSession.next_answer = (
+        "I still need write approval before I can pause that job.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    with pytest.raises(SelfManagementBuiltInAgentUnavailableError) as excinfo:
+        await self_management_built_in_agent_service.reply_permission_interrupt(
+            db=async_db_session,
+            current_user=user,
+            request_id=interrupt_result.interrupt.request_id,
+            reply="once",
+        )
+
+    assert "requested write approval after write tools were enabled" in str(
+        excinfo.value
+    )
+
+    messages, _extra, _db_mutated = await session_hub_service.list_messages(
+        async_db_session,
+        user_id=cast(Any, user.id),
+        conversation_id=conversation_id,
+        before=None,
+        limit=20,
+    )
+    assert [item["role"] for item in messages] == ["user", "agent"]
+    assert messages[1]["status"] == "interrupted"
+
+    recovered = await self_management_built_in_agent_service.recover_pending_interrupts(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+    )
+    assert [item.request_id for item in recovered] == [
+        interrupt_result.interrupt.request_id
+    ]
 
 
 async def test_built_in_agent_permission_reply_reject_returns_no_change_result(

--- a/backend/tests/runtime/test_settings_security_baseline.py
+++ b/backend/tests/runtime/test_settings_security_baseline.py
@@ -58,6 +58,7 @@ def _set_base_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AUTH_REFRESH_COOKIE_SECURE", "true")
     monkeypatch.setenv("AUTH_REFRESH_COOKIE_SAMESITE", "lax")
     monkeypatch.setenv("BACKEND_CORS_ORIGINS", '["https://app.example.com"]')
+    monkeypatch.setenv("AUTH_COOKIE_TRUSTED_ORIGINS", '["https://app.example.com"]')
     monkeypatch.setenv("WS_ALLOWED_ORIGINS", '["https://app.example.com"]')
     monkeypatch.setenv("WS_REQUIRE_ORIGIN", "true")
     monkeypatch.setenv("A2A_PROXY_ALLOWED_HOSTS", '["agent.example.com"]')

--- a/backend/tests/sessions/test_me_sessions_routes.py
+++ b/backend/tests/sessions/test_me_sessions_routes.py
@@ -10,6 +10,10 @@ from app.db.models.agent_message import AgentMessage
 from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
 from app.features.schedules.service import a2a_schedule_service
+from app.features.self_management_shared.constants import (
+    SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID,
+    SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+)
 from app.features.sessions import router as me_sessions
 from app.features.sessions.service import session_hub_service
 from app.utils.timezone_util import utc_now
@@ -232,6 +236,59 @@ async def test_me_sessions_query_supports_agent_id_filter(
     assert len(payload["items"]) == 1
     assert payload["items"][0]["conversationId"] == str(session_a.id)
     assert payload["items"][0]["agent_id"] == str(agent_a.id)
+
+
+async def test_me_sessions_query_supports_built_in_agent_public_id_filter(
+    async_db_session,
+    async_session_maker,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    now = utc_now()
+
+    built_in_session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID,
+        agent_source="builtin",
+        title="Built-in Session",
+        last_active_at=now,
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    other_session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=uuid4(),
+        agent_source="personal",
+        title="Other Session",
+        last_active_at=now - timedelta(minutes=1),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(built_in_session)
+    async_db_session.add(other_session)
+    await async_db_session.commit()
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.post(
+            "/me/conversations:query",
+            json={
+                "page": 1,
+                "size": 20,
+                "agent_id": SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["pagination"]["total"] == 1
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["conversationId"] == str(built_in_session.id)
+    assert payload["items"][0]["agent_id"] == SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID
 
 
 async def test_me_sessions_cancel_returns_accepted_for_inflight_task(


### PR DESCRIPTION
## 关联 issues

Closes #785
Related #757

## 变更说明

### backend/app/core/config.py
- 将 `SELF_MANAGEMENT_SWIVAL_DELEGATED_TOKEN_TTL_SECONDS` 默认值调整为 `1800` 秒，使其与 built-in runtime session TTL 更协调
- 修正 runtime hardening 覆盖下的 settings 测试基线环境

### backend/app/features/self_management_agent/service.py
- 在 built-in self-management runtime 中记录 delegated token 的过期时间
- 会话复用前检查 token 是否临近过期，必要时自动重建 swival session
- 当 swival 返回 MCP/tool transport 错误时，显式失效 runtime session 并向上抛出结构化错误
- 在 write-approved 路径上，如果模型再次请求 write approval，显式视为 runtime 协议错误，避免重复 agent 回复继续落库

### backend/app/features/sessions/router.py / schemas.py
- `POST /api/v1/me/conversations:query` 的 `agent_id` 现在支持 built-in self-management assistant 的 public id
- 在路由层将 built-in public id 映射为内部 UUID，再复用现有查询逻辑

### tests
- 新增 built-in runtime token 过期后自动重建 session 的回归测试
- 新增 MCP 401 / transport 错误显式失败的回归测试
- 新增 reply 后重复 approval sentinel 被拒绝的回归测试
- 新增 built-in self-management assistant public id 查询会话列表的路由测试
- 修正 settings security baseline 测试基线环境，使其与当前 production baseline 约束一致

## 验证

### backend scoped checks
- `cd backend && uv run --locked pre-commit run --files app/core/config.py app/features/self_management_agent/service.py app/features/sessions/router.py app/features/sessions/schemas.py tests/runtime/test_self_management_built_in_agent.py tests/sessions/test_me_sessions_routes.py tests/runtime/test_settings_security_baseline.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_self_management_built_in_agent.py tests/sessions/test_me_sessions_routes.py tests/runtime/test_settings_security_baseline.py`

结果：`60 passed`

## 风险与边界

- 本 PR 不补新能力面，只收敛 built-in runtime 的稳定性与会话查询兼容性
- 不包含本地调试专用的默认 write-tools 放开逻辑
- 不包含 `_dev schema` 命名支持
