### PR TITLE
feat(self-management): expand tools and harden runtime

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -900,7 +900,7 @@ class Settings(BaseSettings):
         description="Maximum output tokens allowed for one built-in self-management agent run.",
     )
     self_management_swival_delegated_token_ttl_seconds: int = Field(
-        default=300,
+        default=30 * 60,
         alias="SELF_MANAGEMENT_SWIVAL_DELEGATED_TOKEN_TTL_SECONDS",
         description="Maximum lifetime in seconds for delegated built-in agent access tokens used against the internal MCP adapter.",
     )

--- a/backend/app/features/personal_agents/self_management_agents_service.py
+++ b/backend/app/features/personal_agents/self_management_agents_service.py
@@ -9,11 +9,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.user import User
 from app.features.personal_agents.service import (
+    A2AAgentHealthCheckItemRecord,
+    A2AAgentHealthCheckSummaryRecord,
     A2AAgentListCounts,
     A2AAgentRecord,
     a2a_agent_service,
 )
 from app.features.self_management_shared.capability_catalog import (
+    SELF_AGENTS_CHECK_HEALTH,
+    SELF_AGENTS_CHECK_HEALTH_ALL,
+    SELF_AGENTS_CREATE,
+    SELF_AGENTS_DELETE,
     SELF_AGENTS_GET,
     SELF_AGENTS_LIST,
     SELF_AGENTS_UPDATE_CONFIG,
@@ -71,6 +77,85 @@ class SelfManagementAgentsService:
         )
         return result.result
 
+    async def check_agent_health(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        agent_id: UUID,
+        force: bool = True,
+    ) -> tuple[A2AAgentHealthCheckSummaryRecord, list[A2AAgentHealthCheckItemRecord]]:
+        del db
+        result = await gateway.execute(
+            operation=SELF_AGENTS_CHECK_HEALTH,
+            resource_id=str(agent_id),
+            handler=lambda: a2a_agent_service.check_agents_health(
+                user_id=self._user_id(current_user),
+                agent_id=agent_id,
+                force=force,
+            ),
+        )
+        return result.result
+
+    async def check_all_agents_health(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        force: bool = False,
+    ) -> tuple[A2AAgentHealthCheckSummaryRecord, list[A2AAgentHealthCheckItemRecord]]:
+        del db
+        result = await gateway.execute(
+            operation=SELF_AGENTS_CHECK_HEALTH_ALL,
+            handler=lambda: a2a_agent_service.check_agents_health(
+                user_id=self._user_id(current_user),
+                force=force,
+            ),
+        )
+        return result.result
+
+    async def create_agent(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        name: str,
+        card_url: str,
+        auth_type: str,
+        auth_header: str | None = None,
+        auth_scheme: str | None = None,
+        enabled: bool = True,
+        tags: list[str] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        invoke_metadata_defaults: dict[str, str] | None = None,
+        token: str | None = None,
+        basic_username: str | None = None,
+        basic_password: str | None = None,
+    ) -> A2AAgentRecord:
+        result = await gateway.execute(
+            operation=SELF_AGENTS_CREATE,
+            handler=lambda: a2a_agent_service.create_agent(
+                db,
+                user_id=self._user_id(current_user),
+                name=name,
+                card_url=card_url,
+                auth_type=auth_type,
+                auth_header=auth_header,
+                auth_scheme=auth_scheme,
+                enabled=enabled,
+                tags=tags,
+                extra_headers=extra_headers,
+                invoke_metadata_defaults=invoke_metadata_defaults,
+                token=token,
+                basic_username=basic_username,
+                basic_password=basic_password,
+            ),
+        )
+        return result.result
+
     async def update_config(
         self,
         *,
@@ -79,10 +164,17 @@ class SelfManagementAgentsService:
         current_user: User,
         agent_id: UUID,
         name: str | None = None,
+        card_url: str | None = None,
+        auth_type: str | None = None,
+        auth_header: str | None = None,
+        auth_scheme: str | None = None,
         enabled: bool | None = None,
         tags: list[str] | None = None,
         extra_headers: dict[str, str] | None = None,
         invoke_metadata_defaults: dict[str, str] | None = None,
+        token: str | None = None,
+        basic_username: str | None = None,
+        basic_password: str | None = None,
     ) -> A2AAgentRecord:
         result = await gateway.execute(
             operation=SELF_AGENTS_UPDATE_CONFIG,
@@ -92,13 +184,38 @@ class SelfManagementAgentsService:
                 user_id=self._user_id(current_user),
                 agent_id=agent_id,
                 name=name,
+                card_url=card_url,
+                auth_type=auth_type,
+                auth_header=auth_header,
+                auth_scheme=auth_scheme,
                 enabled=enabled,
                 tags=tags,
                 extra_headers=extra_headers,
                 invoke_metadata_defaults=invoke_metadata_defaults,
+                token=token,
+                basic_username=basic_username,
+                basic_password=basic_password,
             ),
         )
         return result.result
+
+    async def delete_agent(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        agent_id: UUID,
+    ) -> None:
+        await gateway.execute(
+            operation=SELF_AGENTS_DELETE,
+            resource_id=str(agent_id),
+            handler=lambda: a2a_agent_service.delete_agent(
+                db,
+                user_id=self._user_id(current_user),
+                agent_id=agent_id,
+            ),
+        )
 
 
 self_management_agents_service = SelfManagementAgentsService()

--- a/backend/app/features/schedules/self_management_jobs_service.py
+++ b/backend/app/features/schedules/self_management_jobs_service.py
@@ -13,10 +13,13 @@ from app.db.models.user import User
 from app.features.schedules.schemas import A2AScheduleTaskUpdate
 from app.features.schedules.service import a2a_schedule_service
 from app.features.self_management_shared.capability_catalog import (
+    SELF_JOBS_CREATE,
+    SELF_JOBS_DELETE,
     SELF_JOBS_GET,
     SELF_JOBS_LIST,
     SELF_JOBS_PAUSE,
     SELF_JOBS_RESUME,
+    SELF_JOBS_UPDATE,
     SELF_JOBS_UPDATE_PROMPT,
     SELF_JOBS_UPDATE_SCHEDULE,
 )
@@ -107,6 +110,43 @@ class SelfManagementJobsService:
         )
         return result.result
 
+    async def create_job(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        name: str,
+        agent_id: UUID,
+        prompt: str,
+        cycle_type: str,
+        time_point: dict[str, object],
+        enabled: bool,
+        conversation_policy: str,
+        timezone_str: str,
+    ) -> A2AScheduleTask:
+        result = await gateway.execute(
+            operation=SELF_JOBS_CREATE,
+            handler=lambda: a2a_schedule_service.create_task(
+                db,
+                user_id=self._user_id(current_user),
+                is_superuser=bool(current_user.is_superuser),
+                timezone_str=timezone_str,
+                name=name,
+                agent_id=agent_id,
+                prompt=prompt,
+                cycle_type=cycle_type,
+                time_point=time_point,
+                enabled=enabled,
+                conversation_policy=conversation_policy,
+            ),
+        )
+        logger.info(
+            "Self-management job create requested",
+            extra=result.audit_fields.as_log_extra(),
+        )
+        return result.result
+
     async def pause_job(
         self,
         *,
@@ -157,6 +197,46 @@ class SelfManagementJobsService:
         )
         logger.info(
             "Self-management job resume requested",
+            extra=result.audit_fields.as_log_extra(),
+        )
+        return result.result
+
+    async def update_job(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        task_id: UUID,
+        timezone_str: str,
+        name: str | None = None,
+        agent_id: UUID | None = None,
+        prompt: str | None = None,
+        cycle_type: str | None = None,
+        time_point: dict[str, object] | None = None,
+        enabled: bool | None = None,
+        conversation_policy: str | None = None,
+    ) -> A2AScheduleTask:
+        result = await gateway.execute(
+            operation=SELF_JOBS_UPDATE,
+            resource_id=str(task_id),
+            handler=lambda: a2a_schedule_service.update_task(
+                db,
+                user_id=self._user_id(current_user),
+                task_id=task_id,
+                is_superuser=bool(current_user.is_superuser),
+                timezone_str=timezone_str,
+                name=name,
+                agent_id=agent_id,
+                prompt=prompt,
+                cycle_type=cycle_type,
+                time_point=time_point,
+                enabled=enabled,
+                conversation_policy=conversation_policy,
+            ),
+        )
+        logger.info(
+            "Self-management job update requested",
             extra=result.audit_fields.as_log_extra(),
         )
         return result.result
@@ -218,6 +298,28 @@ class SelfManagementJobsService:
             extra=result.audit_fields.as_log_extra(),
         )
         return result.result
+
+    async def delete_job(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        task_id: UUID,
+    ) -> None:
+        result = await gateway.execute(
+            operation=SELF_JOBS_DELETE,
+            resource_id=str(task_id),
+            handler=lambda: a2a_schedule_service.delete_task(
+                db,
+                user_id=self._user_id(current_user),
+                task_id=task_id,
+            ),
+        )
+        logger.info(
+            "Self-management job delete requested",
+            extra=result.audit_fields.as_log_extra(),
+        )
 
 
 self_management_jobs_service = SelfManagementJobsService()

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -166,6 +166,7 @@ class _ConversationRuntimeState:
     session: Any | None = None
     write_tools_enabled: bool = False
     auto_approve_writes: bool = False
+    delegated_token_expires_at_monotonic: float = 0.0
     last_accessed_monotonic: float = 0.0
     lock: asyncio.Lock | None = None
 
@@ -184,6 +185,61 @@ class SelfManagementBuiltInAgentService:
         ] = {}
         self._registry_lock = threading.Lock()
         self._session_support = SessionHubSupport()
+
+    def _delegated_token_ttl_seconds(self) -> int:
+        return min(
+            settings.jwt_access_token_ttl_seconds,
+            settings.self_management_swival_delegated_token_ttl_seconds,
+        )
+
+    def _delegated_token_refresh_skew_seconds(self) -> int:
+        ttl_seconds = self._delegated_token_ttl_seconds()
+        return max(5, min(30, ttl_seconds // 10 or 1))
+
+    def _runtime_session_needs_refresh(
+        self,
+        *,
+        runtime_state: _ConversationRuntimeState,
+        write_tools_enabled: bool,
+    ) -> bool:
+        if runtime_state.session is None:
+            return True
+        if runtime_state.write_tools_enabled != write_tools_enabled:
+            return True
+        expires_at = runtime_state.delegated_token_expires_at_monotonic
+        if expires_at <= 0:
+            return False
+        refresh_cutoff = expires_at - self._delegated_token_refresh_skew_seconds()
+        return time.monotonic() >= refresh_cutoff
+
+    async def _invalidate_runtime_session(
+        self,
+        runtime_state: _ConversationRuntimeState,
+    ) -> None:
+        session = runtime_state.session
+        runtime_state.session = None
+        runtime_state.delegated_token_expires_at_monotonic = 0.0
+        runtime_state.write_tools_enabled = False
+        runtime_state.last_accessed_monotonic = time.monotonic()
+        if session is not None:
+            await asyncio.to_thread(self._close_swival_session, session)
+
+    def _extract_mcp_runtime_error(self, result: Any) -> str | None:
+        raw_messages = getattr(result, "messages", None)
+        if not isinstance(raw_messages, list):
+            return None
+        for raw_message in reversed(raw_messages):
+            if not isinstance(raw_message, dict):
+                continue
+            if raw_message.get("role") != "tool":
+                continue
+            content = raw_message.get("content")
+            if not isinstance(content, str):
+                continue
+            normalized = content.strip()
+            if normalized.startswith("error: MCP server "):
+                return normalized
+        return None
 
     def get_profile(self) -> SelfManagementBuiltInAgentProfile:
         tool_definitions = list_self_management_mcp_tool_definitions()
@@ -357,9 +413,16 @@ class SelfManagementBuiltInAgentService:
             try:
                 result = await asyncio.to_thread(session.ask, message)
             except Exception as exc:  # pragma: no cover - exercised with integration
+                await self._invalidate_runtime_session(runtime_state)
                 raise SelfManagementBuiltInAgentUnavailableError(
                     f"swival built-in agent run failed: {exc}"
                 ) from exc
+            mcp_runtime_error = self._extract_mcp_runtime_error(result)
+            if mcp_runtime_error is not None:
+                await self._invalidate_runtime_session(runtime_state)
+                raise SelfManagementBuiltInAgentUnavailableError(
+                    f"swival built-in agent MCP call failed: {mcp_runtime_error}"
+                )
             runtime_state.last_accessed_monotonic = time.monotonic()
         answer = cast(str | None, getattr(result, "answer", None))
         exhausted = bool(getattr(result, "exhausted", False))
@@ -387,6 +450,12 @@ class SelfManagementBuiltInAgentService:
                 local_session=local_session,
                 local_session_id=local_session_id,
                 local_source=local_source,
+            )
+        if effective_write_tools and self._answer_requests_write_approval(answer):
+            await self._invalidate_runtime_session(runtime_state)
+            raise SelfManagementBuiltInAgentUnavailableError(
+                "swival built-in agent requested write approval after write "
+                "tools were enabled"
             )
         return _ExecutedBuiltInRun(
             result=SelfManagementBuiltInAgentRunResult(
@@ -805,9 +874,9 @@ class SelfManagementBuiltInAgentService:
         conversation_id: str,
         write_tools_enabled: bool,
     ) -> Any:
-        if (
-            runtime_state.session is not None
-            and runtime_state.write_tools_enabled == write_tools_enabled
+        if not self._runtime_session_needs_refresh(
+            runtime_state=runtime_state,
+            write_tools_enabled=write_tools_enabled,
         ):
             runtime_state.last_accessed_monotonic = time.monotonic()
             return runtime_state.session
@@ -831,6 +900,13 @@ class SelfManagementBuiltInAgentService:
 
         runtime_state.session = new_session
         runtime_state.write_tools_enabled = write_tools_enabled
+        runtime_state.delegated_token_expires_at_monotonic = float(
+            getattr(
+                new_session,
+                "_self_management_delegated_token_expires_at_monotonic",
+                0.0,
+            )
+        )
         runtime_state.last_accessed_monotonic = time.monotonic()
         return new_session
 
@@ -968,6 +1044,7 @@ class SelfManagementBuiltInAgentService:
         tool_definitions = self._select_run_tool_definitions(
             allow_write_tools=write_tools_enabled
         )
+        delegated_token_ttl_seconds = self._delegated_token_ttl_seconds()
         token = create_self_management_access_token(
             cast(Any, current_user.id),
             allowed_operations=[
@@ -1000,6 +1077,11 @@ class SelfManagementBuiltInAgentService:
                     "headers": {"Authorization": f"Bearer {token}"},
                 }
             },
+        )
+        setattr(
+            session,
+            "_self_management_delegated_token_expires_at_monotonic",
+            time.monotonic() + delegated_token_ttl_seconds,
         )
         return session
 

--- a/backend/app/features/self_management_shared/capability_catalog.py
+++ b/backend/app/features/self_management_shared/capability_catalog.py
@@ -47,6 +47,48 @@ SELF_AGENTS_GET = SelfManagementOperation(
     description="Read one current-user agent in detail.",
 )
 
+SELF_AGENTS_CHECK_HEALTH = SelfManagementOperation(
+    operation_id="self.agents.check_health",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.AGENTS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_agent.check_health.requested",
+    command_name="agents.check-health",
+    tool_name="self.agents.check_health",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Run a health check for one current-user agent.",
+)
+
+SELF_AGENTS_CHECK_HEALTH_ALL = SelfManagementOperation(
+    operation_id="self.agents.check_health_all",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.AGENTS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_agent.check_health_all.requested",
+    command_name="agents.check-health-all",
+    tool_name="self.agents.check_health_all",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Run a health check sweep for all current-user agents.",
+)
+
+SELF_AGENTS_CREATE = SelfManagementOperation(
+    operation_id="self.agents.create",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.AGENTS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_agent.create.requested",
+    command_name="agents.create",
+    tool_name="self.agents.create",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Create one current-user agent.",
+)
+
 SELF_AGENTS_UPDATE_CONFIG = SelfManagementOperation(
     operation_id="self.agents.update_config",
     scope=SelfManagementScope.SELF,
@@ -58,7 +100,21 @@ SELF_AGENTS_UPDATE_CONFIG = SelfManagementOperation(
     confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
     first_wave_exposed=True,
     surfaces=_SELF_ENTRY_SURFACES,
-    description="Update a constrained subset of the current user's agent config.",
+    description="Update one current-user agent.",
+)
+
+SELF_AGENTS_DELETE = SelfManagementOperation(
+    operation_id="self.agents.delete",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.AGENTS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_agent.delete.requested",
+    command_name="agents.delete",
+    tool_name="self.agents.delete",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Soft-delete one current-user agent.",
 )
 
 SELF_SESSIONS_LIST = SelfManagementOperation(
@@ -87,6 +143,48 @@ SELF_SESSIONS_GET = SelfManagementOperation(
     description="Read one current-user session in detail.",
 )
 
+SELF_SESSIONS_UPDATE = SelfManagementOperation(
+    operation_id="self.sessions.update",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.SESSIONS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_session.update.requested",
+    command_name="sessions.update",
+    tool_name="self.sessions.update",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Update one current-user session.",
+)
+
+SELF_SESSIONS_ARCHIVE = SelfManagementOperation(
+    operation_id="self.sessions.archive",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.SESSIONS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_session.archive.requested",
+    command_name="sessions.archive",
+    tool_name="self.sessions.archive",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Archive one current-user session as a soft delete.",
+)
+
+SELF_SESSIONS_UNARCHIVE = SelfManagementOperation(
+    operation_id="self.sessions.unarchive",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.SESSIONS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_session.unarchive.requested",
+    command_name="sessions.unarchive",
+    tool_name="self.sessions.unarchive",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Restore one archived current-user session.",
+)
+
 SELF_JOBS_LIST = SelfManagementOperation(
     operation_id="self.jobs.list",
     scope=SelfManagementScope.SELF,
@@ -111,6 +209,23 @@ SELF_JOBS_GET = SelfManagementOperation(
     first_wave_exposed=True,
     surfaces=_SELF_ENTRY_SURFACES,
     description="Read one current-user job in detail.",
+)
+
+SELF_JOBS_CREATE = SelfManagementOperation(
+    operation_id="self.jobs.create",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.JOBS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_job.create.requested",
+    command_name="jobs.create",
+    tool_name="self.jobs.create",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description=(
+        "Create one current-user job. For `conversation_policy`, use the exact "
+        "enum `new_each_run` or `reuse_single`."
+    ),
 )
 
 SELF_JOBS_PAUSE = SelfManagementOperation(
@@ -155,6 +270,23 @@ SELF_JOBS_UPDATE_PROMPT = SelfManagementOperation(
     description="Update the prompt of one current-user job.",
 )
 
+SELF_JOBS_UPDATE = SelfManagementOperation(
+    operation_id="self.jobs.update",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.JOBS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_job.update.requested",
+    command_name="jobs.update",
+    tool_name="self.jobs.update",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description=(
+        "Update one current-user job. For `conversation_policy`, use the exact "
+        "enum `new_each_run` or `reuse_single`."
+    ),
+)
+
 SELF_JOBS_UPDATE_SCHEDULE = SelfManagementOperation(
     operation_id="self.jobs.update_schedule",
     scope=SelfManagementScope.SELF,
@@ -167,6 +299,20 @@ SELF_JOBS_UPDATE_SCHEDULE = SelfManagementOperation(
     first_wave_exposed=True,
     surfaces=_SELF_ENTRY_SURFACES,
     description="Update the schedule of one current-user job.",
+)
+
+SELF_JOBS_DELETE = SelfManagementOperation(
+    operation_id="self.jobs.delete",
+    scope=SelfManagementScope.SELF,
+    resource=SelfManagementResource.JOBS,
+    action=SelfManagementAction.WRITE,
+    event_name="self_job.delete.requested",
+    command_name="jobs.delete",
+    tool_name="self.jobs.delete",
+    confirmation_policy=SelfManagementConfirmationPolicy.REQUIRED,
+    first_wave_exposed=True,
+    surfaces=_SELF_ENTRY_SURFACES,
+    description="Soft-delete one current-user job.",
 )
 
 ADMIN_HUB_AGENTS_LIST = SelfManagementOperation(
@@ -253,15 +399,25 @@ ADMIN_HUB_AGENT_ALLOWLIST_REMOVE = SelfManagementOperation(
 FIRST_WAVE_EXPOSED_OPERATIONS = (
     SELF_AGENTS_LIST,
     SELF_AGENTS_GET,
+    SELF_AGENTS_CHECK_HEALTH,
+    SELF_AGENTS_CHECK_HEALTH_ALL,
+    SELF_AGENTS_CREATE,
     SELF_AGENTS_UPDATE_CONFIG,
+    SELF_AGENTS_DELETE,
     SELF_SESSIONS_LIST,
     SELF_SESSIONS_GET,
+    SELF_SESSIONS_UPDATE,
+    SELF_SESSIONS_ARCHIVE,
+    SELF_SESSIONS_UNARCHIVE,
     SELF_JOBS_LIST,
     SELF_JOBS_GET,
+    SELF_JOBS_CREATE,
     SELF_JOBS_PAUSE,
     SELF_JOBS_RESUME,
+    SELF_JOBS_UPDATE,
     SELF_JOBS_UPDATE_PROMPT,
     SELF_JOBS_UPDATE_SCHEDULE,
+    SELF_JOBS_DELETE,
 )
 
 INTERNAL_ADMIN_OPERATIONS = (
@@ -278,9 +434,7 @@ INTERNAL_ADMIN_OPERATIONS = (
 
 UNSUPPORTED_FIRST_WAVE_OPERATION_IDS = frozenset(
     {
-        "self.jobs.delete",
         "self.sessions.delete",
-        "self.agents.delete",
         "admin.agents.delete",
     }
 )
@@ -315,15 +469,25 @@ __all__ = [
     "INTERNAL_ADMIN_OPERATIONS",
     "SELF_AGENTS_GET",
     "SELF_AGENTS_LIST",
+    "SELF_AGENTS_CREATE",
+    "SELF_AGENTS_CHECK_HEALTH",
+    "SELF_AGENTS_CHECK_HEALTH_ALL",
+    "SELF_AGENTS_DELETE",
     "SELF_AGENTS_UPDATE_CONFIG",
+    "SELF_JOBS_CREATE",
+    "SELF_JOBS_DELETE",
     "SELF_JOBS_GET",
     "SELF_JOBS_LIST",
     "SELF_JOBS_PAUSE",
     "SELF_JOBS_RESUME",
+    "SELF_JOBS_UPDATE",
     "SELF_JOBS_UPDATE_PROMPT",
     "SELF_JOBS_UPDATE_SCHEDULE",
+    "SELF_SESSIONS_ARCHIVE",
     "SELF_SESSIONS_GET",
     "SELF_SESSIONS_LIST",
+    "SELF_SESSIONS_UNARCHIVE",
+    "SELF_SESSIONS_UPDATE",
     "UNSUPPORTED_FIRST_WAVE_OPERATION_IDS",
     "get_self_management_operation",
 ]

--- a/backend/app/features/self_management_shared/self_management_mcp.py
+++ b/backend/app/features/self_management_shared/self_management_mcp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from fastmcp import Context, FastMCP
@@ -22,18 +22,33 @@ from app.core.security import (
 )
 from app.db.session import AsyncSessionLocal
 from app.features.auth.service import UserNotFoundError, get_active_user
+from app.features.personal_agents.service import A2AAgentError
+from app.features.schedules.common import A2AScheduleError
 from app.features.self_management_shared.actor_context import (
     SelfManagementAuthorizationError,
 )
 from app.features.self_management_shared.capability_catalog import (
+    SELF_AGENTS_CHECK_HEALTH,
+    SELF_AGENTS_CHECK_HEALTH_ALL,
+    SELF_AGENTS_CREATE,
+    SELF_AGENTS_DELETE,
     SELF_AGENTS_GET,
     SELF_AGENTS_LIST,
     SELF_AGENTS_UPDATE_CONFIG,
+    SELF_JOBS_CREATE,
+    SELF_JOBS_DELETE,
     SELF_JOBS_GET,
     SELF_JOBS_LIST,
     SELF_JOBS_PAUSE,
+    SELF_JOBS_RESUME,
+    SELF_JOBS_UPDATE,
+    SELF_JOBS_UPDATE_PROMPT,
+    SELF_JOBS_UPDATE_SCHEDULE,
+    SELF_SESSIONS_ARCHIVE,
     SELF_SESSIONS_GET,
     SELF_SESSIONS_LIST,
+    SELF_SESSIONS_UNARCHIVE,
+    SELF_SESSIONS_UPDATE,
 )
 from app.features.self_management_shared.self_management_tool_contract import (
     SelfManagementToolDefinition,
@@ -56,12 +71,25 @@ _MCP_ALLOWED_OPERATION_IDS_STATE_KEY = "self_management_mcp_allowed_operation_id
 SELF_MANAGEMENT_MCP_OPERATION_IDS = (
     SELF_AGENTS_LIST.operation_id,
     SELF_AGENTS_GET.operation_id,
+    SELF_AGENTS_CHECK_HEALTH.operation_id,
+    SELF_AGENTS_CHECK_HEALTH_ALL.operation_id,
+    SELF_AGENTS_CREATE.operation_id,
     SELF_AGENTS_UPDATE_CONFIG.operation_id,
+    SELF_AGENTS_DELETE.operation_id,
     SELF_JOBS_LIST.operation_id,
     SELF_JOBS_GET.operation_id,
+    SELF_JOBS_CREATE.operation_id,
     SELF_JOBS_PAUSE.operation_id,
+    SELF_JOBS_RESUME.operation_id,
+    SELF_JOBS_UPDATE.operation_id,
+    SELF_JOBS_UPDATE_PROMPT.operation_id,
+    SELF_JOBS_UPDATE_SCHEDULE.operation_id,
+    SELF_JOBS_DELETE.operation_id,
     SELF_SESSIONS_LIST.operation_id,
     SELF_SESSIONS_GET.operation_id,
+    SELF_SESSIONS_UPDATE.operation_id,
+    SELF_SESSIONS_ARCHIVE.operation_id,
+    SELF_SESSIONS_UNARCHIVE.operation_id,
 )
 SELF_MANAGEMENT_MCP_READONLY_OPERATION_IDS = frozenset(
     {
@@ -214,6 +242,8 @@ async def execute_self_management_mcp_operation(
                 arguments=arguments,
             )
         except (
+            A2AAgentError,
+            A2AScheduleError,
             SelfManagementAuthorizationError,
             SelfManagementToolInputError,
             UserNotFoundError,
@@ -296,6 +326,88 @@ def build_self_management_mcp_server(
                 allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
             )
 
+    if _exposed(SELF_AGENTS_CHECK_HEALTH.operation_id):
+
+        @mcp.tool(
+            name=SELF_AGENTS_CHECK_HEALTH.tool_name,
+            description=SELF_AGENTS_CHECK_HEALTH.description,
+        )
+        async def self_agents_check_health(
+            agent_id: str,
+            force: bool = True,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_AGENTS_CHECK_HEALTH.operation_id,
+                arguments={"agent_id": agent_id, "force": force},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_AGENTS_CHECK_HEALTH_ALL.operation_id):
+
+        @mcp.tool(
+            name=SELF_AGENTS_CHECK_HEALTH_ALL.tool_name,
+            description=SELF_AGENTS_CHECK_HEALTH_ALL.description,
+        )
+        async def self_agents_check_health_all(
+            force: bool = False,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_AGENTS_CHECK_HEALTH_ALL.operation_id,
+                arguments={"force": force},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_AGENTS_CREATE.operation_id):
+
+        @mcp.tool(
+            name=SELF_AGENTS_CREATE.tool_name,
+            description=SELF_AGENTS_CREATE.description,
+        )
+        async def self_agents_create(
+            name: str,
+            card_url: str,
+            auth_type: str,
+            auth_header: str | None = None,
+            auth_scheme: str | None = None,
+            enabled: bool = True,
+            tags: list[str] | None = None,
+            extra_headers: dict[str, str] | None = None,
+            invoke_metadata_defaults: dict[str, str] | None = None,
+            token: str | None = None,
+            basic_username: str | None = None,
+            basic_password: str | None = None,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_AGENTS_CREATE.operation_id,
+                arguments={
+                    "name": name,
+                    "card_url": card_url,
+                    "auth_type": auth_type,
+                    "auth_header": auth_header,
+                    "auth_scheme": auth_scheme,
+                    "enabled": enabled,
+                    "tags": tags,
+                    "extra_headers": extra_headers,
+                    "invoke_metadata_defaults": invoke_metadata_defaults,
+                    "token": token,
+                    "basic_username": basic_username,
+                    "basic_password": basic_password,
+                },
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
     if _exposed(SELF_AGENTS_UPDATE_CONFIG.operation_id):
 
         @mcp.tool(
@@ -305,10 +417,17 @@ def build_self_management_mcp_server(
         async def self_agents_update_config(
             agent_id: str,
             name: str | None = None,
+            card_url: str | None = None,
+            auth_type: str | None = None,
+            auth_header: str | None = None,
+            auth_scheme: str | None = None,
             enabled: bool | None = None,
             tags: list[str] | None = None,
             extra_headers: dict[str, str] | None = None,
             invoke_metadata_defaults: dict[str, str] | None = None,
+            token: str | None = None,
+            basic_username: str | None = None,
+            basic_password: str | None = None,
             ctx: Context | None = None,
         ) -> dict[str, Any]:
             if ctx is None:
@@ -319,11 +438,37 @@ def build_self_management_mcp_server(
                 arguments={
                     "agent_id": agent_id,
                     "name": name,
+                    "card_url": card_url,
+                    "auth_type": auth_type,
+                    "auth_header": auth_header,
+                    "auth_scheme": auth_scheme,
                     "enabled": enabled,
                     "tags": tags,
                     "extra_headers": extra_headers,
                     "invoke_metadata_defaults": invoke_metadata_defaults,
+                    "token": token,
+                    "basic_username": basic_username,
+                    "basic_password": basic_password,
                 },
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_AGENTS_DELETE.operation_id):
+
+        @mcp.tool(
+            name=SELF_AGENTS_DELETE.tool_name,
+            description=SELF_AGENTS_DELETE.description,
+        )
+        async def self_agents_delete(
+            agent_id: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_AGENTS_DELETE.operation_id,
+                arguments={"agent_id": agent_id},
                 allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
             )
 
@@ -344,6 +489,43 @@ def build_self_management_mcp_server(
                 user_id=_require_request_user_id(ctx),
                 operation_id=SELF_JOBS_LIST.operation_id,
                 arguments={"page": page, "size": size},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_JOBS_CREATE.operation_id):
+
+        @mcp.tool(
+            name=SELF_JOBS_CREATE.tool_name,
+            description=SELF_JOBS_CREATE.description,
+        )
+        async def self_jobs_create(
+            name: str,
+            agent_id: str,
+            prompt: str,
+            cycle_type: str,
+            time_point: dict[str, object],
+            enabled: bool = True,
+            conversation_policy: Literal["new_each_run", "reuse_single"] = (
+                "new_each_run"
+            ),
+            schedule_timezone: str | None = None,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_JOBS_CREATE.operation_id,
+                arguments={
+                    "name": name,
+                    "agent_id": agent_id,
+                    "prompt": prompt,
+                    "cycle_type": cycle_type,
+                    "time_point": time_point,
+                    "enabled": enabled,
+                    "conversation_policy": conversation_policy,
+                    "schedule_timezone": schedule_timezone,
+                },
                 allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
             )
 
@@ -385,6 +567,128 @@ def build_self_management_mcp_server(
                 allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
             )
 
+    if _exposed(SELF_JOBS_RESUME.operation_id):
+
+        @mcp.tool(
+            name=SELF_JOBS_RESUME.tool_name,
+            description=SELF_JOBS_RESUME.description,
+        )
+        async def self_jobs_resume(
+            task_id: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_JOBS_RESUME.operation_id,
+                arguments={"task_id": task_id},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_JOBS_UPDATE.operation_id):
+
+        @mcp.tool(
+            name=SELF_JOBS_UPDATE.tool_name,
+            description=SELF_JOBS_UPDATE.description,
+        )
+        async def self_jobs_update(
+            task_id: str,
+            name: str | None = None,
+            agent_id: str | None = None,
+            prompt: str | None = None,
+            cycle_type: str | None = None,
+            time_point: dict[str, object] | None = None,
+            enabled: bool | None = None,
+            conversation_policy: Literal["new_each_run", "reuse_single"] | None = None,
+            schedule_timezone: str | None = None,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_JOBS_UPDATE.operation_id,
+                arguments={
+                    "task_id": task_id,
+                    "name": name,
+                    "agent_id": agent_id,
+                    "prompt": prompt,
+                    "cycle_type": cycle_type,
+                    "time_point": time_point,
+                    "enabled": enabled,
+                    "conversation_policy": conversation_policy,
+                    "schedule_timezone": schedule_timezone,
+                },
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_JOBS_UPDATE_PROMPT.operation_id):
+
+        @mcp.tool(
+            name=SELF_JOBS_UPDATE_PROMPT.tool_name,
+            description=SELF_JOBS_UPDATE_PROMPT.description,
+        )
+        async def self_jobs_update_prompt(
+            task_id: str,
+            prompt: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_JOBS_UPDATE_PROMPT.operation_id,
+                arguments={"task_id": task_id, "prompt": prompt},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_JOBS_UPDATE_SCHEDULE.operation_id):
+
+        @mcp.tool(
+            name=SELF_JOBS_UPDATE_SCHEDULE.tool_name,
+            description=SELF_JOBS_UPDATE_SCHEDULE.description,
+        )
+        async def self_jobs_update_schedule(
+            task_id: str,
+            cycle_type: str | None = None,
+            time_point: dict[str, object] | None = None,
+            schedule_timezone: str | None = None,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_JOBS_UPDATE_SCHEDULE.operation_id,
+                arguments={
+                    "task_id": task_id,
+                    "cycle_type": cycle_type,
+                    "time_point": time_point,
+                    "schedule_timezone": schedule_timezone,
+                },
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_JOBS_DELETE.operation_id):
+
+        @mcp.tool(
+            name=SELF_JOBS_DELETE.tool_name,
+            description=SELF_JOBS_DELETE.description,
+        )
+        async def self_jobs_delete(
+            task_id: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_JOBS_DELETE.operation_id,
+                arguments={"task_id": task_id},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
     if _exposed(SELF_SESSIONS_LIST.operation_id):
 
         @mcp.tool(
@@ -395,6 +699,7 @@ def build_self_management_mcp_server(
             page: int = 1,
             size: int = 20,
             source: str | None = None,
+            status: str = "active",
             agent_id: str | None = None,
             ctx: Context | None = None,
         ) -> dict[str, Any]:
@@ -407,6 +712,7 @@ def build_self_management_mcp_server(
                     "page": page,
                     "size": size,
                     "source": source,
+                    "status": status,
                     "agent_id": agent_id,
                 },
                 allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
@@ -427,6 +733,64 @@ def build_self_management_mcp_server(
             return await execute_self_management_mcp_operation(
                 user_id=_require_request_user_id(ctx),
                 operation_id=SELF_SESSIONS_GET.operation_id,
+                arguments={"conversation_id": conversation_id},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_SESSIONS_UPDATE.operation_id):
+
+        @mcp.tool(
+            name=SELF_SESSIONS_UPDATE.tool_name,
+            description=SELF_SESSIONS_UPDATE.description,
+        )
+        async def self_sessions_update(
+            conversation_id: str,
+            title: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_SESSIONS_UPDATE.operation_id,
+                arguments={"conversation_id": conversation_id, "title": title},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_SESSIONS_ARCHIVE.operation_id):
+
+        @mcp.tool(
+            name=SELF_SESSIONS_ARCHIVE.tool_name,
+            description=SELF_SESSIONS_ARCHIVE.description,
+        )
+        async def self_sessions_archive(
+            conversation_id: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_SESSIONS_ARCHIVE.operation_id,
+                arguments={"conversation_id": conversation_id},
+                allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
+            )
+
+    if _exposed(SELF_SESSIONS_UNARCHIVE.operation_id):
+
+        @mcp.tool(
+            name=SELF_SESSIONS_UNARCHIVE.tool_name,
+            description=SELF_SESSIONS_UNARCHIVE.description,
+        )
+        async def self_sessions_unarchive(
+            conversation_id: str,
+            ctx: Context | None = None,
+        ) -> dict[str, Any]:
+            if ctx is None:
+                raise RuntimeError("FastMCP context is required.")
+            return await execute_self_management_mcp_operation(
+                user_id=_require_request_user_id(ctx),
+                operation_id=SELF_SESSIONS_UNARCHIVE.operation_id,
                 arguments={"conversation_id": conversation_id},
                 allowed_operation_ids=_require_request_allowed_operation_ids(ctx),
             )

--- a/backend/app/features/self_management_shared/self_management_tool_contract.py
+++ b/backend/app/features/self_management_shared/self_management_tool_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -32,6 +32,24 @@ class _JobGetInput(_StrictBaseModel):
     task_id: str = Field(min_length=1)
 
 
+class _JobsCreateInput(_StrictBaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    agent_id: str = Field(min_length=1)
+    prompt: str = Field(min_length=1)
+    cycle_type: str = Field(pattern="^(daily|weekly|monthly|interval|sequential)$")
+    time_point: dict[str, object] = Field(default_factory=dict)
+    enabled: bool = True
+    conversation_policy: Literal["new_each_run", "reuse_single"] = Field(
+        default="new_each_run",
+        description=(
+            "Use the exact enum `new_each_run` to create a fresh conversation for "
+            "every run, or `reuse_single` to keep reusing one conversation across "
+            "runs."
+        ),
+    )
+    schedule_timezone: str | None = None
+
+
 class _JobUpdatePromptInput(_JobGetInput):
     prompt: str = Field(min_length=1)
 
@@ -42,15 +60,41 @@ class _JobUpdateScheduleInput(_JobGetInput):
     schedule_timezone: str | None = None
 
 
+class _JobUpdateInput(_JobGetInput):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    agent_id: str | None = None
+    prompt: str | None = Field(default=None, min_length=1)
+    cycle_type: str | None = Field(
+        default=None,
+        pattern="^(daily|weekly|monthly|interval|sequential)$",
+    )
+    time_point: dict[str, object] | None = None
+    enabled: bool | None = None
+    conversation_policy: Literal["new_each_run", "reuse_single"] | None = Field(
+        default=None,
+        description=(
+            "When provided, use the exact enum `new_each_run` for a fresh "
+            "conversation on every run, or `reuse_single` to keep reusing one "
+            "conversation across runs."
+        ),
+    )
+    schedule_timezone: str | None = None
+
+
 class _SessionsListInput(_StrictBaseModel):
     page: int = Field(default=1, ge=1)
     size: int = Field(default=20, ge=1)
     source: str | None = Field(default=None, pattern="^(manual|scheduled)$")
+    status: str = Field(default="active", pattern="^(active|archived|all)$")
     agent_id: str | None = None
 
 
 class _SessionGetInput(_StrictBaseModel):
     conversation_id: str = Field(min_length=1)
+
+
+class _SessionUpdateInput(_SessionGetInput):
+    title: str = Field(min_length=1, max_length=255)
 
 
 class _AgentsListInput(_StrictBaseModel):
@@ -66,26 +110,66 @@ class _AgentGetInput(_StrictBaseModel):
     agent_id: str = Field(min_length=1)
 
 
+class _AgentCheckHealthInput(_AgentGetInput):
+    force: bool = True
+
+
+class _AgentsCheckHealthAllInput(_StrictBaseModel):
+    force: bool = False
+
+
+class _AgentCreateInput(_StrictBaseModel):
+    name: str = Field(min_length=1)
+    card_url: str = Field(min_length=1)
+    auth_type: str = Field(pattern="^(none|bearer|basic)$")
+    auth_header: str | None = None
+    auth_scheme: str | None = None
+    enabled: bool = True
+    tags: list[str] | None = None
+    extra_headers: dict[str, str] | None = None
+    invoke_metadata_defaults: dict[str, str] | None = None
+    token: str | None = None
+    basic_username: str | None = None
+    basic_password: str | None = None
+
+
 class _AgentUpdateConfigInput(_AgentGetInput):
     name: str | None = None
+    card_url: str | None = None
+    auth_type: str | None = Field(default=None, pattern="^(none|bearer|basic)$")
+    auth_header: str | None = None
+    auth_scheme: str | None = None
     enabled: bool | None = None
     tags: list[str] | None = None
     extra_headers: dict[str, str] | None = None
     invoke_metadata_defaults: dict[str, str] | None = None
+    token: str | None = None
+    basic_username: str | None = None
+    basic_password: str | None = None
 
 
 _INPUT_MODELS_BY_OPERATION_ID: dict[str, type[BaseModel]] = {
     "self.jobs.list": _JobsListInput,
     "self.jobs.get": _JobGetInput,
+    "self.jobs.create": _JobsCreateInput,
     "self.jobs.pause": _JobGetInput,
     "self.jobs.resume": _JobGetInput,
+    "self.jobs.update": _JobUpdateInput,
     "self.jobs.update_prompt": _JobUpdatePromptInput,
     "self.jobs.update_schedule": _JobUpdateScheduleInput,
+    "self.jobs.delete": _JobGetInput,
     "self.sessions.list": _SessionsListInput,
     "self.sessions.get": _SessionGetInput,
+    "self.sessions.update": _SessionUpdateInput,
+    "self.sessions.archive": _SessionGetInput,
+    "self.sessions.unarchive": _SessionGetInput,
     "self.agents.list": _AgentsListInput,
     "self.agents.get": _AgentGetInput,
+    "self.agents.check_health": _AgentCheckHealthInput,
+    "self.agents.check_health_all": _AgentsCheckHealthAllInput,
+    "self.agents.create": _AgentCreateInput,
     "self.agents.update_config": _AgentUpdateConfigInput,
+    "self.agents.delete": _AgentGetInput,
 }
 
 

--- a/backend/app/features/self_management_shared/self_management_toolkit.py
+++ b/backend/app/features/self_management_shared/self_management_toolkit.py
@@ -18,17 +18,27 @@ from app.features.schedules.self_management_jobs_service import (
     self_management_jobs_service,
 )
 from app.features.self_management_shared.capability_catalog import (
+    SELF_AGENTS_CHECK_HEALTH,
+    SELF_AGENTS_CHECK_HEALTH_ALL,
+    SELF_AGENTS_CREATE,
+    SELF_AGENTS_DELETE,
     SELF_AGENTS_GET,
     SELF_AGENTS_LIST,
     SELF_AGENTS_UPDATE_CONFIG,
+    SELF_JOBS_CREATE,
+    SELF_JOBS_DELETE,
     SELF_JOBS_GET,
     SELF_JOBS_LIST,
     SELF_JOBS_PAUSE,
     SELF_JOBS_RESUME,
+    SELF_JOBS_UPDATE,
     SELF_JOBS_UPDATE_PROMPT,
     SELF_JOBS_UPDATE_SCHEDULE,
+    SELF_SESSIONS_ARCHIVE,
     SELF_SESSIONS_GET,
     SELF_SESSIONS_LIST,
+    SELF_SESSIONS_UNARCHIVE,
+    SELF_SESSIONS_UPDATE,
     get_self_management_operation,
 )
 from app.features.self_management_shared.tool_gateway import SelfManagementToolGateway
@@ -76,24 +86,44 @@ class SelfManagementToolkit:
             payload = await self._list_jobs(args)
         elif operation.operation_id == SELF_JOBS_GET.operation_id:
             payload = await self._get_job(args)
+        elif operation.operation_id == SELF_JOBS_CREATE.operation_id:
+            payload = await self._create_job(args)
         elif operation.operation_id == SELF_JOBS_PAUSE.operation_id:
             payload = await self._pause_job(args)
         elif operation.operation_id == SELF_JOBS_RESUME.operation_id:
             payload = await self._resume_job(args)
+        elif operation.operation_id == SELF_JOBS_UPDATE.operation_id:
+            payload = await self._update_job(args)
         elif operation.operation_id == SELF_JOBS_UPDATE_PROMPT.operation_id:
             payload = await self._update_job_prompt(args)
         elif operation.operation_id == SELF_JOBS_UPDATE_SCHEDULE.operation_id:
             payload = await self._update_job_schedule(args)
+        elif operation.operation_id == SELF_JOBS_DELETE.operation_id:
+            payload = await self._delete_job(args)
         elif operation.operation_id == SELF_SESSIONS_LIST.operation_id:
             payload = await self._list_sessions(args)
         elif operation.operation_id == SELF_SESSIONS_GET.operation_id:
             payload = await self._get_session(args)
+        elif operation.operation_id == SELF_SESSIONS_UPDATE.operation_id:
+            payload = await self._update_session(args)
+        elif operation.operation_id == SELF_SESSIONS_ARCHIVE.operation_id:
+            payload = await self._archive_session(args)
+        elif operation.operation_id == SELF_SESSIONS_UNARCHIVE.operation_id:
+            payload = await self._unarchive_session(args)
         elif operation.operation_id == SELF_AGENTS_LIST.operation_id:
             payload = await self._list_agents(args)
         elif operation.operation_id == SELF_AGENTS_GET.operation_id:
             payload = await self._get_agent(args)
+        elif operation.operation_id == SELF_AGENTS_CHECK_HEALTH.operation_id:
+            payload = await self._check_agent_health(args)
+        elif operation.operation_id == SELF_AGENTS_CHECK_HEALTH_ALL.operation_id:
+            payload = await self._check_all_agents_health(args)
+        elif operation.operation_id == SELF_AGENTS_CREATE.operation_id:
+            payload = await self._create_agent(args)
         elif operation.operation_id == SELF_AGENTS_UPDATE_CONFIG.operation_id:
             payload = await self._update_agent_config(args)
+        elif operation.operation_id == SELF_AGENTS_DELETE.operation_id:
+            payload = await self._delete_agent(args)
         else:  # pragma: no cover - defensive guard
             raise SelfManagementToolInputError(
                 f"Operation `{operation_id}` is not implemented by the toolkit."
@@ -132,6 +162,38 @@ class SelfManagementToolkit:
         )
         return {"job": self._serialize_job(task, timezone_str=self._timezone_str())}
 
+    async def _create_job(self, args: dict[str, Any]) -> dict[str, Any]:
+        schedule_timezone = (
+            self._as_optional_str(args.get("schedule_timezone")) or self._timezone_str()
+        )
+        enabled = (
+            cast(
+                bool,
+                self._as_optional_bool(args.get("enabled"), field_name="enabled"),
+            )
+            if args.get("enabled") is not None
+            else True
+        )
+        task = await self_management_jobs_service.create_job(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            name=self._as_str(args.get("name"), field_name="name"),
+            agent_id=self._as_uuid(args.get("agent_id"), field_name="agent_id"),
+            prompt=self._as_str(args.get("prompt"), field_name="prompt"),
+            cycle_type=self._as_str(args.get("cycle_type"), field_name="cycle_type"),
+            time_point=(
+                self._as_optional_dict(args.get("time_point"), field_name="time_point")
+                or {}
+            ),
+            enabled=enabled,
+            conversation_policy=(
+                self._as_optional_str(args.get("conversation_policy")) or "new_each_run"
+            ),
+            timezone_str=schedule_timezone,
+        )
+        return {"job": self._serialize_job(task, timezone_str=schedule_timezone)}
+
     async def _pause_job(self, args: dict[str, Any]) -> dict[str, Any]:
         task = await self_management_jobs_service.pause_job(
             db=self.db,
@@ -151,6 +213,31 @@ class SelfManagementToolkit:
             timezone_str=self._timezone_str(),
         )
         return {"job": self._serialize_job(task, timezone_str=self._timezone_str())}
+
+    async def _update_job(self, args: dict[str, Any]) -> dict[str, Any]:
+        schedule_timezone = (
+            self._as_optional_str(args.get("schedule_timezone")) or self._timezone_str()
+        )
+        task = await self_management_jobs_service.update_job(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            task_id=self._as_uuid(args.get("task_id"), field_name="task_id"),
+            timezone_str=schedule_timezone,
+            name=self._as_optional_str(args.get("name")),
+            agent_id=self._as_optional_uuid(
+                args.get("agent_id"), field_name="agent_id"
+            ),
+            prompt=self._as_optional_str(args.get("prompt")),
+            cycle_type=self._as_optional_str(args.get("cycle_type")),
+            time_point=self._as_optional_dict(
+                args.get("time_point"),
+                field_name="time_point",
+            ),
+            enabled=self._as_optional_bool(args.get("enabled"), field_name="enabled"),
+            conversation_policy=self._as_optional_str(args.get("conversation_policy")),
+        )
+        return {"job": self._serialize_job(task, timezone_str=schedule_timezone)}
 
     async def _update_job_prompt(self, args: dict[str, Any]) -> dict[str, Any]:
         prompt = self._as_str(args.get("prompt"), field_name="prompt")
@@ -183,11 +270,24 @@ class SelfManagementToolkit:
         )
         return {"job": self._serialize_job(task, timezone_str=schedule_timezone)}
 
+    async def _delete_job(self, args: dict[str, Any]) -> dict[str, Any]:
+        task_id = self._as_uuid(args.get("task_id"), field_name="task_id")
+        await self_management_jobs_service.delete_job(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            task_id=task_id,
+        )
+        return {"task_id": str(task_id), "deleted": True}
+
     async def _list_sessions(self, args: dict[str, Any]) -> dict[str, Any]:
         page = self._as_int(args.get("page", 1), field_name="page", minimum=1)
         size = self._as_int(args.get("size", 20), field_name="size", minimum=1)
         raw_source = self._as_optional_str(args.get("source"))
         source = self._as_session_source(raw_source)
+        status = self._as_session_status(
+            self._as_optional_str(args.get("status")) or "active"
+        )
         agent_id = self._as_optional_uuid(args.get("agent_id"), field_name="agent_id")
         items, extra, _db_mutated = (
             await self_management_sessions_service.list_sessions(
@@ -197,6 +297,7 @@ class SelfManagementToolkit:
                 page=page,
                 size=size,
                 source=source,
+                status=status,
                 agent_id=agent_id,
             )
         )
@@ -215,6 +316,43 @@ class SelfManagementToolkit:
             gateway=self.gateway,
             current_user=self.current_user,
             conversation_id=conversation_id,
+        )
+        return {"session": self._serialize_session(session_item)}
+
+    async def _update_session(self, args: dict[str, Any]) -> dict[str, Any]:
+        session_item = await self_management_sessions_service.update_session(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            conversation_id=self._as_str(
+                args.get("conversation_id"),
+                field_name="conversation_id",
+            ),
+            title=self._as_str(args.get("title"), field_name="title"),
+        )
+        return {"session": self._serialize_session(session_item)}
+
+    async def _archive_session(self, args: dict[str, Any]) -> dict[str, Any]:
+        session_item = await self_management_sessions_service.archive_session(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            conversation_id=self._as_str(
+                args.get("conversation_id"),
+                field_name="conversation_id",
+            ),
+        )
+        return {"session": self._serialize_session(session_item)}
+
+    async def _unarchive_session(self, args: dict[str, Any]) -> dict[str, Any]:
+        session_item = await self_management_sessions_service.unarchive_session(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            conversation_id=self._as_str(
+                args.get("conversation_id"),
+                field_name="conversation_id",
+            ),
         )
         return {"session": self._serialize_session(session_item)}
 
@@ -258,6 +396,69 @@ class SelfManagementToolkit:
         )
         return {"agent": self._serialize_agent(record)}
 
+    async def _check_agent_health(self, args: dict[str, Any]) -> dict[str, Any]:
+        force = (
+            cast(bool, self._as_optional_bool(args.get("force"), field_name="force"))
+            if args.get("force") is not None
+            else True
+        )
+        summary, items = await self_management_agents_service.check_agent_health(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            agent_id=self._as_uuid(args.get("agent_id"), field_name="agent_id"),
+            force=force,
+        )
+        return self._serialize_agent_health_check(summary=summary, items=items)
+
+    async def _check_all_agents_health(self, args: dict[str, Any]) -> dict[str, Any]:
+        force = (
+            cast(bool, self._as_optional_bool(args.get("force"), field_name="force"))
+            if args.get("force") is not None
+            else False
+        )
+        summary, items = await self_management_agents_service.check_all_agents_health(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            force=force,
+        )
+        return self._serialize_agent_health_check(summary=summary, items=items)
+
+    async def _create_agent(self, args: dict[str, Any]) -> dict[str, Any]:
+        enabled = (
+            cast(
+                bool,
+                self._as_optional_bool(args.get("enabled"), field_name="enabled"),
+            )
+            if args.get("enabled") is not None
+            else True
+        )
+        record = await self_management_agents_service.create_agent(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            name=self._as_str(args.get("name"), field_name="name"),
+            card_url=self._as_str(args.get("card_url"), field_name="card_url"),
+            auth_type=self._as_str(args.get("auth_type"), field_name="auth_type"),
+            auth_header=self._as_optional_str(args.get("auth_header")),
+            auth_scheme=self._as_optional_str(args.get("auth_scheme")),
+            enabled=enabled,
+            tags=self._as_optional_str_list(args.get("tags"), field_name="tags"),
+            extra_headers=self._as_optional_str_dict(
+                args.get("extra_headers"),
+                field_name="extra_headers",
+            ),
+            invoke_metadata_defaults=self._as_optional_str_dict(
+                args.get("invoke_metadata_defaults"),
+                field_name="invoke_metadata_defaults",
+            ),
+            token=self._as_optional_str(args.get("token")),
+            basic_username=self._as_optional_str(args.get("basic_username")),
+            basic_password=self._as_optional_str(args.get("basic_password")),
+        )
+        return {"agent": self._serialize_agent(record)}
+
     async def _update_agent_config(self, args: dict[str, Any]) -> dict[str, Any]:
         record = await self_management_agents_service.update_config(
             db=self.db,
@@ -265,6 +466,10 @@ class SelfManagementToolkit:
             current_user=self.current_user,
             agent_id=self._as_uuid(args.get("agent_id"), field_name="agent_id"),
             name=self._as_optional_str(args.get("name")),
+            card_url=self._as_optional_str(args.get("card_url")),
+            auth_type=self._as_optional_str(args.get("auth_type")),
+            auth_header=self._as_optional_str(args.get("auth_header")),
+            auth_scheme=self._as_optional_str(args.get("auth_scheme")),
             enabled=self._as_optional_bool(args.get("enabled"), field_name="enabled"),
             tags=self._as_optional_str_list(args.get("tags"), field_name="tags"),
             extra_headers=self._as_optional_str_dict(
@@ -275,8 +480,21 @@ class SelfManagementToolkit:
                 args.get("invoke_metadata_defaults"),
                 field_name="invoke_metadata_defaults",
             ),
+            token=self._as_optional_str(args.get("token")),
+            basic_username=self._as_optional_str(args.get("basic_username")),
+            basic_password=self._as_optional_str(args.get("basic_password")),
         )
         return {"agent": self._serialize_agent(record)}
+
+    async def _delete_agent(self, args: dict[str, Any]) -> dict[str, Any]:
+        agent_id = self._as_uuid(args.get("agent_id"), field_name="agent_id")
+        await self_management_agents_service.delete_agent(
+            db=self.db,
+            gateway=self.gateway,
+            current_user=self.current_user,
+            agent_id=agent_id,
+        )
+        return {"agent_id": str(agent_id), "deleted": True}
 
     def _timezone_str(self) -> str:
         return cast(str, self.current_user.timezone or "UTC")
@@ -398,6 +616,14 @@ class SelfManagementToolkit:
         )
 
     @staticmethod
+    def _as_session_status(value: str) -> str:
+        if value in {"active", "archived", "all"}:
+            return value
+        raise SelfManagementToolInputError(
+            "`status` must be one of: active, archived, all."
+        )
+
+    @staticmethod
     def _serialize_job(task: A2AScheduleTask, *, timezone_str: str) -> dict[str, Any]:
         return {
             "id": str(cast(UUID | None, task.id)),
@@ -437,6 +663,7 @@ class SelfManagementToolkit:
             ),
             "agent_source": item.get("agent_source"),
             "title": item.get("title"),
+            "status": item.get("status"),
             "last_active_at": (
                 item["last_active_at"].isoformat()
                 if item.get("last_active_at") is not None
@@ -479,6 +706,32 @@ class SelfManagementToolkit:
             "username_hint": record.username_hint,
             "created_at": str(record.created_at),
             "updated_at": str(record.updated_at),
+        }
+
+    @staticmethod
+    def _serialize_agent_health_check(
+        *, summary: Any, items: list[Any]
+    ) -> dict[str, Any]:
+        return {
+            "summary": {
+                "requested": int(summary.requested),
+                "checked": int(summary.checked),
+                "skipped_cooldown": int(summary.skipped_cooldown),
+                "healthy": int(summary.healthy),
+                "degraded": int(summary.degraded),
+                "unavailable": int(summary.unavailable),
+                "unknown": int(summary.unknown),
+            },
+            "items": [
+                {
+                    "agent_id": str(item.agent_id),
+                    "health_status": item.health_status,
+                    "checked_at": item.checked_at.isoformat(),
+                    "skipped_cooldown": bool(item.skipped_cooldown),
+                    "error": item.error,
+                }
+                for item in items
+            ],
         }
 
 

--- a/backend/app/features/sessions/router.py
+++ b/backend/app/features/sessions/router.py
@@ -12,6 +12,10 @@ from app.api.deps import get_async_db, get_current_user
 from app.api.routing import StrictAPIRouter
 from app.db.models.user import User
 from app.db.transaction import commit_safely
+from app.features.self_management_shared.constants import (
+    SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID,
+    SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+)
 from app.features.sessions.schemas import (
     SessionCancelResponse,
     SessionContinueResponse,
@@ -65,6 +69,14 @@ def _status_code_for_session_error(detail: str) -> int:
     return 400
 
 
+def _resolve_session_query_agent_id(agent_id: str | None) -> UUID | None:
+    if agent_id is None:
+        return None
+    if agent_id == SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID:
+        return SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID
+    return UUID(agent_id)
+
+
 @router.post(":query", response_model=SessionListResponse)
 async def list_unified_sessions(
     *,
@@ -79,7 +91,7 @@ async def list_unified_sessions(
         page=payload.page,
         size=payload.size,
         source=payload.source,
-        agent_id=payload.agent_id,
+        agent_id=_resolve_session_query_agent_id(payload.agent_id),
     )
     if db_mutated:
         await commit_safely(db)

--- a/backend/app/features/sessions/schemas.py
+++ b/backend/app/features/sessions/schemas.py
@@ -6,8 +6,11 @@ from datetime import datetime
 from typing import Any, Dict, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
+from app.features.self_management_shared.constants import (
+    SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+)
 from app.schemas.pagination import Pagination
 
 SessionSource = Literal["manual", "scheduled"]
@@ -21,10 +24,29 @@ class SessionQueryRequest(BaseModel):
         None,
         description="Filter by source (manual/scheduled)",
     )
-    agent_id: Optional[UUID] = Field(
+    agent_id: Optional[str] = Field(
         None,
-        description="Filter by agent id.",
+        description=(
+            "Filter by agent id. Accepts a UUID or the built-in self-management "
+            "assistant public id."
+        ),
     )
+
+    @field_validator("agent_id")
+    @classmethod
+    def validate_agent_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if value == SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID:
+            return value
+        try:
+            UUID(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "Input should be a valid UUID or the built-in self-management "
+                "assistant id."
+            ) from exc
+        return value
 
 
 class SessionViewItem(BaseModel):

--- a/backend/app/features/sessions/self_management_sessions_service.py
+++ b/backend/app/features/sessions/self_management_sessions_service.py
@@ -1,20 +1,26 @@
-"""Shared self-management sessions service built on top of session domain services."""
+"""Shared self-management session services for self-owned conversation threads."""
 
 from __future__ import annotations
 
 from typing import Any, cast
 from uuid import UUID
 
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.db.models.conversation_thread import ConversationThread
 from app.db.models.user import User
+from app.db.transaction import commit_safely
 from app.features.self_management_shared.capability_catalog import (
+    SELF_SESSIONS_ARCHIVE,
     SELF_SESSIONS_GET,
     SELF_SESSIONS_LIST,
+    SELF_SESSIONS_UNARCHIVE,
+    SELF_SESSIONS_UPDATE,
 )
 from app.features.self_management_shared.tool_gateway import SelfManagementToolGateway
 from app.features.sessions.common import SessionSource
-from app.features.sessions.service import session_hub_service
+from app.utils.timezone_util import utc_now
 
 
 class SelfManagementSessionsService:
@@ -26,6 +32,74 @@ class SelfManagementSessionsService:
             raise ValueError("Authenticated user id is required")
         return user_id
 
+    @staticmethod
+    def _serialize_thread_summary(thread: ConversationThread) -> dict[str, Any]:
+        thread_source = cast(str | None, thread.source)
+        resolved_source = "scheduled" if thread_source == "scheduled" else "manual"
+        title_fallback = (
+            "Scheduled Session" if resolved_source == "scheduled" else "Manual Session"
+        )
+        raw_title = cast(str, thread.title)
+        title = raw_title if raw_title else title_fallback
+        if ConversationThread.is_placeholder_title(title):
+            title = "Session" if resolved_source == "manual" else title_fallback
+        return {
+            "conversationId": str(cast(UUID, thread.id)),
+            "source": resolved_source,
+            "external_provider": cast(str | None, thread.external_provider),
+            "external_session_id": cast(str | None, thread.external_session_id),
+            "agent_id": (
+                str(cast(UUID, thread.agent_id))
+                if cast(UUID | None, thread.agent_id) is not None
+                else None
+            ),
+            "agent_source": cast(str | None, thread.agent_source) or "personal",
+            "title": title,
+            "status": cast(str, thread.status),
+            "last_active_at": thread.last_active_at,
+            "created_at": thread.created_at,
+        }
+
+    @staticmethod
+    def _resolve_status_filter(status: str) -> tuple[str, ...]:
+        if status == "all":
+            return (
+                ConversationThread.STATUS_ACTIVE,
+                ConversationThread.STATUS_ARCHIVED,
+            )
+        if status == "archived":
+            return (ConversationThread.STATUS_ARCHIVED,)
+        return (ConversationThread.STATUS_ACTIVE,)
+
+    async def _get_thread(
+        self,
+        *,
+        db: AsyncSession,
+        user_id: UUID,
+        conversation_id: UUID,
+        allowed_statuses: tuple[str, ...],
+        for_update: bool = False,
+    ) -> ConversationThread:
+        stmt = select(ConversationThread).where(
+            and_(
+                ConversationThread.id == conversation_id,
+                ConversationThread.user_id == user_id,
+                ConversationThread.status.in_(allowed_statuses),
+                ConversationThread.source.in_(
+                    [
+                        ConversationThread.SOURCE_MANUAL,
+                        ConversationThread.SOURCE_SCHEDULED,
+                    ]
+                ),
+            )
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        thread = cast(ConversationThread | None, await db.scalar(stmt.limit(1)))
+        if thread is None:
+            raise ValueError("session_not_found")
+        return thread
+
     async def list_sessions(
         self,
         *,
@@ -35,16 +109,20 @@ class SelfManagementSessionsService:
         page: int,
         size: int,
         source: SessionSource | None = None,
+        status: str = "active",
         agent_id: UUID | None = None,
     ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
+        allowed_statuses = self._resolve_status_filter(status)
+
         result = await gateway.execute(
             operation=SELF_SESSIONS_LIST,
-            handler=lambda: session_hub_service.list_sessions(
-                db,
+            handler=lambda: self._list_sessions_query(
+                db=db,
                 user_id=self._user_id(current_user),
                 page=page,
                 size=size,
                 source=source,
+                status_filter=allowed_statuses,
                 agent_id=agent_id,
             ),
         )
@@ -58,17 +136,211 @@ class SelfManagementSessionsService:
         current_user: User,
         conversation_id: str,
     ) -> dict[str, Any]:
+        resolved_conversation_id = UUID(conversation_id)
         result = await gateway.execute(
             operation=SELF_SESSIONS_GET,
             resource_id=conversation_id,
-            handler=lambda: session_hub_service.get_session(
-                db,
+            handler=lambda: self._get_thread_query(
+                db=db,
                 user_id=self._user_id(current_user),
-                conversation_id=conversation_id,
+                conversation_id=resolved_conversation_id,
+                allowed_statuses=(
+                    ConversationThread.STATUS_ACTIVE,
+                    ConversationThread.STATUS_ARCHIVED,
+                ),
             ),
         )
-        session_item, _db_mutated = result.result
-        return session_item
+        return result.result
+
+    async def update_session(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        conversation_id: str,
+        title: str,
+    ) -> dict[str, Any]:
+        resolved_conversation_id = UUID(conversation_id)
+        result = await gateway.execute(
+            operation=SELF_SESSIONS_UPDATE,
+            resource_id=conversation_id,
+            handler=lambda: self._update_thread(
+                db=db,
+                user_id=self._user_id(current_user),
+                conversation_id=resolved_conversation_id,
+                title=title,
+            ),
+        )
+        return result.result
+
+    async def archive_session(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        conversation_id: str,
+    ) -> dict[str, Any]:
+        resolved_conversation_id = UUID(conversation_id)
+        result = await gateway.execute(
+            operation=SELF_SESSIONS_ARCHIVE,
+            resource_id=conversation_id,
+            handler=lambda: self._set_thread_status(
+                db=db,
+                user_id=self._user_id(current_user),
+                conversation_id=resolved_conversation_id,
+                from_status=ConversationThread.STATUS_ACTIVE,
+                to_status=ConversationThread.STATUS_ARCHIVED,
+            ),
+        )
+        return result.result
+
+    async def unarchive_session(
+        self,
+        *,
+        db: AsyncSession,
+        gateway: SelfManagementToolGateway,
+        current_user: User,
+        conversation_id: str,
+    ) -> dict[str, Any]:
+        resolved_conversation_id = UUID(conversation_id)
+        result = await gateway.execute(
+            operation=SELF_SESSIONS_UNARCHIVE,
+            resource_id=conversation_id,
+            handler=lambda: self._set_thread_status(
+                db=db,
+                user_id=self._user_id(current_user),
+                conversation_id=resolved_conversation_id,
+                from_status=ConversationThread.STATUS_ARCHIVED,
+                to_status=ConversationThread.STATUS_ACTIVE,
+            ),
+        )
+        return result.result
+
+    async def _list_sessions_query(
+        self,
+        *,
+        db: AsyncSession,
+        user_id: UUID,
+        page: int,
+        size: int,
+        source: SessionSource | None,
+        status_filter: tuple[str, ...],
+        agent_id: UUID | None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any], bool]:
+        offset = (page - 1) * size if page > 0 else 0
+        filters: list[Any] = [
+            ConversationThread.user_id == user_id,
+            ConversationThread.status.in_(status_filter),
+            ConversationThread.source.in_(
+                [
+                    ConversationThread.SOURCE_MANUAL,
+                    ConversationThread.SOURCE_SCHEDULED,
+                ]
+            ),
+        ]
+        if source is not None:
+            filters.append(ConversationThread.source == source)
+        if agent_id is not None:
+            filters.append(ConversationThread.agent_id == agent_id)
+
+        total = int(
+            cast(
+                int | None,
+                await db.scalar(
+                    select(func.count())
+                    .select_from(ConversationThread)
+                    .where(and_(*filters))
+                ),
+            )
+            or 0
+        )
+        stmt = (
+            select(ConversationThread)
+            .where(and_(*filters))
+            .order_by(
+                ConversationThread.last_active_at.desc(),
+                ConversationThread.created_at.desc(),
+            )
+            .offset(offset)
+            .limit(size)
+        )
+        threads = list((await db.execute(stmt)).scalars().all())
+        pages = (total + size - 1) // size if size else 0
+        return (
+            [self._serialize_thread_summary(thread) for thread in threads],
+            {
+                "pagination": {
+                    "page": page,
+                    "size": size,
+                    "total": total,
+                    "pages": pages,
+                }
+            },
+            False,
+        )
+
+    async def _get_thread_query(
+        self,
+        *,
+        db: AsyncSession,
+        user_id: UUID,
+        conversation_id: UUID,
+        allowed_statuses: tuple[str, ...],
+    ) -> dict[str, Any]:
+        thread = await self._get_thread(
+            db=db,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            allowed_statuses=allowed_statuses,
+        )
+        return self._serialize_thread_summary(thread)
+
+    async def _update_thread(
+        self,
+        *,
+        db: AsyncSession,
+        user_id: UUID,
+        conversation_id: UUID,
+        title: str,
+    ) -> dict[str, Any]:
+        thread = await self._get_thread(
+            db=db,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            allowed_statuses=(
+                ConversationThread.STATUS_ACTIVE,
+                ConversationThread.STATUS_ARCHIVED,
+            ),
+            for_update=True,
+        )
+        setattr(thread, "title", ConversationThread.normalize_title(title))
+        await commit_safely(db)
+        await db.refresh(thread)
+        return self._serialize_thread_summary(thread)
+
+    async def _set_thread_status(
+        self,
+        *,
+        db: AsyncSession,
+        user_id: UUID,
+        conversation_id: UUID,
+        from_status: str,
+        to_status: str,
+    ) -> dict[str, Any]:
+        thread = await self._get_thread(
+            db=db,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            allowed_statuses=(from_status,),
+            for_update=True,
+        )
+        setattr(thread, "status", to_status)
+        setattr(thread, "last_active_at", utc_now())
+        await commit_safely(db)
+        await db.refresh(thread)
+        return self._serialize_thread_summary(thread)
 
 
 self_management_sessions_service = SelfManagementSessionsService()

--- a/backend/tests/personal_agents/test_self_management_agents_service.py
+++ b/backend/tests/personal_agents/test_self_management_agents_service.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import pytest
 
+from app.features.personal_agents import service as personal_agent_service_module
 from app.features.personal_agents.self_management_agents_service import (
     self_management_agents_service,
 )
+from app.features.personal_agents.service import A2AAgentNotFoundError
 from app.features.self_management_shared.actor_context import (
     SelfManagementActorType,
     build_self_management_actor_context,
@@ -95,3 +97,109 @@ async def test_self_management_agents_service_update_config(
     assert updated.tags == ["cli", "self"]
     assert updated.extra_headers == {"X-Test": "1"}
     assert updated.invoke_metadata_defaults == {"model": "gpt-5"}
+
+
+async def test_self_management_agents_service_checks_agent_health(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(async_db_session)
+    record = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="self-health",
+    )
+    gateway = _build_gateway(user)
+
+    async def _fake_check_agents_health(*, user_id, force=False, agent_id=None):
+        assert user_id == user.id
+        return (
+            personal_agent_service_module.A2AAgentHealthCheckSummaryRecord(
+                requested=1 if agent_id is not None else 2,
+                checked=1,
+                skipped_cooldown=0,
+                healthy=1,
+                degraded=0,
+                unavailable=0,
+                unknown=0,
+            ),
+            [
+                personal_agent_service_module.A2AAgentHealthCheckItemRecord(
+                    agent_id=record.id,
+                    health_status="healthy",
+                    checked_at=record.updated_at,
+                    skipped_cooldown=not force,
+                    error=None,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        personal_agent_service_module.a2a_agent_service,
+        "check_agents_health",
+        _fake_check_agents_health,
+    )
+
+    single_summary, single_items = (
+        await self_management_agents_service.check_agent_health(
+            db=async_db_session,
+            gateway=gateway,
+            current_user=user,
+            agent_id=record.id,
+            force=True,
+        )
+    )
+    all_summary, all_items = (
+        await self_management_agents_service.check_all_agents_health(
+            db=async_db_session,
+            gateway=gateway,
+            current_user=user,
+            force=True,
+        )
+    )
+
+    assert single_summary.requested == 1
+    assert len(single_items) == 1
+    assert single_items[0].agent_id == record.id
+    assert all_summary.requested >= 1
+    assert any(item.agent_id == record.id for item in all_items)
+
+
+async def test_self_management_agents_service_create_and_delete_agent(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+    gateway = _build_gateway(user)
+
+    created = await self_management_agents_service.create_agent(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        name="Created Agent",
+        card_url="https://example.com/self-created/.well-known/agent-card.json",
+        auth_type="bearer",
+        token="secret-token",
+        tags=["managed"],
+        extra_headers={"X-Scope": "self"},
+    )
+
+    assert created.name == "Created Agent"
+    assert created.auth_type == "bearer"
+    assert created.tags == ["managed"]
+    assert created.extra_headers == {"X-Scope": "self"}
+    assert created.token_last4 == "oken"
+
+    await self_management_agents_service.delete_agent(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        agent_id=created.id,
+    )
+
+    with pytest.raises(A2AAgentNotFoundError, match="A2A agent not found"):
+        await self_management_agents_service.get_agent(
+            db=async_db_session,
+            gateway=gateway,
+            current_user=user,
+            agent_id=created.id,
+        )

--- a/backend/tests/runtime/test_self_management_actor_context.py
+++ b/backend/tests/runtime/test_self_management_actor_context.py
@@ -306,7 +306,11 @@ def test_first_wave_capability_catalog_contains_expected_surfaces() -> None:
     exposed_ids = {item.operation_id for item in FIRST_WAVE_EXPOSED_OPERATIONS}
 
     assert "self.jobs.list" in exposed_ids
+    assert "self.agents.check_health" in exposed_ids
+    assert "self.jobs.create" in exposed_ids
     assert "self.sessions.get" in exposed_ids
+    assert "self.sessions.archive" in exposed_ids
+    assert "self.agents.create" in exposed_ids
     assert "self.agents.update_config" in exposed_ids
     assert all(item.first_wave_exposed for item in FIRST_WAVE_EXPOSED_OPERATIONS)
     assert all(item.surfaces for item in FIRST_WAVE_EXPOSED_OPERATIONS)
@@ -322,7 +326,7 @@ def test_internal_admin_capability_is_not_first_wave_exposed() -> None:
 
 
 def test_unsupported_first_wave_operation_ids_are_explicit() -> None:
-    assert "self.jobs.delete" in UNSUPPORTED_FIRST_WAVE_OPERATION_IDS
+    assert "self.sessions.delete" in UNSUPPORTED_FIRST_WAVE_OPERATION_IDS
     assert "admin.agents.delete" in UNSUPPORTED_FIRST_WAVE_OPERATION_IDS
 
 

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -18,8 +19,12 @@ from app.core.security import (
 )
 from app.db.models.agent_message import AgentMessage
 from app.features.self_management_agent import router as self_management_agent_router
+from app.features.self_management_agent import (
+    service as self_management_agent_service_module,
+)
 from app.features.self_management_agent.service import (
     _WRITE_APPROVAL_SENTINEL,
+    SelfManagementBuiltInAgentUnavailableError,
     self_management_built_in_agent_service,
 )
 from app.features.sessions.service import session_hub_service
@@ -33,6 +38,8 @@ class _FakeSwivalSession:
     last_init_kwargs: dict[str, object] | None = None
     last_message: str | None = None
     next_answer: str = "Built-in agent reply"
+    next_messages: list[dict[str, object]] | None = None
+    next_error: Exception | None = None
     ask_call_count: int = 0
     instance_count: int = 0
     instances: list["_FakeSwivalSession"] = []
@@ -45,6 +52,10 @@ class _FakeSwivalSession:
         self.closed = False
 
     def ask(self, message: str) -> object:
+        if type(self).next_error is not None:
+            exc = type(self).next_error
+            type(self).next_error = None
+            raise exc
         type(self).last_message = message
         type(self).ask_call_count += 1
         if self._conv_state is None:
@@ -52,7 +63,17 @@ class _FakeSwivalSession:
         messages = cast(list[dict[str, str]], self._conv_state["messages"])
         messages.append({"role": "user", "content": message})
         messages.append({"role": "assistant", "content": type(self).next_answer})
-        return SimpleNamespace(answer=type(self).next_answer, exhausted=False)
+        result_messages = (
+            copy.deepcopy(type(self).next_messages)
+            if type(self).next_messages is not None
+            else copy.deepcopy(messages)
+        )
+        type(self).next_messages = None
+        return SimpleNamespace(
+            answer=type(self).next_answer,
+            exhausted=False,
+            messages=result_messages,
+        )
 
     def close(self) -> None:
         self.closed = True
@@ -62,6 +83,8 @@ def _install_fake_swival(monkeypatch: pytest.MonkeyPatch) -> None:
     _FakeSwivalSession.last_init_kwargs = None
     _FakeSwivalSession.last_message = None
     _FakeSwivalSession.next_answer = "Built-in agent reply"
+    _FakeSwivalSession.next_messages = None
+    _FakeSwivalSession.next_error = None
     _FakeSwivalSession.ask_call_count = 0
     _FakeSwivalSession.instance_count = 0
     _FakeSwivalSession.instances = []
@@ -286,6 +309,93 @@ async def test_built_in_agent_run_uses_swival_with_authenticated_mcp_server(
     assert get_self_management_allowed_operations(claims) == frozenset(
         result.tool_names
     )
+
+
+async def test_built_in_agent_rebuilds_session_when_delegated_token_expires(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    monkeypatch.setattr(settings, "jwt_access_token_ttl_seconds", 5)
+    monkeypatch.setattr(
+        settings, "self_management_swival_delegated_token_ttl_seconds", 5
+    )
+    monotonic_time = {"value": 100.0}
+    monkeypatch.setattr(
+        self_management_agent_service_module.time,
+        "monotonic",
+        lambda: monotonic_time["value"],
+    )
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+
+    first = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="List my jobs",
+        allow_write_tools=False,
+    )
+    assert first.answer == "Built-in agent reply"
+    assert _FakeSwivalSession.instance_count == 1
+
+    monotonic_time["value"] += 10.0
+    _FakeSwivalSession.next_answer = "Second built-in agent reply"
+    second = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="List my agents",
+        allow_write_tools=False,
+    )
+
+    assert second.answer == "Second built-in agent reply"
+    assert _FakeSwivalSession.instance_count == 2
+    assert _FakeSwivalSession.instances[0].closed is True
+    assert _FakeSwivalSession.instances[1]._conv_state is not None
+    assert cast(
+        list[dict[str, str]], _FakeSwivalSession.instances[1]._conv_state["messages"]
+    )[:2] == [
+        {"role": "user", "content": "List my jobs"},
+        {"role": "assistant", "content": "Built-in agent reply"},
+    ]
+
+
+async def test_built_in_agent_raises_when_mcp_runtime_returns_transport_error(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+
+    _FakeSwivalSession.next_answer = "Backend appears unavailable."
+    _FakeSwivalSession.next_messages = [
+        {"role": "user", "content": "List my agents"},
+        {
+            "role": "tool",
+            "content": (
+                "error: MCP server 'a2a-client-hub' failed: "
+                "Client error '401 Unauthorized'"
+            ),
+        },
+        {"role": "assistant", "content": "Backend appears unavailable."},
+    ]
+
+    with pytest.raises(SelfManagementBuiltInAgentUnavailableError) as excinfo:
+        await self_management_built_in_agent_service.run(
+            db=async_db_session,
+            current_user=user,
+            conversation_id=_new_conversation_id(),
+            message="List my agents",
+            allow_write_tools=False,
+        )
+
+    assert "MCP call failed" in str(excinfo.value)
+    assert "401 Unauthorized" in str(excinfo.value)
 
 
 async def test_built_in_agent_reuses_same_swival_base_dir_for_same_user(
@@ -904,6 +1014,66 @@ async def test_built_in_agent_permission_reply_once_resumes_with_write_tools(
         "url"
     ] == ("http://internal-mcp/mcp-write/")
     assert _FakeSwivalSession.instance_count == 1
+
+
+async def test_built_in_agent_permission_reply_rejects_repeated_write_approval(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+    _FakeSwivalSession.next_answer = (
+        "I can pause the requested job after you approve write access.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    interrupt_result = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Pause my job",
+        allow_write_tools=False,
+    )
+    assert interrupt_result.interrupt is not None
+
+    _FakeSwivalSession.next_answer = (
+        "I still need write approval before I can pause that job.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    with pytest.raises(SelfManagementBuiltInAgentUnavailableError) as excinfo:
+        await self_management_built_in_agent_service.reply_permission_interrupt(
+            db=async_db_session,
+            current_user=user,
+            request_id=interrupt_result.interrupt.request_id,
+            reply="once",
+        )
+
+    assert "requested write approval after write tools were enabled" in str(
+        excinfo.value
+    )
+
+    messages, _extra, _db_mutated = await session_hub_service.list_messages(
+        async_db_session,
+        user_id=cast(Any, user.id),
+        conversation_id=conversation_id,
+        before=None,
+        limit=20,
+    )
+    assert [item["role"] for item in messages] == ["user", "agent"]
+    assert messages[1]["status"] == "interrupted"
+
+    recovered = await self_management_built_in_agent_service.recover_pending_interrupts(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+    )
+    assert [item.request_id for item in recovered] == [
+        interrupt_result.interrupt.request_id
+    ]
 
 
 async def test_built_in_agent_permission_reply_reject_returns_no_change_result(

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -140,14 +140,27 @@ async def test_built_in_agent_profile_exposes_full_available_tool_surface(
     assert profile.configured is True
     assert profile.resources == ("agents", "jobs", "sessions")
     assert [item.operation_id for item in profile.tool_definitions] == [
+        "self.agents.check_health",
+        "self.agents.check_health_all",
+        "self.agents.create",
+        "self.agents.delete",
         "self.agents.get",
         "self.agents.list",
         "self.agents.update_config",
+        "self.jobs.create",
+        "self.jobs.delete",
         "self.jobs.get",
         "self.jobs.list",
         "self.jobs.pause",
+        "self.jobs.resume",
+        "self.jobs.update",
+        "self.jobs.update_prompt",
+        "self.jobs.update_schedule",
+        "self.sessions.archive",
         "self.sessions.get",
         "self.sessions.list",
+        "self.sessions.unarchive",
+        "self.sessions.update",
     ]
 
 
@@ -361,14 +374,27 @@ async def test_built_in_agent_write_approved_run_uses_write_enabled_mcp_surface(
     )
 
     assert result.tool_names == (
+        "self.agents.check_health",
+        "self.agents.check_health_all",
+        "self.agents.create",
+        "self.agents.delete",
         "self.agents.get",
         "self.agents.list",
         "self.agents.update_config",
+        "self.jobs.create",
+        "self.jobs.delete",
         "self.jobs.get",
         "self.jobs.list",
         "self.jobs.pause",
+        "self.jobs.resume",
+        "self.jobs.update",
+        "self.jobs.update_prompt",
+        "self.jobs.update_schedule",
+        "self.sessions.archive",
         "self.sessions.get",
         "self.sessions.list",
+        "self.sessions.unarchive",
+        "self.sessions.update",
     )
     assert result.status == "completed"
     assert result.write_tools_enabled is True
@@ -424,14 +450,27 @@ async def test_built_in_agent_run_route_returns_swival_result(
     assert profile_response.status_code == 200
     assert profile_response.json()["resources"] == ["agents", "jobs", "sessions"]
     assert [item["operation_id"] for item in profile_response.json()["tools"]] == [
+        "self.agents.check_health",
+        "self.agents.check_health_all",
+        "self.agents.create",
+        "self.agents.delete",
         "self.agents.get",
         "self.agents.list",
         "self.agents.update_config",
+        "self.jobs.create",
+        "self.jobs.delete",
         "self.jobs.get",
         "self.jobs.list",
         "self.jobs.pause",
+        "self.jobs.resume",
+        "self.jobs.update",
+        "self.jobs.update_prompt",
+        "self.jobs.update_schedule",
+        "self.sessions.archive",
         "self.sessions.get",
         "self.sessions.list",
+        "self.sessions.unarchive",
+        "self.sessions.update",
     ]
     assert run_response.status_code == 200
     assert run_response.json() == {
@@ -749,8 +788,21 @@ async def test_built_in_agent_can_recover_unresolved_permission_interrupts(
     assert recovered[0].type == "permission"
     assert recovered[0].details["permission"] == "self-management-write"
     assert recovered[0].details["patterns"] == [
+        "self.agents.check_health",
+        "self.agents.check_health_all",
+        "self.agents.create",
+        "self.agents.delete",
         "self.agents.update_config",
+        "self.jobs.create",
+        "self.jobs.delete",
         "self.jobs.pause",
+        "self.jobs.resume",
+        "self.jobs.update",
+        "self.jobs.update_prompt",
+        "self.jobs.update_schedule",
+        "self.sessions.archive",
+        "self.sessions.unarchive",
+        "self.sessions.update",
     ]
 
 
@@ -855,8 +907,21 @@ async def test_built_in_agent_read_only_run_can_raise_permission_interrupt(
     assert result.interrupt is not None
     assert result.interrupt.permission == "self-management-write"
     assert result.interrupt.patterns == (
+        "self.agents.check_health",
+        "self.agents.check_health_all",
+        "self.agents.create",
+        "self.agents.delete",
         "self.agents.update_config",
+        "self.jobs.create",
+        "self.jobs.delete",
         "self.jobs.pause",
+        "self.jobs.resume",
+        "self.jobs.update",
+        "self.jobs.update_prompt",
+        "self.jobs.update_schedule",
+        "self.sessions.archive",
+        "self.sessions.unarchive",
+        "self.sessions.update",
     )
     claims = verify_jwt_token_claims(
         result.interrupt.request_id,
@@ -866,8 +931,21 @@ async def test_built_in_agent_read_only_run_can_raise_permission_interrupt(
     assert claims.subject == str(user.id)
     assert get_self_management_interrupt_message(claims) == "Pause my job"
     assert get_self_management_interrupt_tool_names(claims) == (
+        "self.agents.check_health",
+        "self.agents.check_health_all",
+        "self.agents.create",
+        "self.agents.delete",
         "self.agents.update_config",
+        "self.jobs.create",
+        "self.jobs.delete",
         "self.jobs.pause",
+        "self.jobs.resume",
+        "self.jobs.update",
+        "self.jobs.update_prompt",
+        "self.jobs.update_schedule",
+        "self.sessions.archive",
+        "self.sessions.unarchive",
+        "self.sessions.update",
     )
 
 
@@ -1023,8 +1101,21 @@ async def test_built_in_agent_interrupt_recovery_route_returns_unresolved_interr
             "details": {
                 "permission": "self-management-write",
                 "patterns": [
+                    "self.agents.check_health",
+                    "self.agents.check_health_all",
+                    "self.agents.create",
+                    "self.agents.delete",
                     "self.agents.update_config",
+                    "self.jobs.create",
+                    "self.jobs.delete",
                     "self.jobs.pause",
+                    "self.jobs.resume",
+                    "self.jobs.update",
+                    "self.jobs.update_prompt",
+                    "self.jobs.update_schedule",
+                    "self.sessions.archive",
+                    "self.sessions.unarchive",
+                    "self.sessions.update",
                 ],
                 "displayMessage": "I can pause the requested job after you approve write access.",
             },

--- a/backend/tests/runtime/test_self_management_mcp.py
+++ b/backend/tests/runtime/test_self_management_mcp.py
@@ -8,6 +8,7 @@ from fastapi.responses import JSONResponse
 from httpx import ASGITransport, AsyncClient
 
 from app.core.security import create_self_management_access_token
+from app.features.personal_agents import service as personal_agent_service_module
 from app.features.self_management_shared.self_management_mcp import (
     _MCP_ALLOWED_OPERATION_IDS_STATE_KEY,
     _MCP_USER_ID_STATE_KEY,
@@ -51,8 +52,19 @@ async def test_self_management_write_mcp_server_lists_write_tools() -> None:
     tools = await self_management_write_mcp_server.list_tools()
     tool_names = {tool.name for tool in tools}
 
+    assert "self.agents.check_health" in tool_names
+    assert "self.agents.check_health_all" in tool_names
+    assert "self.agents.create" in tool_names
     assert "self.agents.update_config" in tool_names
+    assert "self.agents.delete" in tool_names
+    assert "self.jobs.create" in tool_names
     assert "self.jobs.pause" in tool_names
+    assert "self.jobs.resume" in tool_names
+    assert "self.jobs.update" in tool_names
+    assert "self.jobs.delete" in tool_names
+    assert "self.sessions.update" in tool_names
+    assert "self.sessions.archive" in tool_names
+    assert "self.sessions.unarchive" in tool_names
 
 
 async def test_execute_self_management_mcp_operation_returns_swival_envelope(
@@ -121,6 +133,7 @@ async def test_execute_self_management_mcp_operation_supports_sessions(
     assert get_result["ok"] is True
     assert get_result["result"]["session"]["conversation_id"] == str(thread.id)
     assert get_result["result"]["session"]["title"] == "MCP Session"
+    assert get_result["result"]["session"]["status"] == "active"
 
 
 async def test_execute_self_management_mcp_operation_supports_agents(
@@ -169,6 +182,227 @@ async def test_execute_self_management_mcp_operation_supports_agents(
     assert update_result["result"]["agent"]["name"] == "MCP Updated Agent"
     assert update_result["result"]["agent"]["enabled"] is False
     assert update_result["result"]["agent"]["tags"] == ["after"]
+
+
+async def test_execute_self_management_mcp_operation_supports_agent_health_checks(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(async_db_session)
+    agent = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="mcp-agent-health",
+    )
+
+    async def _fake_check_agents_health(*, user_id, force=False, agent_id=None):
+        assert user_id == user.id
+        return (
+            personal_agent_service_module.A2AAgentHealthCheckSummaryRecord(
+                requested=1 if agent_id is not None else 2,
+                checked=1,
+                skipped_cooldown=0,
+                healthy=1,
+                degraded=0,
+                unavailable=0,
+                unknown=0,
+            ),
+            [
+                personal_agent_service_module.A2AAgentHealthCheckItemRecord(
+                    agent_id=agent.id,
+                    health_status="healthy",
+                    checked_at=agent.updated_at,
+                    skipped_cooldown=not force,
+                    error=None,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        personal_agent_service_module.a2a_agent_service,
+        "check_agents_health",
+        _fake_check_agents_health,
+    )
+
+    single_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.agents.check_health",
+        arguments={"agent_id": str(agent.id), "force": True},
+        db=async_db_session,
+    )
+    all_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.agents.check_health_all",
+        arguments={"force": True},
+        db=async_db_session,
+    )
+
+    assert single_result["ok"] is True
+    assert single_result["result"]["summary"]["requested"] == 1
+    assert single_result["result"]["items"][0]["agent_id"] == str(agent.id)
+    assert all_result["ok"] is True
+    assert all_result["result"]["summary"]["requested"] >= 1
+    assert any(
+        item["agent_id"] == str(agent.id) for item in all_result["result"]["items"]
+    )
+
+
+async def test_execute_self_management_mcp_operation_supports_agent_create_delete(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+
+    create_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.agents.create",
+        arguments={
+            "name": "Created via MCP",
+            "card_url": "https://example.com/mcp-created/.well-known/agent-card.json",
+            "auth_type": "bearer",
+            "token": "secret-token",
+        },
+        db=async_db_session,
+    )
+
+    assert create_result["ok"] is True
+    created_agent_id = create_result["result"]["agent"]["id"]
+
+    delete_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.agents.delete",
+        arguments={"agent_id": created_agent_id},
+        db=async_db_session,
+    )
+
+    assert delete_result == {
+        "ok": True,
+        "result": {"agent_id": created_agent_id, "deleted": True},
+    }
+
+
+async def test_execute_self_management_mcp_operation_supports_job_create_update_delete(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+    agent = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="mcp-job-create",
+    )
+
+    create_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.jobs.create",
+        arguments={
+            "name": "Created job",
+            "agent_id": str(agent.id),
+            "prompt": "run it",
+            "cycle_type": "daily",
+            "time_point": {"time": "10:15"},
+            "enabled": True,
+        },
+        db=async_db_session,
+    )
+
+    assert create_result["ok"] is True
+    task_id = create_result["result"]["job"]["id"]
+
+    update_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.jobs.update",
+        arguments={
+            "task_id": task_id,
+            "name": "Updated job",
+            "enabled": False,
+            "conversation_policy": "reuse_single",
+        },
+        db=async_db_session,
+    )
+    delete_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.jobs.delete",
+        arguments={"task_id": task_id},
+        db=async_db_session,
+    )
+
+    assert update_result["ok"] is True
+    assert update_result["result"]["job"]["name"] == "Updated job"
+    assert update_result["result"]["job"]["enabled"] is False
+    assert update_result["result"]["job"]["conversation_policy"] == "reuse_single"
+    assert delete_result == {
+        "ok": True,
+        "result": {"task_id": task_id, "deleted": True},
+    }
+
+
+async def test_execute_self_management_mcp_operation_rejects_noncanonical_job_conversation_policy(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+    agent = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="mcp-job-policy-invalid",
+    )
+
+    create_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.jobs.create",
+        arguments={
+            "name": "Aliased policy job",
+            "agent_id": str(agent.id),
+            "prompt": "run it",
+            "cycle_type": "daily",
+            "time_point": {"time": "10:15"},
+            "conversation_policy": "reuse",
+        },
+        db=async_db_session,
+    )
+
+    assert create_result == {
+        "ok": False,
+        "error": "conversation_policy must be one of new_each_run, reuse_single",
+    }
+
+
+async def test_execute_self_management_mcp_operation_supports_session_writes(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+    thread = await create_conversation_thread(
+        async_db_session,
+        user_id=user.id,
+        title="Before",
+    )
+
+    update_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.sessions.update",
+        arguments={
+            "conversation_id": str(thread.id),
+            "title": "After",
+        },
+        db=async_db_session,
+    )
+    archive_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.sessions.archive",
+        arguments={"conversation_id": str(thread.id)},
+        db=async_db_session,
+    )
+    unarchive_result = await execute_self_management_mcp_operation(
+        user_id=user.id,
+        operation_id="self.sessions.unarchive",
+        arguments={"conversation_id": str(thread.id)},
+        db=async_db_session,
+    )
+
+    assert update_result["ok"] is True
+    assert update_result["result"]["session"]["title"] == "After"
+    assert archive_result["ok"] is True
+    assert archive_result["result"]["session"]["status"] == "archived"
+    assert unarchive_result["ok"] is True
+    assert unarchive_result["result"]["session"]["status"] == "active"
 
 
 async def test_self_management_mcp_http_app_requires_bearer_auth(

--- a/backend/tests/runtime/test_self_management_tool_contract.py
+++ b/backend/tests/runtime/test_self_management_tool_contract.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from app.features.self_management_shared.capability_catalog import (
     ADMIN_HUB_AGENTS_LIST,
+    SELF_AGENTS_CHECK_HEALTH,
+    SELF_AGENTS_CREATE,
+    SELF_JOBS_CREATE,
     SELF_JOBS_UPDATE_SCHEDULE,
 )
 from app.features.self_management_shared.self_management_tool_contract import (
@@ -34,9 +37,48 @@ def test_list_self_management_tool_definitions_filters_by_surface() -> None:
     operation_ids = {item.operation_id for item in definitions}
 
     assert "self.jobs.list" in operation_ids
+    assert "self.agents.create" in operation_ids
+    assert "self.jobs.delete" in operation_ids
+    assert "self.sessions.archive" in operation_ids
     assert "self.sessions.get" in operation_ids
     assert "self.agents.update_config" in operation_ids
     assert "admin.agents.list" not in operation_ids
+
+
+def test_build_self_management_tool_definition_supports_agent_create() -> None:
+    definition = build_self_management_tool_definition(SELF_AGENTS_CREATE)
+
+    assert definition.operation_id == "self.agents.create"
+    assert definition.tool_name == "self.agents.create"
+    assert definition.confirmation_policy.value == "required"
+    assert definition.input_json_schema["properties"]["card_url"]["type"] == "string"
+
+
+def test_build_self_management_tool_definition_supports_agent_health_check() -> None:
+    definition = build_self_management_tool_definition(SELF_AGENTS_CHECK_HEALTH)
+
+    assert definition.operation_id == "self.agents.check_health"
+    assert definition.tool_name == "self.agents.check_health"
+    assert definition.confirmation_policy.value == "required"
+    assert definition.input_json_schema["properties"]["force"]["type"] == "boolean"
+
+
+def test_build_self_management_tool_definition_documents_job_conversation_policy() -> (
+    None
+):
+    definition = build_self_management_tool_definition(SELF_JOBS_CREATE)
+
+    conversation_policy = definition.input_json_schema["properties"][
+        "conversation_policy"
+    ]
+
+    assert definition.operation_id == "self.jobs.create"
+    assert "exact enum `new_each_run` or `reuse_single`" in definition.description
+    assert conversation_policy["enum"] == ["new_each_run", "reuse_single"]
+    assert conversation_policy["description"] == (
+        "Use the exact enum `new_each_run` to create a fresh conversation for "
+        "every run, or `reuse_single` to keep reusing one conversation across runs."
+    )
 
 
 def test_build_self_management_tool_definition_rejects_missing_tool_name() -> None:

--- a/backend/tests/runtime/test_self_management_toolkit.py
+++ b/backend/tests/runtime/test_self_management_toolkit.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from app.features.personal_agents import service as personal_agent_service_module
 from app.features.self_management_shared.actor_context import (
     SelfManagementActorType,
     build_self_management_actor_context,
 )
 from app.features.self_management_shared.capability_catalog import (
+    SELF_AGENTS_CHECK_HEALTH,
+    SELF_AGENTS_CHECK_HEALTH_ALL,
     SELF_AGENTS_UPDATE_CONFIG,
     SELF_JOBS_GET,
     SELF_JOBS_LIST,
@@ -113,6 +116,64 @@ async def test_self_management_toolkit_updates_agent_config(
     assert result.payload["agent"]["name"] == "Toolkit Updated Agent"
     assert result.payload["agent"]["enabled"] is False
     assert result.payload["agent"]["tags"] == ["cli", "toolkit"]
+
+
+async def test_self_management_toolkit_checks_agent_health(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(async_db_session)
+    record = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="toolkit-health",
+    )
+    toolkit = _build_toolkit(async_db_session, user)
+
+    async def _fake_check_agents_health(*, user_id, force=False, agent_id=None):
+        assert user_id == user.id
+        return (
+            personal_agent_service_module.A2AAgentHealthCheckSummaryRecord(
+                requested=1 if agent_id is not None else 2,
+                checked=1,
+                skipped_cooldown=0,
+                healthy=1,
+                degraded=0,
+                unavailable=0,
+                unknown=0,
+            ),
+            [
+                personal_agent_service_module.A2AAgentHealthCheckItemRecord(
+                    agent_id=record.id,
+                    health_status="healthy",
+                    checked_at=record.updated_at,
+                    skipped_cooldown=not force,
+                    error=None,
+                )
+            ],
+        )
+
+    monkeypatch.setattr(
+        personal_agent_service_module.a2a_agent_service,
+        "check_agents_health",
+        _fake_check_agents_health,
+    )
+
+    single_result = await toolkit.execute(
+        operation_id=SELF_AGENTS_CHECK_HEALTH.operation_id,
+        arguments={"agent_id": str(record.id), "force": True},
+    )
+    all_result = await toolkit.execute(
+        operation_id=SELF_AGENTS_CHECK_HEALTH_ALL.operation_id,
+        arguments={"force": True},
+    )
+
+    assert single_result.payload["summary"]["requested"] == 1
+    assert single_result.payload["items"][0]["agent_id"] == str(record.id)
+    assert all_result.payload["summary"]["requested"] >= 1
+    assert any(
+        item["agent_id"] == str(record.id) for item in all_result.payload["items"]
+    )
 
 
 async def test_self_management_toolkit_rejects_invalid_schedule_inputs(

--- a/backend/tests/runtime/test_settings_security_baseline.py
+++ b/backend/tests/runtime/test_settings_security_baseline.py
@@ -58,6 +58,7 @@ def _set_base_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AUTH_REFRESH_COOKIE_SECURE", "true")
     monkeypatch.setenv("AUTH_REFRESH_COOKIE_SAMESITE", "lax")
     monkeypatch.setenv("BACKEND_CORS_ORIGINS", '["https://app.example.com"]')
+    monkeypatch.setenv("AUTH_COOKIE_TRUSTED_ORIGINS", '["https://app.example.com"]')
     monkeypatch.setenv("WS_ALLOWED_ORIGINS", '["https://app.example.com"]')
     monkeypatch.setenv("WS_REQUIRE_ORIGIN", "true")
     monkeypatch.setenv("A2A_PROXY_ALLOWED_HOSTS", '["agent.example.com"]')

--- a/backend/tests/schedules/test_self_management_jobs_service.py
+++ b/backend/tests/schedules/test_self_management_jobs_service.py
@@ -143,3 +143,71 @@ async def test_self_management_jobs_service_updates_prompt_and_schedule(
 
     assert updated_prompt.prompt == "new prompt"
     assert updated_schedule.time_point["time"] == "10:30"
+
+
+async def test_self_management_jobs_service_create_update_and_delete_job(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+    first_agent = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="jobs-create-a",
+    )
+    second_agent = await create_a2a_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="jobs-create-b",
+    )
+    gateway = _build_gateway(user)
+    timezone_str = user.timezone or "UTC"
+
+    created = await self_management_jobs_service.create_job(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        name="Created job",
+        agent_id=first_agent.id,
+        prompt="Run this",
+        cycle_type="daily",
+        time_point={"time": "09:45"},
+        enabled=True,
+        conversation_policy="reuse_single",
+        timezone_str=timezone_str,
+    )
+
+    assert created.name == "Created job"
+    assert created.conversation_policy == "reuse_single"
+
+    updated = await self_management_jobs_service.update_job(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        task_id=created.id,
+        timezone_str=timezone_str,
+        name="Updated job",
+        agent_id=second_agent.id,
+        enabled=False,
+        conversation_policy="new_each_run",
+    )
+
+    assert updated.name == "Updated job"
+    assert updated.agent_id == second_agent.id
+    assert updated.enabled is False
+    assert updated.conversation_policy == "new_each_run"
+
+    await self_management_jobs_service.delete_job(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        task_id=created.id,
+    )
+
+    items, _total = await self_management_jobs_service.list_jobs(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        page=1,
+        size=20,
+    )
+    assert all(item.id != created.id for item in items)

--- a/backend/tests/sessions/test_me_sessions_routes.py
+++ b/backend/tests/sessions/test_me_sessions_routes.py
@@ -10,6 +10,10 @@ from app.db.models.agent_message import AgentMessage
 from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
 from app.features.schedules.service import a2a_schedule_service
+from app.features.self_management_shared.constants import (
+    SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID,
+    SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+)
 from app.features.sessions import router as me_sessions
 from app.features.sessions.service import session_hub_service
 from app.utils.timezone_util import utc_now
@@ -232,6 +236,59 @@ async def test_me_sessions_query_supports_agent_id_filter(
     assert len(payload["items"]) == 1
     assert payload["items"][0]["conversationId"] == str(session_a.id)
     assert payload["items"][0]["agent_id"] == str(agent_a.id)
+
+
+async def test_me_sessions_query_supports_built_in_agent_public_id_filter(
+    async_db_session,
+    async_session_maker,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    now = utc_now()
+
+    built_in_session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=SELF_MANAGEMENT_BUILT_IN_AGENT_INTERNAL_ID,
+        agent_source="builtin",
+        title="Built-in Session",
+        last_active_at=now,
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    other_session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=uuid4(),
+        agent_source="personal",
+        title="Other Session",
+        last_active_at=now - timedelta(minutes=1),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(built_in_session)
+    async_db_session.add(other_session)
+    await async_db_session.commit()
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.post(
+            "/me/conversations:query",
+            json={
+                "page": 1,
+                "size": 20,
+                "agent_id": SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID,
+            },
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["pagination"]["total"] == 1
+    assert len(payload["items"]) == 1
+    assert payload["items"][0]["conversationId"] == str(built_in_session.id)
+    assert payload["items"][0]["agent_id"] == SELF_MANAGEMENT_BUILT_IN_AGENT_PUBLIC_ID
 
 
 async def test_me_sessions_cancel_returns_accepted_for_inflight_task(

--- a/backend/tests/sessions/test_self_management_sessions_service.py
+++ b/backend/tests/sessions/test_self_management_sessions_service.py
@@ -97,3 +97,63 @@ async def test_self_management_sessions_service_list_respects_filters(
     assert len(items) == 1
     assert items[0]["conversationId"] == str(kept_thread.id)
     assert items[0]["source"] == "scheduled"
+
+
+async def test_self_management_sessions_service_update_archive_and_unarchive(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session)
+    thread = await create_conversation_thread(
+        async_db_session,
+        user_id=user.id,
+        title="Rename Me",
+    )
+    gateway = _build_gateway(user)
+
+    updated = await self_management_sessions_service.update_session(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        conversation_id=str(thread.id),
+        title="Renamed Session",
+    )
+    archived = await self_management_sessions_service.archive_session(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        conversation_id=str(thread.id),
+    )
+    active_items, active_extra, _ = (
+        await self_management_sessions_service.list_sessions(
+            db=async_db_session,
+            gateway=gateway,
+            current_user=user,
+            page=1,
+            size=20,
+        )
+    )
+    archived_items, archived_extra, _ = (
+        await self_management_sessions_service.list_sessions(
+            db=async_db_session,
+            gateway=gateway,
+            current_user=user,
+            page=1,
+            size=20,
+            status="archived",
+        )
+    )
+    restored = await self_management_sessions_service.unarchive_session(
+        db=async_db_session,
+        gateway=gateway,
+        current_user=user,
+        conversation_id=str(thread.id),
+    )
+
+    assert updated["title"] == "Renamed Session"
+    assert updated["status"] == "active"
+    assert archived["status"] == "archived"
+    assert active_extra["pagination"]["total"] == 0
+    assert active_items == []
+    assert archived_extra["pagination"]["total"] == 1
+    assert archived_items[0]["conversationId"] == str(thread.id)
+    assert restored["status"] == "active"


### PR DESCRIPTION
## 关联 issues

Closes #785
Closes #786
Related #757

## 变更说明

### backend/app/core/config.py
- 将 `SELF_MANAGEMENT_SWIVAL_DELEGATED_TOKEN_TTL_SECONDS` 默认值调整为 `1800` 秒，使 delegated token 生命周期与 built-in runtime session TTL 更协调
- 修正 settings security baseline 测试基线环境，使其与当前 production baseline 约束一致

### backend/app/features/self_management_agent/service.py
- 在 built-in self-management runtime 中记录 delegated token 过期时间
- 会话复用前检查 token 是否临近过期，必要时自动重建 swival session
- 当 swival 返回 MCP/tool transport 错误时，显式失效 runtime session 并向上抛出结构化错误
- 在 write-approved 路径上，如果模型再次请求 write approval，显式视为 runtime 协议错误，避免重复 agent 回复继续落库

### backend/app/features/sessions/router.py / schemas.py
- `POST /api/v1/me/conversations:query` 的 `agent_id` 现在支持 built-in self-management assistant 的 public id
- 在路由层将 built-in public id 映射为内部 UUID，再复用现有查询逻辑

### backend/app/features/personal_agents/self_management_agents_service.py
- 新增当前用户 agent 的健康检查能力：`check_health` / `check_health_all`
- 新增当前用户 agent 的创建能力：`create`
- 新增当前用户 agent 的软删能力：`delete`
- 扩展 `update_config` 支持的认证相关配置字段

### backend/app/features/schedules/self_management_jobs_service.py
- 新增当前用户 job 的创建能力：`create`
- 新增当前用户 job 的综合更新能力：`update`
- 新增当前用户 job 的软删能力：`delete`
- 继续只接受 canonical `conversation_policy` 枚举：`new_each_run` / `reuse_single`

### backend/app/features/sessions/self_management_sessions_service.py
- 新增 session 标题更新能力：`update`
- 新增 session 归档能力：`archive`
- 新增 session 恢复能力：`unarchive`
- `list` 支持 `active / archived / all` 过滤

### backend/app/features/self_management_shared/*
- 扩展 capability catalog，补齐 agents/jobs/sessions 的新增 operation
- 扩展 tool contract，明确新增输入 schema 与 canonical `conversation_policy` 枚举
- 扩展 MCP surface，使新增能力可通过 built-in runtime / MCP 调用
- 扩展 toolkit，将新增能力接到对应 domain services

### backend/tests/*
- 新增 built-in runtime token 过期后自动重建 session 的回归测试
- 新增 MCP 401 / transport 错误显式失败的回归测试
- 新增 reply 后重复 approval sentinel 被拒绝的回归测试
- 新增 built-in self-management assistant public id 查询会话列表的路由测试
- 新增 personal agents / schedules / sessions / MCP / toolkit / built-in agent 的能力面回归测试
- 更新 built-in agent 的 tool surface 与 interrupt pattern 断言，覆盖新增能力面

## 验证

### backend scoped checks
- `cd backend && uv run --locked pre-commit run --files app/core/config.py app/features/personal_agents/self_management_agents_service.py app/features/schedules/self_management_jobs_service.py app/features/self_management_agent/service.py app/features/self_management_shared/capability_catalog.py app/features/self_management_shared/self_management_mcp.py app/features/self_management_shared/self_management_tool_contract.py app/features/self_management_shared/self_management_toolkit.py app/features/sessions/router.py app/features/sessions/schemas.py app/features/sessions/self_management_sessions_service.py tests/personal_agents/test_self_management_agents_service.py tests/runtime/test_self_management_actor_context.py tests/runtime/test_self_management_built_in_agent.py tests/runtime/test_self_management_mcp.py tests/runtime/test_self_management_tool_contract.py tests/runtime/test_self_management_toolkit.py tests/runtime/test_settings_security_baseline.py tests/schedules/test_self_management_jobs_service.py tests/sessions/test_me_sessions_routes.py tests/sessions/test_self_management_sessions_service.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/personal_agents/test_self_management_agents_service.py tests/runtime/test_self_management_actor_context.py tests/runtime/test_self_management_built_in_agent.py tests/runtime/test_self_management_mcp.py tests/runtime/test_self_management_tool_contract.py tests/runtime/test_self_management_toolkit.py tests/runtime/test_settings_security_baseline.py tests/schedules/test_self_management_jobs_service.py tests/sessions/test_me_sessions_routes.py tests/sessions/test_self_management_sessions_service.py`

结果：`112 passed`

## 风险与边界

- 本 PR 只覆盖 backend self-management 相关收敛，不调整 frontend 中更大范围的入口组织方式
- 不包含本地调试专用的默认 write-tools 放开逻辑
- 不包含 `_dev schema` 命名支持
