### PR TITLE
fix(backend): downgrade unsupported upstream streaming to blocking invoke

### DIFF
--- a/backend/app/integrations/a2a_client/adapters/sdk.py
+++ b/backend/app/integrations/a2a_client/adapters/sdk.py
@@ -126,6 +126,9 @@ class SDKA2AAdapter(A2AAdapter):
                 raise _map_protocol_error(exc) from exc
 
     async def stream_message(self, request: A2AMessageRequest) -> AsyncIterator[Any]:
+        if not bool(getattr(self.descriptor, "supports_streaming", True)):
+            yield await self.send_message(request)
+            return
         async with self._operation_usage(), self._transport_usage():
             client = await self._get_client(streaming=True)
             try:

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -43,6 +43,7 @@ from app.integrations.a2a_client.errors import (
     A2AClientResetRequiredError,
     A2AOutboundNotAllowedError,
     A2APeerProtocolError,
+    A2AStreamingNotSupportedError,
     A2AUnsupportedBindingError,
     A2AUnsupportedOperationError,
     A2AUpstreamTimeoutError,
@@ -715,6 +716,7 @@ class A2AClient:
     ) -> AsyncIterator[Any]:
         descriptor = await self._get_peer_descriptor()
         last_error: Exception | None = None
+        should_downgrade_to_blocking = False
         for dialect in await self._get_preferred_dialects(descriptor):
             adapter = await self._get_adapter(dialect)
             did_reset_adapter = False
@@ -771,11 +773,26 @@ class A2AClient:
                     except Exception as retry_exc:  # noqa: BLE001
                         exc = retry_exc
                 last_error = exc
+                should_downgrade_to_blocking = (
+                    not yielded_payload
+                    and self._should_fallback_stream_to_blocking(exc)
+                )
                 if not self._should_try_alternate_dialect(
                     descriptor=descriptor,
                     dialect=dialect,
                     exc=exc,
                 ):
+                    if should_downgrade_to_blocking:
+                        logger.info(
+                            "Downgrading A2A stream to blocking invoke",
+                            extra={
+                                "agent_url": redact_url_for_logging(self.agent_url),
+                                "failed_dialect": dialect,
+                                "error_type": type(exc).__name__,
+                                "error_code": getattr(exc, "error_code", None),
+                            },
+                        )
+                        break
                     raise
                 await self._discard_adapter(dialect, expected_adapter=adapter)
                 logger.info(
@@ -786,6 +803,9 @@ class A2AClient:
                     },
                 )
                 continue
+        if should_downgrade_to_blocking:
+            yield await self._send_with_fallback(request)
+            return
         if last_error is not None:
             raise last_error
 
@@ -1037,7 +1057,34 @@ class A2AClient:
         if dialect != JSONRPC_SLASH_DIALECT:
             return False
         if isinstance(exc, A2APeerProtocolError):
-            return exc.error_code == "method_not_found" or exc.code == -32601
+            return (
+                exc.error_code in {"method_not_found", "method_not_supported"}
+                or exc.code == -32601
+            )
+        return False
+
+    @staticmethod
+    def _should_fallback_stream_to_blocking(exc: Exception) -> bool:
+        message = str(exc).lower()
+        if isinstance(exc, A2AStreamingNotSupportedError):
+            return True
+        if isinstance(exc, A2AUnsupportedOperationError):
+            return (
+                getattr(exc, "error_code", None) == "streaming_not_supported"
+                or "stream" in message
+            )
+        if not isinstance(exc, A2APeerProtocolError):
+            return False
+        if exc.error_code in {
+            "method_not_found",
+            "method_not_supported",
+            "streaming_not_supported",
+        }:
+            return True
+        if exc.code == -32601:
+            return True
+        if getattr(exc, "error_code", None) == "unsupported_operation":
+            return "stream" in message
         return False
 
     async def _fetch_authenticated_extended_agent_card(

--- a/backend/tests/client/test_a2a_client.py
+++ b/backend/tests/client/test_a2a_client.py
@@ -972,6 +972,46 @@ async def test_stream_agent_maps_connect_timeout_to_timeout() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_with_fallback_downgrades_to_blocking_when_streaming_is_not_supported() -> (
+    None
+):
+    request = client_module.A2AMessageRequest(query="hello", context_id="ctx-1")
+    descriptor = SimpleNamespace(
+        agent_url="http://example-agent.internal:24020",
+        card_fingerprint="fp-1",
+        selected_transport="JSONRPC",
+    )
+
+    class _UnsupportedStreamAdapter:
+        async def stream_message(self, _request):
+            raise A2APeerProtocolError(
+                "Unknown method: SendStreamingMessage",
+                error_code="method_not_supported",
+                rpc_code=-32601,
+            )
+            yield  # pragma: no cover
+
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_peer_descriptor = AsyncMock(return_value=descriptor)
+    a2a_client._get_preferred_dialects = AsyncMock(
+        return_value=[
+            client_module.JSONRPC_SLASH_DIALECT,
+            client_module.JSONRPC_PASCAL_DIALECT,
+        ]
+    )
+    a2a_client._get_adapter = AsyncMock(return_value=_UnsupportedStreamAdapter())
+    a2a_client._discard_adapter = AsyncMock()
+    a2a_client._send_with_fallback = AsyncMock(
+        return_value={"parts": [{"text": "fallback-result"}]}
+    )
+
+    events = [payload async for payload in a2a_client._stream_with_fallback(request)]
+
+    assert events == [{"parts": [{"text": "fallback-result"}]}]
+    a2a_client._send_with_fallback.assert_awaited_once_with(request)
+
+
+@pytest.mark.asyncio
 async def test_cancel_task_returns_success_for_valid_request() -> None:
     a2a_client = A2AClient("http://example-agent.internal:24020")
     a2a_client._cancel_with_fallback = AsyncMock(return_value={"id": "task-1"})

--- a/backend/tests/client/test_a2a_client_interoperability.py
+++ b/backend/tests/client/test_a2a_client_interoperability.py
@@ -954,6 +954,49 @@ async def test_sdk_http_json_adapter_send_message_uses_sdk_transport_defaults(
 
 
 @pytest.mark.asyncio
+async def test_sdk_http_json_adapter_stream_message_downgrades_when_peer_disables_streaming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeFactory:
+        def __init__(self, *, config, consumers) -> None:
+            captured["config"] = config
+            captured["consumers"] = consumers
+
+        def create(self, *_args, **_kwargs):
+            class FakeClient:
+                async def send_message(self, _message):
+                    yield {"event": "blocking-result"}
+
+                async def close(self) -> None:
+                    return None
+
+            return FakeClient()
+
+    monkeypatch.setattr(sdk_module, "ClientFactory", FakeFactory)
+
+    adapter = SDKA2AAdapter(
+        SimpleNamespace(
+            card=Mock(),
+            selected_transport="HTTP+JSON",
+            supports_streaming=False,
+        ),
+        transport_http_client=AsyncMock(),
+    )
+
+    events: list[dict[str, str]] = []
+    async for payload in adapter.stream_message(
+        client_module.A2AMessageRequest(query="hello", context_id="ctx-1")
+    ):
+        events.append(payload)
+
+    assert events == [{"event": "blocking-result"}]
+    assert captured["config"].streaming is False
+    await adapter.close()
+
+
+@pytest.mark.asyncio
 async def test_sdk_http_json_adapter_get_task_forwards_history_length_and_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/invoke/test_a2a_invoke_service.py
+++ b/backend/tests/invoke/test_a2a_invoke_service.py
@@ -1663,6 +1663,38 @@ async def test_consume_stream_finalized_callback_failure_is_isolated(caplog):
 
 
 @pytest.mark.asyncio
+async def test_consume_stream_accepts_single_blocking_message_payload() -> None:
+    result = await a2a_invoke_service.consume_stream(
+        gateway=_GatewayWithEvents(
+            [
+                {
+                    "kind": "message",
+                    "message_id": "msg-blocking-1",
+                    "task_id": "task-blocking-1",
+                    "parts": [{"type": "text", "text": "blocking-result"}],
+                    "metadata": {
+                        "event_id": "evt-blocking-1",
+                        "block_type": "text",
+                    },
+                }
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+    )
+
+    assert result.success is True
+    assert result.finish_reason == StreamFinishReason.SUCCESS
+    assert result.final_text == "blocking-result"
+    assert result.terminal_event_seen is False
+
+
+@pytest.mark.asyncio
 async def test_send_ws_error_ignores_closed_socket_runtime_error() -> None:
     websocket = _ClosedWebSocket()
     await a2a_invoke_service.send_ws_error(

--- a/backend/tests/invoke/test_invoke_route_runner.py
+++ b/backend/tests/invoke/test_invoke_route_runner.py
@@ -690,6 +690,99 @@ async def test_run_http_invoke_uses_recovered_state_context_id_for_upstream_requ
 
 
 @pytest.mark.asyncio
+async def test_run_http_invoke_non_stream_accepts_blocking_message_payload_via_consume_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Gateway:
+        async def stream(self, **kwargs):  # noqa: ARG002
+            yield SimpleNamespace(
+                model_dump=lambda exclude_none=True: {  # noqa: ARG005
+                    "kind": "message",
+                    "message_id": "msg-run-http-invoke-1",
+                    "task_id": "task-run-http-invoke-1",
+                    "parts": [{"type": "text", "text": "downgraded result"}],
+                    "metadata": {
+                        "event_id": "evt-run-http-invoke-1",
+                        "block_type": "text",
+                    },
+                }
+            )
+
+    async def fake_prepare_state(**kwargs):  # noqa: ARG001
+        return invoke_route_runner._InvokeState(
+            local_session_id=None,
+            local_source=None,
+            context_id=None,
+            metadata={},
+            stream_identity={},
+            stream_usage={},
+        )
+
+    async def fake_persist_stream_block_update(**kwargs):  # noqa: ARG001
+        return None
+
+    async def fake_persist_interrupt_lifecycle_event(**kwargs):  # noqa: ARG001
+        return None
+
+    async def fake_flush_stream_buffer(**kwargs):  # noqa: ARG001
+        return None
+
+    async def fake_persist_local_outcome(**kwargs):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(invoke_route_runner, "_prepare_state", fake_prepare_state)
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_persist_stream_block_update",
+        fake_persist_stream_block_update,
+    )
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_persist_interrupt_lifecycle_event",
+        fake_persist_interrupt_lifecycle_event,
+    )
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_flush_stream_buffer",
+        fake_flush_stream_buffer,
+    )
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_persist_local_outcome",
+        fake_persist_local_outcome,
+    )
+
+    payload = A2AAgentInvokeRequest.model_validate(
+        {
+            "query": "hello",
+            "conversationId": str(uuid4()),
+            "metadata": {},
+        }
+    )
+    runtime = SimpleNamespace(
+        resolved=SimpleNamespace(name="Demo Agent", url="https://example.com/a2a")
+    )
+
+    response = await invoke_route_runner.run_http_invoke(
+        gateway=_Gateway(),
+        runtime=runtime,
+        user_id=uuid4(),
+        agent_id=uuid4(),
+        agent_source="shared",
+        payload=payload,
+        stream=False,
+        validate_message=lambda _: [],
+        logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+        log_extra={},
+    )
+
+    assert isinstance(response, A2AAgentInvokeResponse)
+    assert response.success is True
+    assert response.content == "downgraded result"
+    assert response.error is None
+
+
+@pytest.mark.asyncio
 async def test_run_http_invoke_returns_structured_error_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 关联 Issues

- Closes #790

## 模块变更

### backend/app/integrations/a2a_client/client.py

- 在 `A2AClient._stream_with_fallback()` 增加运行时流式不支持判定
- 当流式调用在尚未产出任何 stream payload 前返回 `method_not_supported` / `streaming_not_supported` / `-32601` 时，统一降级为阻塞式 `send_message()`
- 保留现有 JSON-RPC slash -> pascal 的方言切换逻辑，仅在无法继续流式时才回退到阻塞调用

### backend/app/integrations/a2a_client/adapters/sdk.py

- 为 SDK `stream_message()` 补充 `supports_streaming=False` 保护
- 避免对 `HTTP+JSON` 非流式 peer 继续创建 `streaming=True` client

### backend/tests/client

- 在 `test_a2a_client.py` 增加 client 层统一降级回归测试
- 在 `test_a2a_client_interoperability.py` 增加 SDK 非流式 peer 保护回归测试

## 相关提交

- `31df60e` `fix(backend): fallback unsupported upstream streaming (#790)`

## 验证结果

- `cd backend && uv run --locked pre-commit run --files app/integrations/a2a_client/client.py app/integrations/a2a_client/adapters/sdk.py tests/client/test_a2a_client.py tests/client/test_a2a_client_interoperability.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/client/test_a2a_client.py tests/client/test_a2a_client_interoperability.py`
  - `73 passed in 0.69s`

## 风险与说明

- 当前降级只在“尚未向上游消费到任何 stream payload”时触发，避免半流式阶段改变响应语义
- 现有改动覆盖 client 层和互操作层；本 PR 未额外引入 route_runner / invoke service 端到端用例
