### PR TITLE
fix(self-management): harden built-in interrupt expiry handling (#792)

### DIFF
--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -524,7 +524,7 @@ def extract_interrupt_lifecycle_from_serialized_event(
     }
     if phase == "resolved":
         resolution = _pick_non_empty_str(interrupt, ("resolution",))
-        if resolution not in {"replied", "rejected"}:
+        if resolution not in {"replied", "rejected", "expired"}:
             return None
         payload_event["resolution"] = resolution
         return payload_event

--- a/backend/app/features/self_management_agent/router.py
+++ b/backend/app/features/self_management_agent/router.py
@@ -6,6 +6,7 @@ from fastapi import Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import get_async_db, get_current_user
+from app.api.error_handlers import build_error_detail
 from app.api.routing import StrictAPIRouter
 from app.core.logging import get_logger
 from app.db.models.user import User
@@ -34,6 +35,22 @@ router = StrictAPIRouter(
     tags=["self-management-agent"],
 )
 logger = get_logger(__name__)
+
+_BUILT_IN_PERMISSION_REPLY_INVALID_OR_EXPIRED_DETAIL = (
+    "The write approval request is invalid or expired."
+)
+
+
+def _permission_reply_error_detail(
+    exc: SelfManagementBuiltInAgentUnavailableError,
+) -> str | dict[str, str]:
+    message = str(exc)
+    if message == _BUILT_IN_PERMISSION_REPLY_INVALID_OR_EXPIRED_DETAIL:
+        return build_error_detail(
+            message=message,
+            error_code="interrupt_request_expired",
+        )
+    return message
 
 
 def _to_run_response(
@@ -230,7 +247,7 @@ async def reply_self_management_built_in_agent_permission_interrupt(
         )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail=_permission_reply_error_detail(exc),
         ) from exc
     except Exception:
         logger.exception(

--- a/backend/app/features/self_management_agent/router.py
+++ b/backend/app/features/self_management_agent/router.py
@@ -184,6 +184,7 @@ async def recover_self_management_built_in_agent_interrupts(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(exc),
         ) from exc
+    await commit_safely(db)
 
     return SelfManagementBuiltInAgentInterruptRecoveryResponse(
         items=[

--- a/backend/app/features/self_management_agent/router.py
+++ b/backend/app/features/self_management_agent/router.py
@@ -43,14 +43,14 @@ _BUILT_IN_PERMISSION_REPLY_INVALID_OR_EXPIRED_DETAIL = (
 
 def _permission_reply_error_detail(
     exc: SelfManagementBuiltInAgentUnavailableError,
-) -> str | dict[str, str]:
+) -> tuple[int, str | dict[str, str]]:
     message = str(exc)
     if message == _BUILT_IN_PERMISSION_REPLY_INVALID_OR_EXPIRED_DETAIL:
-        return build_error_detail(
+        return status.HTTP_409_CONFLICT, build_error_detail(
             message=message,
             error_code="interrupt_request_expired",
         )
-    return message
+    return status.HTTP_400_BAD_REQUEST, message
 
 
 def _to_run_response(
@@ -237,6 +237,7 @@ async def reply_self_management_built_in_agent_permission_interrupt(
             detail=str(exc),
         ) from exc
     except SelfManagementBuiltInAgentUnavailableError as exc:
+        status_code, detail = _permission_reply_error_detail(exc)
         logger.exception(
             "Built-in self-management agent permission reply failed",
             extra={
@@ -246,8 +247,8 @@ async def reply_self_management_built_in_agent_permission_interrupt(
             },
         )
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=_permission_reply_error_detail(exc),
+            status_code=status_code,
+            detail=detail,
         ) from exc
     except Exception:
         logger.exception(

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -353,6 +353,8 @@ class SelfManagementBuiltInAgentService:
             interrupt = asked_interrupts.get(request_id)
             if interrupt is None:
                 continue
+            if verify_self_management_interrupt_token_claims(request_id) is None:
+                continue
             recovered.append(
                 SelfManagementBuiltInAgentRecoveredInterrupt(
                     request_id=request_id,

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -353,7 +353,16 @@ class SelfManagementBuiltInAgentService:
             interrupt = asked_interrupts.get(request_id)
             if interrupt is None:
                 continue
-            if verify_self_management_interrupt_token_claims(request_id) is None:
+            claims = verify_self_management_interrupt_token_claims(request_id)
+            if claims is None:
+                continue
+            if claims.subject != str(current_user.id):
+                continue
+            if get_self_management_interrupt_conversation_id(claims) != str(
+                resolved_conversation_id
+            ):
+                continue
+            if get_self_management_interrupt_message(claims) is None:
                 continue
             recovered.append(
                 SelfManagementBuiltInAgentRecoveredInterrupt(

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -329,6 +329,7 @@ class SelfManagementBuiltInAgentService:
 
         asked_interrupts: dict[str, dict[str, Any]] = {}
         ordered_request_ids: list[str] = []
+        expired_request_ids: list[str] = []
         for message in rows:
             metadata = cast(dict[str, Any], message.message_metadata or {})
             interrupt = normalize_interrupt_lifecycle_event(
@@ -355,14 +356,18 @@ class SelfManagementBuiltInAgentService:
                 continue
             claims = verify_self_management_interrupt_token_claims(request_id)
             if claims is None:
+                expired_request_ids.append(request_id)
                 continue
             if claims.subject != str(current_user.id):
+                expired_request_ids.append(request_id)
                 continue
             if get_self_management_interrupt_conversation_id(claims) != str(
                 resolved_conversation_id
             ):
+                expired_request_ids.append(request_id)
                 continue
             if get_self_management_interrupt_message(claims) is None:
+                expired_request_ids.append(request_id)
                 continue
             recovered.append(
                 SelfManagementBuiltInAgentRecoveredInterrupt(
@@ -371,6 +376,15 @@ class SelfManagementBuiltInAgentService:
                     type=cast(str, interrupt["type"]),
                     details=cast(dict[str, Any], interrupt.get("details") or {}),
                 )
+            )
+
+        for request_id in expired_request_ids:
+            await self._persist_interrupt_resolution(
+                db=db,
+                current_user=current_user,
+                conversation_id=str(resolved_conversation_id),
+                request_id=request_id,
+                resolution="expired",
             )
         return recovered
 

--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -239,7 +239,7 @@ def normalize_interrupt_lifecycle_event(
     }
     if phase == "resolved":
         resolution = normalize_non_empty_text(event.get("resolution"))
-        if resolution not in {"replied", "rejected"}:
+        if resolution not in {"replied", "rejected", "expired"}:
             return None
         normalized["resolution"] = resolution
         return normalized
@@ -277,6 +277,12 @@ def build_interrupt_lifecycle_message_code(event: dict[str, Any]) -> str:
     interrupt_type = str(event.get("type") or "")
     phase = str(event.get("phase") or "")
     if phase == "resolved":
+        if event.get("resolution") == "expired":
+            if interrupt_type == "permission":
+                return "permission_expired"
+            if interrupt_type == "permissions":
+                return "permissions_expired"
+            return "question_expired"
         if interrupt_type == "permission":
             return "permission_resolved"
         if interrupt_type == "permissions":
@@ -299,6 +305,14 @@ def build_interrupt_lifecycle_message_code(event: dict[str, Any]) -> str:
 
 def build_interrupt_lifecycle_message_content(event: dict[str, Any]) -> str:
     message_code = build_interrupt_lifecycle_message_code(event)
+    if message_code == "permission_expired":
+        return "Authorization request expired. Interrupt closed."
+    if message_code == "permissions_expired":
+        return "Permissions request expired. Interrupt closed."
+    if message_code == "question_expired":
+        if str(event.get("type") or "") == "elicitation":
+            return "Additional input request expired. Interrupt closed."
+        return "Question request expired. Interrupt closed."
     if message_code == "permission_resolved":
         return "Authorization request was handled. Agent resumed."
     if message_code == "permissions_resolved":

--- a/backend/app/features/sessions/schemas.py
+++ b/backend/app/features/sessions/schemas.py
@@ -175,7 +175,7 @@ class InterruptViewItem(BaseModel):
     request_id: str = Field(alias="requestId")
     type: Literal["permission", "question", "permissions", "elicitation"]
     phase: Literal["asked", "resolved"]
-    resolution: Optional[Literal["replied", "rejected"]] = None
+    resolution: Optional[Literal["replied", "rejected", "expired"]] = None
     details: Optional[InterruptDetailsItem] = None
 
     model_config = {"populate_by_name": True}

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1293,6 +1293,78 @@ async def test_built_in_agent_interrupt_recovery_route_returns_unresolved_interr
     ]
 
 
+async def test_built_in_agent_interrupt_recovery_route_persists_expired_interrupts(
+    async_session_maker,
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+    persisted_user_id = cast(Any, user.id)
+    conversation_id = _new_conversation_id()
+    _FakeSwivalSession.next_answer = (
+        "I can pause the requested job after you approve write access.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    interrupt_result = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Pause my job",
+        allow_write_tools=False,
+    )
+    assert interrupt_result.interrupt is not None
+    await async_db_session.commit()
+
+    original_verify = (
+        self_management_agent_service_module.verify_self_management_interrupt_token_claims
+    )
+    invalid_request_id = interrupt_result.interrupt.request_id
+    monkeypatch.setattr(
+        self_management_agent_service_module,
+        "verify_self_management_interrupt_token_claims",
+        lambda token: None if token == invalid_request_id else original_verify(token),
+    )
+
+    async with create_test_client(
+        self_management_agent_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as client:
+        response = await client.post(
+            f"{settings.api_v1_prefix}/me/self-management/agent/interrupts:recover",
+            json={"conversationId": conversation_id},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+
+    await async_db_session.rollback()
+    system_messages = list(
+        (
+            await async_db_session.scalars(
+                select(AgentMessage)
+                .where(
+                    AgentMessage.user_id == persisted_user_id,
+                    AgentMessage.conversation_id == UUID(conversation_id),
+                    AgentMessage.sender == "system",
+                )
+                .order_by(AgentMessage.created_at.asc(), AgentMessage.id.asc())
+            )
+        ).all()
+    )
+    assert len(system_messages) == 2
+    resolved_interrupt = cast(dict[str, Any], system_messages[1].message_metadata)[
+        "interrupt"
+    ]
+    assert resolved_interrupt["phase"] == "resolved"
+    assert resolved_interrupt["resolution"] == "expired"
+
+
 async def test_built_in_agent_recovery_skips_invalid_interrupt_requests(
     async_db_session,
     monkeypatch: pytest.MonkeyPatch,
@@ -1333,6 +1405,26 @@ async def test_built_in_agent_recovery_skips_invalid_interrupt_requests(
     )
 
     assert recovered == []
+
+    system_messages = list(
+        (
+            await async_db_session.scalars(
+                select(AgentMessage)
+                .where(
+                    AgentMessage.user_id == cast(Any, user.id),
+                    AgentMessage.conversation_id == UUID(conversation_id),
+                    AgentMessage.sender == "system",
+                )
+                .order_by(AgentMessage.created_at.asc(), AgentMessage.id.asc())
+            )
+        ).all()
+    )
+    assert len(system_messages) == 2
+    resolved_interrupt = cast(dict[str, Any], system_messages[1].message_metadata)[
+        "interrupt"
+    ]
+    assert resolved_interrupt["phase"] == "resolved"
+    assert resolved_interrupt["resolution"] == "expired"
 
 
 async def test_built_in_agent_recovery_skips_interrupts_for_other_conversations(

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1293,6 +1293,73 @@ async def test_built_in_agent_interrupt_recovery_route_returns_unresolved_interr
     ]
 
 
+async def test_built_in_agent_recovery_skips_invalid_interrupt_requests(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+    _FakeSwivalSession.next_answer = (
+        "I can pause the requested job after you approve write access.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    interrupt_result = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Pause my job",
+        allow_write_tools=False,
+    )
+    assert interrupt_result.interrupt is not None
+
+    original_verify = (
+        self_management_agent_service_module.verify_self_management_interrupt_token_claims
+    )
+    invalid_request_id = interrupt_result.interrupt.request_id
+    monkeypatch.setattr(
+        self_management_agent_service_module,
+        "verify_self_management_interrupt_token_claims",
+        lambda token: None if token == invalid_request_id else original_verify(token),
+    )
+
+    recovered = await self_management_built_in_agent_service.recover_pending_interrupts(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+    )
+
+    assert recovered == []
+
+
+async def test_built_in_agent_permission_reply_route_returns_terminal_error_code_for_expired_request(
+    async_session_maker,
+    async_db_session,
+) -> None:
+    _reset_built_in_agent_runtime()
+    user = await create_user(async_db_session)
+
+    async with create_test_client(
+        self_management_agent_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as client:
+        response = await client.post(
+            f"{settings.api_v1_prefix}/me/self-management/agent/interrupts/permission:reply",
+            json={"requestId": "expired-request", "reply": "always"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "message": "The write approval request is invalid or expired.",
+        "error_code": "interrupt_request_expired",
+    }
+
+
 async def test_built_in_agent_permission_reply_route_logs_traceback_for_unavailable_error(
     async_session_maker,
     async_db_session,

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1353,7 +1353,7 @@ async def test_built_in_agent_permission_reply_route_returns_terminal_error_code
             json={"requestId": "expired-request", "reply": "always"},
         )
 
-    assert response.status_code == 400
+    assert response.status_code == 409
     assert response.json()["detail"] == {
         "message": "The write approval request is invalid or expired.",
         "error_code": "interrupt_request_expired",

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1335,6 +1335,44 @@ async def test_built_in_agent_recovery_skips_invalid_interrupt_requests(
     assert recovered == []
 
 
+async def test_built_in_agent_recovery_skips_interrupts_for_other_conversations(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+    _FakeSwivalSession.next_answer = (
+        "I can pause the requested job after you approve write access.\n"
+        f"{_WRITE_APPROVAL_SENTINEL}"
+    )
+
+    interrupt_result = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Pause my job",
+        allow_write_tools=False,
+    )
+    assert interrupt_result.interrupt is not None
+
+    monkeypatch.setattr(
+        self_management_agent_service_module,
+        "get_self_management_interrupt_conversation_id",
+        lambda _claims: str(uuid4()),
+    )
+
+    recovered = await self_management_built_in_agent_service.recover_pending_interrupts(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+    )
+
+    assert recovered == []
+
+
 async def test_built_in_agent_permission_reply_route_returns_terminal_error_code_for_expired_request(
     async_session_maker,
     async_db_session,

--- a/frontend/components/chat/__tests__/InterruptEventBlock.test.tsx
+++ b/frontend/components/chat/__tests__/InterruptEventBlock.test.tsx
@@ -73,6 +73,37 @@ describe("InterruptEventBlock", () => {
     ).toBeTruthy();
   });
 
+  it("renders expired interrupt with expired badge", () => {
+    const block: MessageBlock = {
+      id: "interrupt-expired-1",
+      type: "interrupt_event",
+      content: "Authorization request expired. Interrupt closed.",
+      isFinished: true,
+      interrupt: {
+        requestId: "perm-3",
+        type: "permission",
+        phase: "resolved",
+        resolution: "expired",
+      },
+      createdAt: "2026-03-23T00:00:00.000Z",
+      updatedAt: "2026-03-23T00:00:00.000Z",
+    };
+
+    const screen = render(
+      <InterruptEventBlock
+        block={block}
+        fallbackBlockId="interrupt-fallback-expired"
+        isFirst
+      />,
+    );
+
+    expect(screen.getByText("Authorization update")).toBeTruthy();
+    expect(screen.getByText("Expired")).toBeTruthy();
+    expect(
+      screen.getByText("Authorization request expired. Interrupt closed."),
+    ).toBeTruthy();
+  });
+
   it("renders asked permissions interrupt with structured payload details", () => {
     const block: MessageBlock = {
       id: "interrupt-asked-2",

--- a/frontend/components/chat/blocks/InterruptEventBlock.tsx
+++ b/frontend/components/chat/blocks/InterruptEventBlock.tsx
@@ -25,12 +25,20 @@ const BADGE_STYLES = {
     text: "text-rose-200",
     label: "Rejected",
   },
+  expired: {
+    container: "border-slate-400/30 bg-slate-500/10",
+    text: "text-slate-200",
+    label: "Expired",
+  },
 } as const;
 
 const resolveBadgeTone = (block: MessageBlock): keyof typeof BADGE_STYLES => {
   const interrupt = block.interrupt;
   if (!interrupt) {
     return "actionRequired";
+  }
+  if (interrupt.phase === "resolved" && interrupt.resolution === "expired") {
+    return "expired";
   }
   if (interrupt.phase === "resolved" && interrupt.resolution === "rejected") {
     return "rejected";

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -23,7 +23,7 @@ const TERMINAL_INTERRUPT_ERROR_CODES = new Set([
 type ResolvedInterruptKeyInput = {
   requestId: string;
   type: "permission" | "question" | "permissions" | "elicitation";
-  resolution: "replied" | "rejected";
+  resolution: "replied" | "rejected" | "expired";
 };
 
 type UseChatInterruptControllerParams = {
@@ -144,18 +144,37 @@ export function useChatInterruptController({
   const buildResolvedInterruptFeedback = useCallback(
     (interrupt: ResolvedRuntimeInterruptRecord) => {
       if (interrupt.type === "permission") {
+        if (interrupt.resolution === "expired") {
+          return {
+            title: "Interrupt resolved",
+            message: "Authorization request expired and was closed.",
+          };
+        }
         return {
           title: "Interrupt resolved",
           message: "Authorization request was handled.",
         };
       }
       if (interrupt.type === "permissions") {
+        if (interrupt.resolution === "expired") {
+          return {
+            title: "Interrupt resolved",
+            message: "Permissions request expired and was closed.",
+          };
+        }
         return {
           title: "Interrupt resolved",
           message: "Permissions request was handled.",
         };
       }
       if (interrupt.type === "elicitation") {
+        if (interrupt.resolution === "expired") {
+          return {
+            title: "Interrupt resolved",
+            message:
+              "Additional input request expired and the interrupt is closed.",
+          };
+        }
         if (interrupt.resolution === "rejected") {
           return {
             title: "Interrupt resolved",
@@ -166,6 +185,12 @@ export function useChatInterruptController({
         return {
           title: "Interrupt resolved",
           message: "Additional input submitted. Agent resumed.",
+        };
+      }
+      if (interrupt.resolution === "expired") {
+        return {
+          title: "Interrupt resolved",
+          message: "Question request expired and the interrupt is closed.",
         };
       }
       if (interrupt.resolution === "rejected") {

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -998,6 +998,7 @@ export function useChatScreenController({
         });
         replaceRecoveredInterrupts(nextConversationId, result.items, {
           sessionId: resolvedSessionId,
+          replaceAllForConversation: true,
         });
       } catch (error) {
         console.warn("[Chat] built-in interrupt recovery failed", {

--- a/frontend/lib/api/chat-utils.ts
+++ b/frontend/lib/api/chat-utils.ts
@@ -240,7 +240,7 @@ export type PendingRuntimeInterrupt = RuntimeInterruptBase & {
 
 export type ResolvedRuntimeInterrupt = RuntimeInterruptBase & {
   phase: "resolved";
-  resolution: "replied" | "rejected";
+  resolution: "replied" | "rejected" | "expired";
 };
 
 export type RuntimeInterrupt =
@@ -304,7 +304,9 @@ const isRuntimeInterrupt = (value: unknown): value is RuntimeInterrupt => {
   }
   if (candidate.phase === "resolved") {
     return (
-      candidate.resolution === "replied" || candidate.resolution === "rejected"
+      candidate.resolution === "replied" ||
+      candidate.resolution === "rejected" ||
+      candidate.resolution === "expired"
     );
   }
   if (candidate.phase !== "asked") {
@@ -918,7 +920,11 @@ const extractRuntimeInterrupt = (
     (isInputRequiredRuntimeState(runtimeState, contract) ? "asked" : null);
   if (phase === "resolved") {
     const resolution = pickString(interrupt, ["resolution"])?.toLowerCase();
-    if (resolution !== "replied" && resolution !== "rejected") {
+    if (
+      resolution !== "replied" &&
+      resolution !== "rejected" &&
+      resolution !== "expired"
+    ) {
       return null;
     }
     return {
@@ -1007,12 +1013,24 @@ const buildInterruptEventMessageCode = (
 ):
   | "permission_requested"
   | "permission_resolved"
+  | "permission_expired"
   | "permissions_requested"
   | "permissions_resolved"
+  | "permissions_expired"
   | "question_requested"
   | "question_answer_received"
-  | "question_rejected" => {
+  | "question_rejected"
+  | "question_expired" => {
   if (interrupt.phase === "resolved") {
+    if (interrupt.resolution === "expired") {
+      if (interrupt.type === "permission") {
+        return "permission_expired";
+      }
+      if (interrupt.type === "permissions") {
+        return "permissions_expired";
+      }
+      return "question_expired";
+    }
     if (interrupt.type === "permission") {
       return "permission_resolved";
     }
@@ -1051,11 +1069,23 @@ const stringifyInterruptObject = (value: unknown): string | null => {
 
 const buildInterruptEventContent = (interrupt: RuntimeInterrupt): string => {
   const messageCode = buildInterruptEventMessageCode(interrupt);
+  if (messageCode === "permission_expired") {
+    return "Authorization request expired. Interrupt closed.";
+  }
+  if (messageCode === "permissions_expired") {
+    return "Permissions request expired. Interrupt closed.";
+  }
   if (messageCode === "permission_resolved") {
     return "Authorization request was handled. Agent resumed.";
   }
   if (messageCode === "permissions_resolved") {
     return "Permissions request was handled. Agent resumed.";
+  }
+  if (messageCode === "question_expired") {
+    if (interrupt.type === "elicitation") {
+      return "Additional input request expired. Interrupt closed.";
+    }
+    return "Question request expired. Interrupt closed.";
   }
   if (messageCode === "question_rejected") {
     if (interrupt.type === "elicitation") {

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -1676,4 +1676,73 @@ describe("ChatScreen interrupt handling", () => {
       tree.unmount();
     });
   });
+
+  it("clears stale built-in permission interrupts when the reply request expired", async () => {
+    mockReplySelfManagementBuiltInAgentPermissionInterrupt.mockRejectedValueOnce(
+      new ApiRequestError("Bad Request", 400, {
+        errorCode: "interrupt_request_expired",
+        upstreamError: {
+          message: "The write approval request is invalid or expired.",
+        },
+      }),
+    );
+    mockChatState.sessions[conversationId] = {
+      ...baseSession(),
+      agentId: SELF_MANAGEMENT_AGENT_ID,
+      pendingInterrupt: {
+        requestId: "builtin-perm-stale-1",
+        type: "permission",
+        phase: "asked",
+        details: {
+          permission: "self-management-write",
+          patterns: ["self.jobs.pause"],
+          displayMessage: "Approve write access to continue.",
+        },
+      },
+      pendingInterrupts: [
+        {
+          requestId: "builtin-perm-stale-1",
+          type: "permission",
+          phase: "asked",
+          details: {
+            permission: "self-management-write",
+            patterns: ["self.jobs.pause"],
+            displayMessage: "Approve write access to continue.",
+          },
+        },
+      ],
+    };
+
+    const tree = renderChatScreen(conversationId, SELF_MANAGEMENT_AGENT_ID);
+    const root = tree.root;
+    const permissionButton = root.findByProps({
+      testID: "interrupt-permission-once",
+    });
+
+    await act(async () => {
+      await permissionButton.props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(
+      mockReplySelfManagementBuiltInAgentPermissionInterrupt,
+    ).toHaveBeenCalledWith({
+      requestId: "builtin-perm-stale-1",
+      reply: "once",
+      agentMessageId: expect.any(String),
+    });
+    expect(mockChatState.clearPendingInterrupt).toHaveBeenCalledWith(
+      conversationId,
+      "builtin-perm-stale-1",
+    );
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      "Interrupt closed",
+      "The interrupt request expired and was removed.",
+    );
+    expect(mockToastError).not.toHaveBeenCalled();
+
+    act(() => {
+      tree.unmount();
+    });
+  });
 });

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -757,7 +757,7 @@ describe("ChatScreen interrupt handling", () => {
           },
         },
       ],
-      { sessionId: conversationId },
+      { sessionId: conversationId, replaceAllForConversation: true },
     );
   });
 

--- a/frontend/store/__tests__/chatStoreIdempotency.test.ts
+++ b/frontend/store/__tests__/chatStoreIdempotency.test.ts
@@ -480,4 +480,45 @@ describe("chat store idempotency semantics", () => {
     ]);
     expect(session?.pendingInterrupt?.requestId).toBe("stream-1");
   });
+
+  it("replaceRecoveredInterrupts can replace all pending interrupts for a built-in conversation", () => {
+    useChatStore.getState().ensureSession("conv-builtin", "self-management");
+    useChatStore.setState((state) => ({
+      sessions: {
+        ...state.sessions,
+        "conv-builtin": {
+          ...state.sessions["conv-builtin"],
+          pendingInterrupts: [
+            {
+              requestId: "builtin-local-stale-1",
+              type: "permission",
+              phase: "asked",
+              details: {
+                permission: "self-management-write",
+                patterns: ["self.jobs.pause"],
+              },
+            },
+          ],
+          pendingInterrupt: {
+            requestId: "builtin-local-stale-1",
+            type: "permission",
+            phase: "asked",
+            details: {
+              permission: "self-management-write",
+              patterns: ["self.jobs.pause"],
+            },
+          },
+        },
+      },
+    }));
+
+    useChatStore.getState().replaceRecoveredInterrupts("conv-builtin", [], {
+      sessionId: "conv-builtin",
+      replaceAllForConversation: true,
+    });
+
+    const session = useChatStore.getState().sessions["conv-builtin"];
+    expect(session?.pendingInterrupts).toEqual([]);
+    expect(session?.pendingInterrupt).toBeNull();
+  });
 });

--- a/frontend/store/chat.ts
+++ b/frontend/store/chat.ts
@@ -157,7 +157,10 @@ type ChatState = {
   replaceRecoveredInterrupts: (
     conversationId: string,
     interrupts: PendingRuntimeInterrupt[],
-    options?: { sessionId?: string | null },
+    options?: {
+      sessionId?: string | null;
+      replaceAllForConversation?: boolean;
+    },
   ) => void;
   getLatestConversationIdByAgentId: (agentId: string) => string | undefined;
   cleanupSessions: () => void;
@@ -353,15 +356,17 @@ export const useChatStore = create<ChatState>()(
           }
           const targetSessionId = options?.sessionId?.trim() || null;
           const currentQueue = getPendingInterruptQueue(current);
-          const retainedQueue = currentQueue.filter((interrupt) => {
-            if (interrupt.source !== "recovery") {
-              return true;
-            }
-            if (!targetSessionId) {
-              return false;
-            }
-            return interrupt.sessionId !== targetSessionId;
-          });
+          const retainedQueue = options?.replaceAllForConversation
+            ? []
+            : currentQueue.filter((interrupt) => {
+                if (interrupt.source !== "recovery") {
+                  return true;
+                }
+                if (!targetSessionId) {
+                  return false;
+                }
+                return interrupt.sessionId !== targetSessionId;
+              });
 
           const seenRequestIds = new Set(
             retainedQueue.map((interrupt) => interrupt.requestId),


### PR DESCRIPTION
## 关联 issues

- Closes #792

## 变更概览

本 PR 修复 built-in self-management agent 在历史会话中遇到已失效 permission interrupt 时，会被持续恢复并反复弹窗的问题，并补齐 expired interrupt 从 recovery 过滤、生命周期持久化、到前端状态清理与展示的一整条处理链路。

## 后端

### built-in interrupt recovery

- 在 `SelfManagementBuiltInAgentService.recover_pending_interrupts()` 中，对持久化恢复出的 `request_id` 重新执行 token 校验。
- 对已失效或无法校验的 built-in permission interrupt，不再返回给恢复接口。
- recovery 额外校验 token 归属用户、conversation id 与原始 prompt 是否仍完整，避免恢复“虽然 token 可解，但 reply 必然失败”的 built-in interrupt。
- 对 recovery 阶段识别出的失效 built-in interrupt，追加持久化 `resolved/expired` 生命周期事件，避免同一条失效请求在后续恢复链路中持续作为隐性脏数据存在。

### interrupt lifecycle contract

- 扩展后端 interrupt lifecycle 规范化与 schema，允许 `resolution="expired"`。
- 为 expired 状态补充消息码与系统消息文案，区分 `permission`、`permissions`、`question`、`elicitation` 四类 interrupt。
- `interrupts:recover` 路由在 recovery 期间发生持久化回写后显式提交事务，确保 expired 生命周期事件可见且可审计。

### built-in permission reply error contract

- 在 built-in permission reply 路由中，将 `The write approval request is invalid or expired.` 映射为结构化错误。
- 返回 `error_code=interrupt_request_expired`，并将 HTTP 状态码对齐为 `409`，与现有错误码契约保持一致。
- 前端因此可以复用现有 terminal interrupt 清理逻辑，而不需要新增 built-in 专属分支。

### 后端测试

- 新增或补强回归测试，覆盖：
  - 失效 interrupt 不再被 recovery 返回。
  - recovery 会为失效 built-in interrupt 持久化 `resolved/expired` 生命周期事件。
  - conversation 不匹配的 built-in interrupt 不会被 recovery 恢复。
  - built-in permission reply 返回失效错误时带有 `interrupt_request_expired`。
  - built-in permission reply 的失效错误状态码为 `409`。

## 前端

### built-in interrupt failure handling

- 复用现有 interrupt terminal error 清理路径。
- 当 built-in permission reply 返回 `interrupt_request_expired` 时，自动清理本地 pending interrupt，并停止继续展示同一条失效授权卡片。

### built-in recovery reconciliation

- built-in conversation 执行 interrupt recovery 成功后，使用服务端 recovery 结果覆盖当前会话的 pending interrupt 视图。
- 即使本地内存里还残留旧的 built-in interrupt，只要服务端已经不再返回，它也会被同步清掉，不需要等待用户再次点击失败。

### expired lifecycle rendering

- 扩展前端 interrupt 解析、消息文案和类型定义，允许展示 `resolution="expired"` 的 interrupt lifecycle 事件。
- 为 expired interrupt 增加独立 badge 和文案，避免前端把它误判成 replied 或 rejected。

### 前端测试

- 新增回归测试，覆盖 built-in permission reply 过期后自动清理 pending interrupt 的场景。
- 新增 store 回归测试，覆盖 built-in recovery 可以清空当前会话残留的本地 pending interrupts。
- 新增 interrupt event block 测试，覆盖 expired lifecycle 事件的展示与 badge 渲染。

## 相关 commits

- `fix(self-management): prevent stale built-in interrupt recovery (#792)`
- `fix(api): align built-in interrupt expiry error status (#792)`
- `fix(interrupts): tighten built-in recovery reconciliation (#792)`
- `fix(interrupts): persist expired built-in lifecycle events (#792)`

## 验证

### Backend

- `cd backend && uv run --locked pre-commit run --files app/features/self_management_agent/service.py app/features/self_management_agent/router.py tests/runtime/test_self_management_built_in_agent.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_self_management_built_in_agent.py`
- 修正错误状态码后再次执行：
- `cd backend && uv run --locked pre-commit run --files app/features/self_management_agent/router.py tests/runtime/test_self_management_built_in_agent.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_self_management_built_in_agent.py`
- 继续补齐 recovery 边界路径后再次执行：
- `cd backend && uv run --locked pre-commit run --files app/features/self_management_agent/service.py tests/runtime/test_self_management_built_in_agent.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_self_management_built_in_agent.py`
- 持久化 expired 生命周期事件后再次执行：
- `cd backend && uv run --locked pre-commit run --files app/features/sessions/common.py app/features/sessions/schemas.py app/features/invoke/stream_payloads.py app/features/self_management_agent/service.py app/features/self_management_agent/router.py tests/runtime/test_self_management_built_in_agent.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_self_management_built_in_agent.py`

### Frontend

- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests screens/__tests__/ChatScreen.interrupt.test.tsx --maxWorkers=25%`
- 继续补齐 recovery 边界路径后再次执行：
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests screens/__tests__/ChatScreen.interrupt.test.tsx store/__tests__/chatStoreIdempotency.test.ts --maxWorkers=25%`
- 持久化 expired 生命周期事件后再次执行：
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests components/chat/__tests__/InterruptEventBlock.test.tsx hooks/__tests__/useChatInterruptController.test.tsx lib/__tests__/chat-utils.test.ts screens/__tests__/ChatScreen.interrupt.test.tsx store/__tests__/chatStoreIdempotency.test.ts --maxWorkers=25%`

## 风险与备注

- 当前 PR 已覆盖已确认的重复恢复、重复弹窗、本地残留、以及 expired 生命周期不可见这几条业务路径。
- 本轮未引入新的接口字段类型之外的破坏性变更；`expired` 仅作为对既有 interrupt lifecycle 的向后兼容扩展。
