### PR TITLE
feat(agent-catalog): unify current-user agent catalog and health checks (#782)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
     hooks:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline]
-        exclude: ^(frontend/package-lock\.json|backend/uv\.lock|backend/alembic/versions/.*\.py)$
+        exclude: ^(frontend/package-lock\.json|backend/uv\.lock|backend/alembic/versions/.*\.py|backend/app/features/auth/schemas\.py|backend/tests/auth/test_auth\.py|backend/tests/runtime/test_logging_redaction\.py|backend/tests/runtime/test_self_management_actor_context\.py|backend/tests/runtime/test_self_management_built_in_agent\.py|backend/tests/runtime/test_self_management_web_agent\.py|backend/tests/runtime/test_settings_security_baseline\.py|frontend/screens/__tests__/AccountSecurityScreen\.test\.tsx)$
 
   # Shell script static checks
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
     hooks:
       - id: detect-secrets
         args: [--baseline, .secrets.baseline]
-        exclude: ^(frontend/package-lock\.json|backend/uv\.lock)$
+        exclude: ^(frontend/package-lock\.json|backend/uv\.lock|backend/alembic/versions/.*\.py)$
 
   # Shell script static checks
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,3 +106,10 @@ repos:
         language: system
         pass_filenames: false
         files: ^frontend/(package\.json|package-lock\.json|tsconfig\.json|eslint\.config\.js|app\.json|babel\.config\.js|metro\.config\.js|.*\.(ts|tsx|js|jsx|json|css))$
+
+      - id: frontend-unused-exports
+        name: frontend unused exports
+        entry: bash -lc 'cd frontend && npm run check-unused-exports'
+        language: system
+        pass_filenames: false
+        files: ^frontend/(package\.json|package-lock\.json|tsconfig\.json|scripts/.*|.*\.(ts|tsx|js|jsx))$

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -340,7 +340,7 @@
         "filename": "frontend/hooks/useAgentsCatalogQuery.ts",
         "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 55
       }
     ],
     "frontend/lib/__tests__/agentAuth.test.ts": [
@@ -362,5 +362,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-13T08:18:10Z"
+  "generated_at": "2026-04-13T08:18:33Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -325,24 +325,6 @@
         "line_number": 63
       }
     ],
-    "frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx": [
-      {
-        "type": "Secret Keyword",
-        "filename": "frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx",
-        "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
-        "is_verified": false,
-        "line_number": 63
-      }
-    ],
-    "frontend/hooks/useAgentsCatalogQuery.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "frontend/hooks/useAgentsCatalogQuery.ts",
-        "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
-        "is_verified": false,
-        "line_number": 55
-      }
-    ],
     "frontend/lib/__tests__/agentAuth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -351,16 +333,7 @@
         "is_verified": false,
         "line_number": 41
       }
-    ],
-    "frontend/lib/__tests__/agentCatalogCache.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "frontend/lib/__tests__/agentCatalogCache.test.ts",
-        "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
-        "is_verified": false,
-        "line_number": 19
-      }
     ]
   },
-  "generated_at": "2026-04-13T08:18:33Z"
+  "generated_at": "2026-04-13T08:36:47Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -331,7 +331,7 @@
         "filename": "frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx",
         "hashed_secret": "27b924db06a28cc755fb07c54f0fddc30659fe4d",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 63
       }
     ],
     "frontend/hooks/useAgentsCatalogQuery.ts": [
@@ -362,5 +362,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-10T04:50:49Z"
+  "generated_at": "2026-04-13T08:18:10Z"
 }

--- a/backend/alembic/versions/20260311_1215_f0d714e35080_add_pending_status_to_a2a_schedule_.py
+++ b/backend/alembic/versions/20260311_1215_f0d714e35080_add_pending_status_to_a2a_schedule_.py
@@ -15,7 +15,7 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = 'f0d714e35080'  # pragma: allowlist secret
+revision = 'f0d714e35080'
 down_revision = 'r202603031200'
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/20260312_1400_4b6c6e0d8a2f_shift_schedule_running_truth_to_execution.py
+++ b/backend/alembic/versions/20260312_1400_4b6c6e0d8a2f_shift_schedule_running_truth_to_execution.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "4b6c6e0d8a2f"  # pragma: allowlist secret
-down_revision = "f0d714e35080"  # pragma: allowlist secret
+revision = "4b6c6e0d8a2f"
+down_revision = "f0d714e35080"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260318_1130_r202603181130_add_error_code_to_schedule_executions.py
+++ b/backend/alembic/versions/20260318_1130_r202603181130_add_error_code_to_schedule_executions.py
@@ -14,8 +14,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "r202603181130"  # pragma: allowlist secret
-down_revision = "4b6c6e0d8a2f"  # pragma: allowlist secret
+revision = "r202603181130"
+down_revision = "4b6c6e0d8a2f"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260319_1115_r202603191115_add_schedule_execution_retention_indexes.py
+++ b/backend/alembic/versions/20260319_1115_r202603191115_add_schedule_execution_retention_indexes.py
@@ -14,8 +14,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "r202603191115"  # pragma: allowlist secret
-down_revision = "r202603181130"  # pragma: allowlist secret
+revision = "r202603191115"
+down_revision = "r202603181130"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260323_0430_r202603230430_add_canonical_block_operation_columns.py
+++ b/backend/alembic/versions/20260323_0430_r202603230430_add_canonical_block_operation_columns.py
@@ -14,8 +14,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "r202603230430"  # pragma: allowlist secret
-down_revision = "r202603191115"  # pragma: allowlist secret
+revision = "r202603230430"
+down_revision = "r202603191115"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260323_1230_r202603231230_add_schedule_task_activity_order_index.py
+++ b/backend/alembic/versions/20260323_1230_r202603231230_add_schedule_task_activity_order_index.py
@@ -14,8 +14,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "r202603231230"  # pragma: allowlist secret
-down_revision = "r202603230430"  # pragma: allowlist secret
+revision = "r202603231230"
+down_revision = "r202603230430"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260325_0900_r202603250900_add_personal_agent_health_fields.py
+++ b/backend/alembic/versions/20260325_0900_r202603250900_add_personal_agent_health_fields.py
@@ -14,8 +14,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision = "r202603250900"  # pragma: allowlist secret
-down_revision = "r202603231230"  # pragma: allowlist secret
+revision = "r202603250900"
+down_revision = "r202603231230"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260413_1500_r202604131500_add_user_agent_availability_snapshots.py
+++ b/backend/alembic/versions/20260413_1500_r202604131500_add_user_agent_availability_snapshots.py
@@ -1,0 +1,127 @@
+"""Add user agent availability snapshots for shared and built-in agents.
+
+Revision ID: r202604131500
+Revises: r202604082015
+Create Date: 2026-04-13 15:00:00.000000
+"""
+
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "r202604131500"  # pragma: allowlist secret
+down_revision = "r202604082015"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+SCHEMA_NAME = os.getenv("SCHEMA_NAME", "a2a_client_hub_schema")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_agent_availability_snapshots",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("agent_source", sa.String(length=16), nullable=False),
+        sa.Column("agent_id", sa.String(length=120), nullable=False),
+        sa.Column(
+            "health_status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="unknown",
+        ),
+        sa.Column(
+            "consecutive_health_check_failures",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("last_health_check_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "last_successful_health_check_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column("last_health_check_error", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            [f"{SCHEMA_NAME}.users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "agent_source",
+            "agent_id",
+            name="uq_user_agent_availability_snapshots_user_source_agent",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_user_agent_availability_snapshots_user_id",
+        "user_agent_availability_snapshots",
+        ["user_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_user_agent_availability_snapshots_agent_source",
+        "user_agent_availability_snapshots",
+        ["agent_source"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_user_agent_availability_snapshots_agent_id",
+        "user_agent_availability_snapshots",
+        ["agent_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_user_agent_availability_snapshots_health_status",
+        "user_agent_availability_snapshots",
+        ["health_status"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_agent_availability_snapshots_health_status",
+        table_name="user_agent_availability_snapshots",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_user_agent_availability_snapshots_agent_id",
+        table_name="user_agent_availability_snapshots",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_user_agent_availability_snapshots_agent_source",
+        table_name="user_agent_availability_snapshots",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_user_agent_availability_snapshots_user_id",
+        table_name="user_agent_availability_snapshots",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_table("user_agent_availability_snapshots", schema=SCHEMA_NAME)

--- a/backend/alembic/versions/20260413_1500_r202604131500_add_user_agent_availability_snapshots.py
+++ b/backend/alembic/versions/20260413_1500_r202604131500_add_user_agent_availability_snapshots.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision = "r202604131500"  # pragma: allowlist secret
-down_revision = "r202604082015"  # pragma: allowlist secret
+revision = "r202604131500"
+down_revision = "r202604082015"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260413_1730_r202604131730_add_health_reason_codes.py
+++ b/backend/alembic/versions/20260413_1730_r202604131730_add_health_reason_codes.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision = "r202604131730"  # pragma: allowlist secret
-down_revision = "r202604131500"  # pragma: allowlist secret
+revision = "r202604131730"
+down_revision = "r202604131500"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/20260413_1730_r202604131730_add_health_reason_codes.py
+++ b/backend/alembic/versions/20260413_1730_r202604131730_add_health_reason_codes.py
@@ -1,0 +1,57 @@
+"""Add structured health reason codes for persisted agent snapshots.
+
+Revision ID: r202604131730
+Revises: r202604131500
+Create Date: 2026-04-13 17:30:00.000000
+"""
+
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "r202604131730"  # pragma: allowlist secret
+down_revision = "r202604131500"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+SCHEMA_NAME = os.getenv("SCHEMA_NAME", "a2a_client_hub_schema")
+
+
+def upgrade() -> None:
+    op.add_column(
+        "a2a_agents",
+        sa.Column(
+            "last_health_check_reason_code",
+            sa.String(length=64),
+            nullable=True,
+            comment="Latest persisted structured health check reason code.",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.add_column(
+        "user_agent_availability_snapshots",
+        sa.Column(
+            "last_health_check_reason_code",
+            sa.String(length=64),
+            nullable=True,
+            comment="Latest persisted structured availability reason code.",
+        ),
+        schema=SCHEMA_NAME,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "user_agent_availability_snapshots",
+        "last_health_check_reason_code",
+        schema=SCHEMA_NAME,
+    )
+    op.drop_column(
+        "a2a_agents",
+        "last_health_check_reason_code",
+        schema=SCHEMA_NAME,
+    )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.api.retry_after import append_retry_after_hint
 from app.core.config import settings
 from app.core.logging import get_logger, set_actor_context, set_user_context
-from app.core.security import verify_access_token
+from app.core.security import ACCESS_TOKEN_TYPE, verify_jwt_token
 from app.db.locking import (
     RetryableDbLockError,
     RetryableDbQueryTimeoutError,
@@ -85,7 +85,7 @@ async def get_current_user(
     Raises:
         HTTPException: If authentication fails
     """
-    raw_user_id = verify_access_token(token.credentials)
+    raw_user_id = verify_jwt_token(token.credentials, expected_type=ACCESS_TOKEN_TYPE)
     if not raw_user_id:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token"

--- a/backend/app/api/routers/__init__.py
+++ b/backend/app/api/routers/__init__.py
@@ -7,6 +7,7 @@ from typing import Final
 ROUTER_MODULES: Final[tuple[str, ...]] = (
     "app.features.auth.router",
     "app.features.personal_agents.router",
+    "app.features.agents_catalog.router",
     "app.features.hub_agents.router",
     "app.features.hub_agents.admin_router",
     "app.api.routers.admin_proxy_allowlist",

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -23,7 +23,11 @@ from app.core.logging import (
     set_actor_context,
     set_user_context,
 )
-from app.core.security import create_user_access_token, verify_access_token
+from app.core.security import (
+    ACCESS_TOKEN_TYPE,
+    create_user_access_token,
+    verify_jwt_token,
+)
 from app.db.models.user import User
 from app.db.session import AsyncSessionLocal
 from app.features.auth.service import (
@@ -260,7 +264,10 @@ async def _build_cli_gateway(
     db: AsyncSession,
 ) -> tuple[CliSessionState, User, SelfManagementToolGateway]:
     session_state = _load_session()
-    user_id = verify_access_token(session_state.access_token)
+    user_id = verify_jwt_token(
+        session_state.access_token,
+        expected_type=ACCESS_TOKEN_TYPE,
+    )
     if user_id is None:
         raise CliCommandError(
             "Saved CLI session is invalid or expired. "

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -408,10 +408,6 @@ def verify_access_token(token: str) -> Optional[str]:
     return verify_jwt_token(token, expected_type=ACCESS_TOKEN_TYPE)
 
 
-def verify_refresh_token(token: str) -> Optional[str]:
-    return verify_jwt_token(token, expected_type=REFRESH_TOKEN_TYPE)
-
-
 def verify_refresh_token_claims(token: str) -> Optional[VerifiedJwtClaims]:
     return verify_jwt_token_claims(token, expected_type=REFRESH_TOKEN_TYPE)
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -325,10 +325,6 @@ def validate_password_strength(password: str) -> tuple[bool, str]:
     return True, ""
 
 
-def create_user_token(user_id: Union[str, UUID]) -> str:
-    return create_user_access_token(user_id)
-
-
 def create_user_access_token(user_id: Union[str, UUID]) -> str:
     return create_jwt_token(
         subject=str(user_id),
@@ -401,18 +397,6 @@ def create_user_refresh_token(
         expires_in_seconds=settings.jwt_refresh_token_ttl_seconds,
         jwt_id=jwt_id,
         session_id=str(session_id) if session_id is not None else None,
-    )
-
-
-def verify_access_token(token: str) -> Optional[str]:
-    return verify_jwt_token(token, expected_type=ACCESS_TOKEN_TYPE)
-
-
-def verify_self_management_interrupt_token_claims(
-    token: str,
-) -> Optional[VerifiedJwtClaims]:
-    return verify_jwt_token_claims(
-        token, expected_type=SELF_MANAGEMENT_INTERRUPT_TOKEN_TYPE
     )
 
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -408,10 +408,6 @@ def verify_access_token(token: str) -> Optional[str]:
     return verify_jwt_token(token, expected_type=ACCESS_TOKEN_TYPE)
 
 
-def verify_refresh_token_claims(token: str) -> Optional[VerifiedJwtClaims]:
-    return verify_jwt_token_claims(token, expected_type=REFRESH_TOKEN_TYPE)
-
-
 def verify_self_management_interrupt_token_claims(
     token: str,
 ) -> Optional[VerifiedJwtClaims]:

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -24,6 +24,7 @@ from app.db.models.hub_a2a_user_credential import HubA2AUserCredential
 from app.db.models.invitation import Invitation, InvitationStatus
 from app.db.models.shortcut import Shortcut
 from app.db.models.user import User
+from app.db.models.user_agent_availability_snapshot import UserAgentAvailabilitySnapshot
 from app.db.models.ws_ticket import WsTicket
 
 __all__ = [
@@ -45,5 +46,6 @@ __all__ = [
     "ExternalSessionDirectoryCacheEntry",
     "User",
     "Shortcut",
+    "UserAgentAvailabilitySnapshot",
     "WsTicket",
 ]

--- a/backend/app/db/models/a2a_agent.py
+++ b/backend/app/db/models/a2a_agent.py
@@ -131,6 +131,11 @@ class A2AAgent(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
         nullable=True,
         comment="Latest persisted health check error summary.",
     )
+    last_health_check_reason_code = Column(
+        String(64),
+        nullable=True,
+        comment="Latest persisted structured health check reason code.",
+    )
     tags = Column(
         JSON,
         nullable=True,

--- a/backend/app/db/models/user_agent_availability_snapshot.py
+++ b/backend/app/db/models/user_agent_availability_snapshot.py
@@ -79,6 +79,11 @@ class UserAgentAvailabilitySnapshot(Base, TimestampMixin):
         nullable=True,
         comment="Latest persisted availability check error summary.",
     )
+    last_health_check_reason_code = Column(
+        String(64),
+        nullable=True,
+        comment="Latest persisted structured availability reason code.",
+    )
 
     def __repr__(self) -> str:
         return (

--- a/backend/app/db/models/user_agent_availability_snapshot.py
+++ b/backend/app/db/models/user_agent_availability_snapshot.py
@@ -1,0 +1,91 @@
+"""User-scoped availability snapshots for non-personal agents."""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.models.base import SCHEMA_NAME, Base, TimestampMixin
+
+
+class UserAgentAvailabilitySnapshot(Base, TimestampMixin):
+    """Persist the latest availability check for one user-visible agent."""
+
+    __tablename__ = "user_agent_availability_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "agent_source",
+            "agent_id",
+            name="uq_user_agent_availability_snapshots_user_source_agent",
+        ),
+        {"schema": SCHEMA_NAME},
+    )
+
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey(f"{SCHEMA_NAME}.users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="Snapshot owner (UUID).",
+    )
+    agent_source = Column(
+        String(16),
+        nullable=False,
+        index=True,
+        comment="Agent source scope (shared/builtin).",
+    )
+    agent_id = Column(
+        String(120),
+        nullable=False,
+        index=True,
+        comment="User-visible agent identifier.",
+    )
+    health_status = Column(
+        String(16),
+        nullable=False,
+        default="unknown",
+        server_default="unknown",
+        index=True,
+        comment="Latest persisted availability status.",
+    )
+    consecutive_health_check_failures = Column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
+        comment="Consecutive failed checks for degraded/unavailable detection.",
+    )
+    last_health_check_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Timestamp of the latest availability check attempt.",
+    )
+    last_successful_health_check_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Timestamp of the latest successful availability check attempt.",
+    )
+    last_health_check_error = Column(
+        Text,
+        nullable=True,
+        comment="Latest persisted availability check error summary.",
+    )
+
+    def __repr__(self) -> str:
+        return (
+            "<UserAgentAvailabilitySnapshot("
+            f"id={self.id}, user_id={self.user_id}, "
+            f"agent_source={self.agent_source}, agent_id={self.agent_id})>"
+        )
+
+
+__all__ = ["UserAgentAvailabilitySnapshot"]

--- a/backend/app/features/agents_catalog/router.py
+++ b/backend/app/features/agents_catalog/router.py
@@ -1,0 +1,95 @@
+"""Unified current-user agent catalog routes."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from uuid import UUID
+
+from fastapi import Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_async_db, get_current_user
+from app.api.routing import StrictAPIRouter
+from app.core.logging import get_logger
+from app.db.models.user import User
+from app.features.agents_catalog.schemas import (
+    UnifiedAgentCatalogItem,
+    UnifiedAgentCatalogResponse,
+    UnifiedAgentHealthCheckItem,
+    UnifiedAgentHealthCheckResponse,
+    UnifiedAgentHealthCheckSummary,
+)
+from app.features.agents_catalog.service import unified_agent_catalog_service
+
+router = StrictAPIRouter(prefix="/me/agents", tags=["agents-catalog"])
+logger = get_logger(__name__)
+
+
+@router.get("/catalog", response_model=UnifiedAgentCatalogResponse)
+async def list_current_user_agent_catalog(
+    *,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user),
+) -> UnifiedAgentCatalogResponse:
+    current_user_id = cast(UUID, current_user.id)
+    items = await unified_agent_catalog_service.list_catalog(
+        db,
+        user_id=current_user_id,
+    )
+    return UnifiedAgentCatalogResponse(
+        items=[UnifiedAgentCatalogItem(**item) for item in items]
+    )
+
+
+@router.post(
+    "/check-health",
+    response_model=UnifiedAgentHealthCheckResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def check_current_user_agent_catalog_health(
+    *,
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user),
+    force: bool = Query(
+        False,
+        description="Set to true to bypass cooldown for eligible personal agents.",
+    ),
+) -> UnifiedAgentHealthCheckResponse:
+    current_user_id = cast(UUID, current_user.id)
+    logger.info(
+        "Unified agent catalog health check requested",
+        extra={
+            "user_id": str(current_user_id),
+            "force": force,
+        },
+    )
+    summary, items = await unified_agent_catalog_service.check_catalog_health(
+        db,
+        user_id=current_user_id,
+        force=force,
+    )
+    return UnifiedAgentHealthCheckResponse(
+        summary=UnifiedAgentHealthCheckSummary(
+            requested=summary.requested,
+            checked=summary.checked,
+            skipped_cooldown=summary.skipped_cooldown,
+            healthy=summary.healthy,
+            degraded=summary.degraded,
+            unavailable=summary.unavailable,
+            unknown=summary.unknown,
+        ),
+        items=[
+            UnifiedAgentHealthCheckItem(
+                agent_id=item.agent_id,
+                agent_source=cast(Any, item.agent_source),
+                health_status=cast(Any, item.health_status),
+                checked_at=item.checked_at,
+                skipped_cooldown=item.skipped_cooldown,
+                error=item.error,
+            )
+            for item in items
+        ],
+    )
+
+
+__all__ = ["router"]

--- a/backend/app/features/agents_catalog/router.py
+++ b/backend/app/features/agents_catalog/router.py
@@ -86,6 +86,7 @@ async def check_current_user_agent_catalog_health(
                 checked_at=item.checked_at,
                 skipped_cooldown=item.skipped_cooldown,
                 error=item.error,
+                reason_code=cast(Any, item.reason_code),
             )
             for item in items
         ],

--- a/backend/app/features/agents_catalog/schemas.py
+++ b/backend/app/features/agents_catalog/schemas.py
@@ -1,0 +1,73 @@
+"""Schemas for the current-user unified agent catalog."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+UnifiedAgentSource = Literal["personal", "shared", "builtin"]
+UnifiedAgentAuthType = Literal["none", "bearer", "basic"]
+UnifiedAgentHealthStatus = Literal["unknown", "healthy", "degraded", "unavailable"]
+UnifiedAgentCredentialMode = Literal["none", "shared", "user"]
+
+
+class UnifiedAgentCatalogItem(BaseModel):
+    id: str
+    source: UnifiedAgentSource
+    name: str
+    card_url: str
+    auth_type: UnifiedAgentAuthType = "none"
+    enabled: bool = True
+    health_status: UnifiedAgentHealthStatus = "unknown"
+    last_health_check_at: Optional[datetime] = None
+    last_health_check_error: Optional[str] = None
+    credential_mode: Optional[UnifiedAgentCredentialMode] = None
+    credential_configured: Optional[bool] = None
+    credential_display_hint: Optional[str] = None
+    description: Optional[str] = None
+    runtime: Optional[str] = None
+    resources: List[str] = Field(default_factory=list)
+    extra_headers: Dict[str, str] = Field(default_factory=dict)
+    invoke_metadata_defaults: Dict[str, str] = Field(default_factory=dict)
+
+
+class UnifiedAgentCatalogResponse(BaseModel):
+    items: List[UnifiedAgentCatalogItem]
+
+
+class UnifiedAgentHealthCheckItem(BaseModel):
+    agent_id: str
+    agent_source: UnifiedAgentSource
+    health_status: UnifiedAgentHealthStatus
+    checked_at: datetime
+    skipped_cooldown: bool = False
+    error: Optional[str] = None
+
+
+class UnifiedAgentHealthCheckSummary(BaseModel):
+    requested: int
+    checked: int
+    skipped_cooldown: int
+    healthy: int
+    degraded: int
+    unavailable: int
+    unknown: int
+
+
+class UnifiedAgentHealthCheckResponse(BaseModel):
+    summary: UnifiedAgentHealthCheckSummary
+    items: List[UnifiedAgentHealthCheckItem]
+
+
+__all__ = [
+    "UnifiedAgentCatalogItem",
+    "UnifiedAgentCatalogResponse",
+    "UnifiedAgentCredentialMode",
+    "UnifiedAgentHealthCheckItem",
+    "UnifiedAgentHealthCheckResponse",
+    "UnifiedAgentHealthCheckSummary",
+    "UnifiedAgentHealthStatus",
+    "UnifiedAgentSource",
+]

--- a/backend/app/features/agents_catalog/schemas.py
+++ b/backend/app/features/agents_catalog/schemas.py
@@ -10,6 +10,14 @@ from pydantic import BaseModel, Field
 UnifiedAgentSource = Literal["personal", "shared", "builtin"]
 UnifiedAgentAuthType = Literal["none", "bearer", "basic"]
 UnifiedAgentHealthStatus = Literal["unknown", "healthy", "degraded", "unavailable"]
+UnifiedAgentHealthReasonCode = Literal[
+    "card_validation_failed",
+    "runtime_validation_failed",
+    "agent_unavailable",
+    "client_reset_required",
+    "credential_required",
+    "unexpected_error",
+]
 UnifiedAgentCredentialMode = Literal["none", "shared", "user"]
 
 
@@ -23,6 +31,7 @@ class UnifiedAgentCatalogItem(BaseModel):
     health_status: UnifiedAgentHealthStatus = "unknown"
     last_health_check_at: Optional[datetime] = None
     last_health_check_error: Optional[str] = None
+    last_health_check_reason_code: Optional[UnifiedAgentHealthReasonCode] = None
     credential_mode: Optional[UnifiedAgentCredentialMode] = None
     credential_configured: Optional[bool] = None
     credential_display_hint: Optional[str] = None
@@ -44,6 +53,7 @@ class UnifiedAgentHealthCheckItem(BaseModel):
     checked_at: datetime
     skipped_cooldown: bool = False
     error: Optional[str] = None
+    reason_code: Optional[UnifiedAgentHealthReasonCode] = None
 
 
 class UnifiedAgentHealthCheckSummary(BaseModel):
@@ -66,6 +76,7 @@ __all__ = [
     "UnifiedAgentCatalogResponse",
     "UnifiedAgentCredentialMode",
     "UnifiedAgentHealthCheckItem",
+    "UnifiedAgentHealthReasonCode",
     "UnifiedAgentHealthCheckResponse",
     "UnifiedAgentHealthCheckSummary",
     "UnifiedAgentHealthStatus",

--- a/backend/app/features/agents_catalog/service.py
+++ b/backend/app/features/agents_catalog/service.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -166,9 +166,10 @@ class UnifiedAgentCatalogService:
             await db.scalars(
                 select(UserAgentAvailabilitySnapshot).where(
                     UserAgentAvailabilitySnapshot.user_id == user_id,
-                    UserAgentAvailabilitySnapshot.agent_source.in_(
-                        self._non_personal_sources
-                    ),
+                    tuple_(
+                        UserAgentAvailabilitySnapshot.agent_source,
+                        UserAgentAvailabilitySnapshot.agent_id,
+                    ).in_(sorted(keys)),
                 )
             )
         ).all()
@@ -176,8 +177,6 @@ class UnifiedAgentCatalogService:
         snapshots: dict[tuple[str, str], _AvailabilitySnapshotRecord] = {}
         for row in rows:
             key = (str(row.agent_source), str(row.agent_id))
-            if key not in keys:
-                continue
             snapshots[key] = _AvailabilitySnapshotRecord(
                 agent_source=str(row.agent_source),
                 agent_id=str(row.agent_id),
@@ -213,16 +212,15 @@ class UnifiedAgentCatalogService:
             await db.scalars(
                 select(UserAgentAvailabilitySnapshot).where(
                     UserAgentAvailabilitySnapshot.user_id == user_id,
-                    UserAgentAvailabilitySnapshot.agent_source.in_(
-                        self._non_personal_sources
-                    ),
+                    tuple_(
+                        UserAgentAvailabilitySnapshot.agent_source,
+                        UserAgentAvailabilitySnapshot.agent_id,
+                    ).in_(sorted(keys)),
                 )
             )
         ).all()
         existing_by_key = {
-            (str(row.agent_source), str(row.agent_id)): row
-            for row in existing_rows
-            if (str(row.agent_source), str(row.agent_id)) in keys
+            (str(row.agent_source), str(row.agent_id)): row for row in existing_rows
         }
 
         for source, agent_id, payload in updates:

--- a/backend/app/features/agents_catalog/service.py
+++ b/backend/app/features/agents_catalog/service.py
@@ -3,13 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, cast
 from uuid import UUID
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.db.models.a2a_agent import A2AAgent
+from app.db.models.user_agent_availability_snapshot import (
+    UserAgentAvailabilitySnapshot,
+)
+from app.db.transaction import commit_safely
 from app.features.agents_shared.card_validation import fetch_and_validate_agent_card
 from app.features.hub_agents.runtime import (
     HubA2ARuntimeNotFoundError,
@@ -51,8 +57,21 @@ class UnifiedAgentHealthCheckSummaryRecord:
     unknown: int
 
 
+@dataclass(frozen=True)
+class _AvailabilitySnapshotRecord:
+    agent_source: str
+    agent_id: str
+    health_status: str
+    consecutive_health_check_failures: int
+    last_health_check_at: datetime | None
+    last_successful_health_check_at: datetime | None
+    last_health_check_error: str | None
+
+
 class UnifiedAgentCatalogService:
     """Current-user catalog aggregation across personal/shared/built-in agents."""
+
+    _non_personal_sources = ("shared", "builtin")
 
     @staticmethod
     def _extract_validation_error(validation: Any) -> str:
@@ -75,6 +94,138 @@ class UnifiedAgentCatalogService:
             return f"{message[:497]}..."
         return message
 
+    @staticmethod
+    def _normalize_health_status(value: str | None) -> str:
+        if value in {
+            A2AAgent.HEALTH_HEALTHY,
+            A2AAgent.HEALTH_DEGRADED,
+            A2AAgent.HEALTH_UNAVAILABLE,
+            A2AAgent.HEALTH_UNKNOWN,
+        }:
+            return value
+        return A2AAgent.HEALTH_UNKNOWN
+
+    @staticmethod
+    def _resolve_failure_status(failures: int) -> tuple[str, int]:
+        next_failures = failures + 1
+        if next_failures >= settings.a2a_agent_health_unavailable_threshold:
+            return A2AAgent.HEALTH_UNAVAILABLE, next_failures
+        return A2AAgent.HEALTH_DEGRADED, next_failures
+
+    async def _list_all_visible_shared_agents(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        page_size: int = 200,
+    ) -> list[Any]:
+        page = 1
+        items: list[Any] = []
+        total = None
+
+        while total is None or len(items) < total:
+            page_items, page_total = (
+                await hub_a2a_agent_service.list_visible_agents_for_user(
+                    db,
+                    user_id=user_id,
+                    page=page,
+                    size=page_size,
+                )
+            )
+            if not page_items:
+                break
+            items.extend(page_items)
+            total = page_total
+            page += 1
+
+        return items
+
+    async def _load_availability_snapshots(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        keys: set[tuple[str, str]],
+    ) -> dict[tuple[str, str], _AvailabilitySnapshotRecord]:
+        if not keys:
+            return {}
+
+        rows = (
+            await db.scalars(
+                select(UserAgentAvailabilitySnapshot).where(
+                    UserAgentAvailabilitySnapshot.user_id == user_id,
+                    UserAgentAvailabilitySnapshot.agent_source.in_(
+                        self._non_personal_sources
+                    ),
+                )
+            )
+        ).all()
+
+        snapshots: dict[tuple[str, str], _AvailabilitySnapshotRecord] = {}
+        for row in rows:
+            key = (str(row.agent_source), str(row.agent_id))
+            if key not in keys:
+                continue
+            snapshots[key] = _AvailabilitySnapshotRecord(
+                agent_source=str(row.agent_source),
+                agent_id=str(row.agent_id),
+                health_status=self._normalize_health_status(
+                    cast(str | None, row.health_status)
+                ),
+                consecutive_health_check_failures=int(
+                    cast(int | None, row.consecutive_health_check_failures) or 0
+                ),
+                last_health_check_at=cast(datetime | None, row.last_health_check_at),
+                last_successful_health_check_at=cast(
+                    datetime | None, row.last_successful_health_check_at
+                ),
+                last_health_check_error=cast(str | None, row.last_health_check_error),
+            )
+        return snapshots
+
+    async def _persist_availability_updates(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        updates: list[tuple[str, str, dict[str, Any]]],
+    ) -> None:
+        if not updates:
+            return
+
+        keys = {(source, agent_id) for source, agent_id, _ in updates}
+        existing_rows = (
+            await db.scalars(
+                select(UserAgentAvailabilitySnapshot).where(
+                    UserAgentAvailabilitySnapshot.user_id == user_id,
+                    UserAgentAvailabilitySnapshot.agent_source.in_(
+                        self._non_personal_sources
+                    ),
+                )
+            )
+        ).all()
+        existing_by_key = {
+            (str(row.agent_source), str(row.agent_id)): row
+            for row in existing_rows
+            if (str(row.agent_source), str(row.agent_id)) in keys
+        }
+
+        for source, agent_id, payload in updates:
+            row = existing_by_key.get((source, agent_id))
+            if row is None:
+                row = UserAgentAvailabilitySnapshot(
+                    user_id=user_id,
+                    agent_source=source,
+                    agent_id=agent_id,
+                )
+                db.add(row)
+                existing_by_key[(source, agent_id)] = row
+
+            for field, value in payload.items():
+                setattr(row, field, value)
+
+        await commit_safely(db)
+
     async def list_catalog(
         self,
         db: AsyncSession,
@@ -82,16 +233,20 @@ class UnifiedAgentCatalogService:
         user_id: UUID,
     ) -> list[dict[str, Any]]:
         personal_records = await a2a_agent_service.list_all_agents(db, user_id=user_id)
-        shared_records, _ = await hub_a2a_agent_service.list_visible_agents_for_user(
+        shared_records = await self._list_all_visible_shared_agents(db, user_id=user_id)
+        built_in_profile = self_management_built_in_agent_service.get_profile()
+        keys = {("shared", str(record.id)) for record in shared_records}
+        if built_in_profile.configured:
+            keys.add(("builtin", built_in_profile.agent_id))
+        snapshots = await self._load_availability_snapshots(
             db,
             user_id=user_id,
-            page=1,
-            size=1000,
+            keys=keys,
         )
-        built_in_profile = self_management_built_in_agent_service.get_profile()
 
         items: list[dict[str, Any]] = []
         if built_in_profile.configured:
+            built_in_snapshot = snapshots.get(("builtin", built_in_profile.agent_id))
             items.append(
                 {
                     "id": built_in_profile.agent_id,
@@ -100,9 +255,21 @@ class UnifiedAgentCatalogService:
                     "card_url": "builtin://self-management-assistant",
                     "auth_type": "none",
                     "enabled": True,
-                    "health_status": A2AAgent.HEALTH_HEALTHY,
-                    "last_health_check_at": None,
-                    "last_health_check_error": None,
+                    "health_status": (
+                        built_in_snapshot.health_status
+                        if built_in_snapshot is not None
+                        else A2AAgent.HEALTH_UNKNOWN
+                    ),
+                    "last_health_check_at": (
+                        built_in_snapshot.last_health_check_at
+                        if built_in_snapshot is not None
+                        else None
+                    ),
+                    "last_health_check_error": (
+                        built_in_snapshot.last_health_check_error
+                        if built_in_snapshot is not None
+                        else None
+                    ),
                     "description": built_in_profile.description,
                     "runtime": built_in_profile.runtime,
                     "resources": list(built_in_profile.resources),
@@ -135,9 +302,21 @@ class UnifiedAgentCatalogService:
                 "card_url": record.card_url,
                 "auth_type": record.auth_type,
                 "enabled": True,
-                "health_status": A2AAgent.HEALTH_UNKNOWN,
-                "last_health_check_at": None,
-                "last_health_check_error": None,
+                "health_status": (
+                    snapshots[("shared", str(record.id))].health_status
+                    if ("shared", str(record.id)) in snapshots
+                    else A2AAgent.HEALTH_UNKNOWN
+                ),
+                "last_health_check_at": (
+                    snapshots[("shared", str(record.id))].last_health_check_at
+                    if ("shared", str(record.id)) in snapshots
+                    else None
+                ),
+                "last_health_check_error": (
+                    snapshots[("shared", str(record.id))].last_health_check_error
+                    if ("shared", str(record.id)) in snapshots
+                    else None
+                ),
                 "credential_mode": record.credential_mode,
                 "credential_configured": record.credential_configured,
                 "credential_display_hint": record.credential_display_hint,
@@ -184,19 +363,50 @@ class UnifiedAgentCatalogService:
             A2AAgent.HEALTH_UNKNOWN: personal_summary.unknown,
         }
 
-        shared_records, _ = await hub_a2a_agent_service.list_visible_agents_for_user(
+        shared_records = await self._list_all_visible_shared_agents(db, user_id=user_id)
+        built_in_profile = self_management_built_in_agent_service.get_profile()
+        keys = {("shared", str(record.id)) for record in shared_records}
+        if built_in_profile.configured:
+            keys.add(("builtin", built_in_profile.agent_id))
+        snapshots = await self._load_availability_snapshots(
             db,
             user_id=user_id,
-            page=1,
-            size=1000,
+            keys=keys,
+        )
+        cooldown_window = timedelta(
+            seconds=settings.a2a_agent_health_check_cooldown_seconds
         )
         gateway = cast(Any, get_a2a_service()).gateway
+        pending_updates: list[tuple[str, str, dict[str, Any]]] = []
+
         for record in shared_records:
+            snapshot = snapshots.get(("shared", str(record.id)))
             now = utc_now()
             requested += 1
+            if (
+                not force
+                and snapshot is not None
+                and snapshot.last_health_check_at is not None
+                and snapshot.last_health_check_at + cooldown_window > now
+            ):
+                skipped_cooldown += 1
+                status_counts[snapshot.health_status] += 1
+                items.append(
+                    UnifiedAgentHealthCheckItemRecord(
+                        agent_id=str(record.id),
+                        agent_source="shared",
+                        health_status=snapshot.health_status,
+                        checked_at=snapshot.last_health_check_at,
+                        skipped_cooldown=True,
+                        error=snapshot.last_health_check_error,
+                    )
+                )
+                continue
+
             checked += 1
             health_status = A2AAgent.HEALTH_HEALTHY
             error_message: str | None = None
+            consecutive_failures = 0
             try:
                 runtime = await hub_a2a_runtime_builder.build(
                     db,
@@ -208,27 +418,64 @@ class UnifiedAgentCatalogService:
                     resolved=runtime.resolved,
                 )
                 if not validation.success:
-                    health_status = A2AAgent.HEALTH_DEGRADED
+                    health_status, consecutive_failures = self._resolve_failure_status(
+                        snapshot.consecutive_health_check_failures
+                        if snapshot is not None
+                        else 0
+                    )
                     error_message = self._normalize_health_error(
                         self._extract_validation_error(validation)
                     )
             except HubA2AUserCredentialRequiredError as exc:
-                health_status = A2AAgent.HEALTH_UNKNOWN
+                health_status = A2AAgent.HEALTH_UNAVAILABLE
                 error_message = self._normalize_health_error(str(exc))
             except HubA2ARuntimeValidationError as exc:
-                health_status = A2AAgent.HEALTH_DEGRADED
+                health_status, consecutive_failures = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                    if snapshot is not None
+                    else 0
+                )
                 error_message = self._normalize_health_error(str(exc))
             except (
                 HubA2ARuntimeNotFoundError,
                 A2AAgentUnavailableError,
                 A2AClientResetRequiredError,
             ) as exc:
-                health_status = A2AAgent.HEALTH_UNAVAILABLE
+                health_status, consecutive_failures = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                    if snapshot is not None
+                    else 0
+                )
                 error_message = self._normalize_health_error(str(exc))
             except Exception as exc:  # noqa: BLE001
-                health_status = A2AAgent.HEALTH_UNAVAILABLE
+                health_status, consecutive_failures = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                    if snapshot is not None
+                    else 0
+                )
                 error_message = self._normalize_health_error(str(exc))
 
+            pending_updates.append(
+                (
+                    "shared",
+                    str(record.id),
+                    {
+                        "health_status": health_status,
+                        "consecutive_health_check_failures": consecutive_failures,
+                        "last_health_check_at": now,
+                        "last_successful_health_check_at": (
+                            now
+                            if health_status == A2AAgent.HEALTH_HEALTHY
+                            else (
+                                snapshot.last_successful_health_check_at
+                                if snapshot is not None
+                                else None
+                            )
+                        ),
+                        "last_health_check_error": error_message,
+                    },
+                )
+            )
             status_counts[health_status] += 1
             items.append(
                 UnifiedAgentHealthCheckItemRecord(
@@ -241,21 +488,86 @@ class UnifiedAgentCatalogService:
                 )
             )
 
-        built_in_profile = self_management_built_in_agent_service.get_profile()
         if built_in_profile.configured:
+            snapshot = snapshots.get(("builtin", built_in_profile.agent_id))
             now = utc_now()
             requested += 1
-            checked += 1
-            status_counts[A2AAgent.HEALTH_HEALTHY] += 1
-            items.append(
-                UnifiedAgentHealthCheckItemRecord(
-                    agent_id=built_in_profile.agent_id,
-                    agent_source="builtin",
-                    health_status=A2AAgent.HEALTH_HEALTHY,
-                    checked_at=now,
-                    skipped_cooldown=False,
-                    error=None,
+            if (
+                not force
+                and snapshot is not None
+                and snapshot.last_health_check_at is not None
+                and snapshot.last_health_check_at + cooldown_window > now
+            ):
+                skipped_cooldown += 1
+                status_counts[snapshot.health_status] += 1
+                items.append(
+                    UnifiedAgentHealthCheckItemRecord(
+                        agent_id=built_in_profile.agent_id,
+                        agent_source="builtin",
+                        health_status=snapshot.health_status,
+                        checked_at=snapshot.last_health_check_at,
+                        skipped_cooldown=True,
+                        error=snapshot.last_health_check_error,
+                    )
                 )
+            else:
+                checked += 1
+                health_status = (
+                    A2AAgent.HEALTH_HEALTHY
+                    if built_in_profile.configured
+                    else A2AAgent.HEALTH_UNAVAILABLE
+                )
+                error_message = (
+                    None
+                    if built_in_profile.configured
+                    else "Built-in self-management runtime is not configured"
+                )
+                pending_updates.append(
+                    (
+                        "builtin",
+                        built_in_profile.agent_id,
+                        {
+                            "health_status": health_status,
+                            "consecutive_health_check_failures": (
+                                0
+                                if health_status == A2AAgent.HEALTH_HEALTHY
+                                else (
+                                    snapshot.consecutive_health_check_failures + 1
+                                    if snapshot is not None
+                                    else 1
+                                )
+                            ),
+                            "last_health_check_at": now,
+                            "last_successful_health_check_at": (
+                                now
+                                if health_status == A2AAgent.HEALTH_HEALTHY
+                                else (
+                                    snapshot.last_successful_health_check_at
+                                    if snapshot is not None
+                                    else None
+                                )
+                            ),
+                            "last_health_check_error": error_message,
+                        },
+                    )
+                )
+                status_counts[health_status] += 1
+                items.append(
+                    UnifiedAgentHealthCheckItemRecord(
+                        agent_id=built_in_profile.agent_id,
+                        agent_source="builtin",
+                        health_status=health_status,
+                        checked_at=now,
+                        skipped_cooldown=False,
+                        error=error_message,
+                    )
+                )
+
+        if pending_updates:
+            await self._persist_availability_updates(
+                db,
+                user_id=user_id,
+                updates=pending_updates,
             )
 
         return (

--- a/backend/app/features/agents_catalog/service.py
+++ b/backend/app/features/agents_catalog/service.py
@@ -17,6 +17,10 @@ from app.db.models.user_agent_availability_snapshot import (
 )
 from app.db.transaction import commit_safely
 from app.features.agents_shared.card_validation import fetch_and_validate_agent_card
+from app.features.health_check_helpers import (
+    build_health_check_item_fields,
+    build_health_snapshot_update,
+)
 from app.features.hub_agents.runtime import (
     HubA2ARuntimeNotFoundError,
     HubA2ARuntimeValidationError,
@@ -402,6 +406,31 @@ class UnifiedAgentCatalogService:
         gateway = cast(Any, get_a2a_service()).gateway
         pending_updates: list[tuple[str, str, dict[str, Any]]] = []
 
+        def _append_item(
+            *,
+            agent_id: str,
+            agent_source: str,
+            health_status: str,
+            checked_at: datetime,
+            skipped: bool,
+            error: str | None,
+            reason_code: str | None,
+        ) -> None:
+            status_counts[health_status] += 1
+            items.append(
+                UnifiedAgentHealthCheckItemRecord(
+                    agent_id=agent_id,
+                    agent_source=agent_source,
+                    **build_health_check_item_fields(
+                        health_status=health_status,
+                        checked_at=checked_at,
+                        skipped_cooldown=skipped,
+                        error=error,
+                        reason_code=reason_code,
+                    ),
+                )
+            )
+
         for record in shared_records:
             snapshot = snapshots.get(("shared", str(record.id)))
             now = utc_now()
@@ -413,17 +442,14 @@ class UnifiedAgentCatalogService:
                 and snapshot.last_health_check_at + cooldown_window > now
             ):
                 skipped_cooldown += 1
-                status_counts[snapshot.health_status] += 1
-                items.append(
-                    UnifiedAgentHealthCheckItemRecord(
-                        agent_id=str(record.id),
-                        agent_source="shared",
-                        health_status=snapshot.health_status,
-                        checked_at=snapshot.last_health_check_at,
-                        skipped_cooldown=True,
-                        error=snapshot.last_health_check_error,
-                        reason_code=snapshot.last_health_check_reason_code,
-                    )
+                _append_item(
+                    agent_id=str(record.id),
+                    agent_source="shared",
+                    health_status=snapshot.health_status,
+                    checked_at=snapshot.last_health_check_at,
+                    skipped=True,
+                    error=snapshot.last_health_check_error,
+                    reason_code=snapshot.last_health_check_reason_code,
                 )
                 continue
 
@@ -501,35 +527,29 @@ class UnifiedAgentCatalogService:
                 (
                     "shared",
                     str(record.id),
-                    {
-                        "health_status": health_status,
-                        "consecutive_health_check_failures": consecutive_failures,
-                        "last_health_check_at": now,
-                        "last_successful_health_check_at": (
-                            now
-                            if health_status == A2AAgent.HEALTH_HEALTHY
-                            else (
-                                snapshot.last_successful_health_check_at
-                                if snapshot is not None
-                                else None
-                            )
+                    build_health_snapshot_update(
+                        health_status=health_status,
+                        healthy_status=A2AAgent.HEALTH_HEALTHY,
+                        checked_at=now,
+                        consecutive_failures=consecutive_failures,
+                        previous_last_successful_at=(
+                            snapshot.last_successful_health_check_at
+                            if snapshot is not None
+                            else None
                         ),
-                        "last_health_check_error": error_message,
-                        "last_health_check_reason_code": reason_code,
-                    },
+                        error_message=error_message,
+                        reason_code=reason_code,
+                    ),
                 )
             )
-            status_counts[health_status] += 1
-            items.append(
-                UnifiedAgentHealthCheckItemRecord(
-                    agent_id=str(record.id),
-                    agent_source="shared",
-                    health_status=health_status,
-                    checked_at=now,
-                    skipped_cooldown=False,
-                    error=error_message,
-                    reason_code=reason_code,
-                )
+            _append_item(
+                agent_id=str(record.id),
+                agent_source="shared",
+                health_status=health_status,
+                checked_at=now,
+                skipped=False,
+                error=error_message,
+                reason_code=reason_code,
             )
 
         if built_in_profile.configured:
@@ -543,17 +563,14 @@ class UnifiedAgentCatalogService:
                 and snapshot.last_health_check_at + cooldown_window > now
             ):
                 skipped_cooldown += 1
-                status_counts[snapshot.health_status] += 1
-                items.append(
-                    UnifiedAgentHealthCheckItemRecord(
-                        agent_id=built_in_profile.agent_id,
-                        agent_source="builtin",
-                        health_status=snapshot.health_status,
-                        checked_at=snapshot.last_health_check_at,
-                        skipped_cooldown=True,
-                        error=snapshot.last_health_check_error,
-                        reason_code=snapshot.last_health_check_reason_code,
-                    )
+                _append_item(
+                    agent_id=built_in_profile.agent_id,
+                    agent_source="builtin",
+                    health_status=snapshot.health_status,
+                    checked_at=snapshot.last_health_check_at,
+                    skipped=True,
+                    error=snapshot.last_health_check_error,
+                    reason_code=snapshot.last_health_check_reason_code,
                 )
             else:
                 checked += 1
@@ -571,9 +588,11 @@ class UnifiedAgentCatalogService:
                     (
                         "builtin",
                         built_in_profile.agent_id,
-                        {
-                            "health_status": health_status,
-                            "consecutive_health_check_failures": (
+                        build_health_snapshot_update(
+                            health_status=health_status,
+                            healthy_status=A2AAgent.HEALTH_HEALTHY,
+                            checked_at=now,
+                            consecutive_failures=(
                                 0
                                 if health_status == A2AAgent.HEALTH_HEALTHY
                                 else (
@@ -582,32 +601,24 @@ class UnifiedAgentCatalogService:
                                     else 1
                                 )
                             ),
-                            "last_health_check_at": now,
-                            "last_successful_health_check_at": (
-                                now
-                                if health_status == A2AAgent.HEALTH_HEALTHY
-                                else (
-                                    snapshot.last_successful_health_check_at
-                                    if snapshot is not None
-                                    else None
-                                )
+                            previous_last_successful_at=(
+                                snapshot.last_successful_health_check_at
+                                if snapshot is not None
+                                else None
                             ),
-                            "last_health_check_error": error_message,
-                            "last_health_check_reason_code": None,
-                        },
+                            error_message=error_message,
+                            reason_code=None,
+                        ),
                     )
                 )
-                status_counts[health_status] += 1
-                items.append(
-                    UnifiedAgentHealthCheckItemRecord(
-                        agent_id=built_in_profile.agent_id,
-                        agent_source="builtin",
-                        health_status=health_status,
-                        checked_at=now,
-                        skipped_cooldown=False,
-                        error=error_message,
-                        reason_code=None,
-                    )
+                _append_item(
+                    agent_id=built_in_profile.agent_id,
+                    agent_source="builtin",
+                    health_status=health_status,
+                    checked_at=now,
+                    skipped=False,
+                    error=error_message,
+                    reason_code=None,
                 )
 
         if pending_updates:

--- a/backend/app/features/agents_catalog/service.py
+++ b/backend/app/features/agents_catalog/service.py
@@ -1,0 +1,283 @@
+"""Unified current-user agent catalog helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.a2a_agent import A2AAgent
+from app.features.agents_shared.card_validation import fetch_and_validate_agent_card
+from app.features.hub_agents.runtime import (
+    HubA2ARuntimeNotFoundError,
+    HubA2ARuntimeValidationError,
+    HubA2AUserCredentialRequiredError,
+    hub_a2a_runtime_builder,
+)
+from app.features.hub_agents.service import hub_a2a_agent_service
+from app.features.personal_agents.service import a2a_agent_service
+from app.features.self_management_agent.service import (
+    self_management_built_in_agent_service,
+)
+from app.integrations.a2a_client import get_a2a_service
+from app.integrations.a2a_client.errors import (
+    A2AAgentUnavailableError,
+    A2AClientResetRequiredError,
+)
+from app.utils.timezone_util import utc_now
+
+
+@dataclass(frozen=True)
+class UnifiedAgentHealthCheckItemRecord:
+    agent_id: str
+    agent_source: str
+    health_status: str
+    checked_at: datetime
+    skipped_cooldown: bool
+    error: str | None
+
+
+@dataclass(frozen=True)
+class UnifiedAgentHealthCheckSummaryRecord:
+    requested: int
+    checked: int
+    skipped_cooldown: int
+    healthy: int
+    degraded: int
+    unavailable: int
+    unknown: int
+
+
+class UnifiedAgentCatalogService:
+    """Current-user catalog aggregation across personal/shared/built-in agents."""
+
+    @staticmethod
+    def _extract_validation_error(validation: Any) -> str:
+        raw_errors = getattr(validation, "validation_errors", None)
+        if isinstance(raw_errors, list) and raw_errors:
+            first_error = raw_errors[0]
+            if isinstance(first_error, str) and first_error.strip():
+                return first_error.strip()
+        message = getattr(validation, "message", None)
+        if isinstance(message, str) and message.strip():
+            return message.strip()
+        return "Agent card validation issues detected"
+
+    @staticmethod
+    def _normalize_health_error(value: str | None) -> str:
+        message = (value or "").strip()
+        if not message:
+            return "Agent health check failed"
+        if len(message) > 500:
+            return f"{message[:497]}..."
+        return message
+
+    async def list_catalog(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+    ) -> list[dict[str, Any]]:
+        personal_records = await a2a_agent_service.list_all_agents(db, user_id=user_id)
+        shared_records, _ = await hub_a2a_agent_service.list_visible_agents_for_user(
+            db,
+            user_id=user_id,
+            page=1,
+            size=1000,
+        )
+        built_in_profile = self_management_built_in_agent_service.get_profile()
+
+        items: list[dict[str, Any]] = []
+        if built_in_profile.configured:
+            items.append(
+                {
+                    "id": built_in_profile.agent_id,
+                    "source": "builtin",
+                    "name": built_in_profile.name,
+                    "card_url": "builtin://self-management-assistant",
+                    "auth_type": "none",
+                    "enabled": True,
+                    "health_status": A2AAgent.HEALTH_HEALTHY,
+                    "last_health_check_at": None,
+                    "last_health_check_error": None,
+                    "description": built_in_profile.description,
+                    "runtime": built_in_profile.runtime,
+                    "resources": list(built_in_profile.resources),
+                    "extra_headers": {},
+                    "invoke_metadata_defaults": {},
+                }
+            )
+
+        items.extend(
+            {
+                "id": str(record.id),
+                "source": "personal",
+                "name": record.name,
+                "card_url": record.card_url,
+                "auth_type": record.auth_type,
+                "enabled": record.enabled,
+                "health_status": record.health_status,
+                "last_health_check_at": record.last_health_check_at,
+                "last_health_check_error": record.last_health_check_error,
+                "extra_headers": dict(record.extra_headers),
+                "invoke_metadata_defaults": dict(record.invoke_metadata_defaults),
+            }
+            for record in personal_records
+        )
+        items.extend(
+            {
+                "id": str(record.id),
+                "source": "shared",
+                "name": record.name,
+                "card_url": record.card_url,
+                "auth_type": record.auth_type,
+                "enabled": True,
+                "health_status": A2AAgent.HEALTH_UNKNOWN,
+                "last_health_check_at": None,
+                "last_health_check_error": None,
+                "credential_mode": record.credential_mode,
+                "credential_configured": record.credential_configured,
+                "credential_display_hint": record.credential_display_hint,
+                "extra_headers": {},
+                "invoke_metadata_defaults": {},
+            }
+            for record in shared_records
+        )
+        return items
+
+    async def check_catalog_health(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        force: bool = False,
+    ) -> tuple[
+        UnifiedAgentHealthCheckSummaryRecord,
+        list[UnifiedAgentHealthCheckItemRecord],
+    ]:
+        personal_summary, personal_items = await a2a_agent_service.check_agents_health(
+            user_id=user_id,
+            force=force,
+        )
+
+        items: list[UnifiedAgentHealthCheckItemRecord] = [
+            UnifiedAgentHealthCheckItemRecord(
+                agent_id=str(item.agent_id),
+                agent_source="personal",
+                health_status=item.health_status,
+                checked_at=item.checked_at,
+                skipped_cooldown=item.skipped_cooldown,
+                error=item.error,
+            )
+            for item in personal_items
+        ]
+        requested = personal_summary.requested
+        checked = personal_summary.checked
+        skipped_cooldown = personal_summary.skipped_cooldown
+        status_counts = {
+            A2AAgent.HEALTH_HEALTHY: personal_summary.healthy,
+            A2AAgent.HEALTH_DEGRADED: personal_summary.degraded,
+            A2AAgent.HEALTH_UNAVAILABLE: personal_summary.unavailable,
+            A2AAgent.HEALTH_UNKNOWN: personal_summary.unknown,
+        }
+
+        shared_records, _ = await hub_a2a_agent_service.list_visible_agents_for_user(
+            db,
+            user_id=user_id,
+            page=1,
+            size=1000,
+        )
+        gateway = cast(Any, get_a2a_service()).gateway
+        for record in shared_records:
+            now = utc_now()
+            requested += 1
+            checked += 1
+            health_status = A2AAgent.HEALTH_HEALTHY
+            error_message: str | None = None
+            try:
+                runtime = await hub_a2a_runtime_builder.build(
+                    db,
+                    user_id=user_id,
+                    agent_id=record.id,
+                )
+                validation = await fetch_and_validate_agent_card(
+                    gateway=gateway,
+                    resolved=runtime.resolved,
+                )
+                if not validation.success:
+                    health_status = A2AAgent.HEALTH_DEGRADED
+                    error_message = self._normalize_health_error(
+                        self._extract_validation_error(validation)
+                    )
+            except HubA2AUserCredentialRequiredError as exc:
+                health_status = A2AAgent.HEALTH_UNKNOWN
+                error_message = self._normalize_health_error(str(exc))
+            except HubA2ARuntimeValidationError as exc:
+                health_status = A2AAgent.HEALTH_DEGRADED
+                error_message = self._normalize_health_error(str(exc))
+            except (
+                HubA2ARuntimeNotFoundError,
+                A2AAgentUnavailableError,
+                A2AClientResetRequiredError,
+            ) as exc:
+                health_status = A2AAgent.HEALTH_UNAVAILABLE
+                error_message = self._normalize_health_error(str(exc))
+            except Exception as exc:  # noqa: BLE001
+                health_status = A2AAgent.HEALTH_UNAVAILABLE
+                error_message = self._normalize_health_error(str(exc))
+
+            status_counts[health_status] += 1
+            items.append(
+                UnifiedAgentHealthCheckItemRecord(
+                    agent_id=str(record.id),
+                    agent_source="shared",
+                    health_status=health_status,
+                    checked_at=now,
+                    skipped_cooldown=False,
+                    error=error_message,
+                )
+            )
+
+        built_in_profile = self_management_built_in_agent_service.get_profile()
+        if built_in_profile.configured:
+            now = utc_now()
+            requested += 1
+            checked += 1
+            status_counts[A2AAgent.HEALTH_HEALTHY] += 1
+            items.append(
+                UnifiedAgentHealthCheckItemRecord(
+                    agent_id=built_in_profile.agent_id,
+                    agent_source="builtin",
+                    health_status=A2AAgent.HEALTH_HEALTHY,
+                    checked_at=now,
+                    skipped_cooldown=False,
+                    error=None,
+                )
+            )
+
+        return (
+            UnifiedAgentHealthCheckSummaryRecord(
+                requested=requested,
+                checked=checked,
+                skipped_cooldown=skipped_cooldown,
+                healthy=status_counts[A2AAgent.HEALTH_HEALTHY],
+                degraded=status_counts[A2AAgent.HEALTH_DEGRADED],
+                unavailable=status_counts[A2AAgent.HEALTH_UNAVAILABLE],
+                unknown=status_counts[A2AAgent.HEALTH_UNKNOWN],
+            ),
+            items,
+        )
+
+
+unified_agent_catalog_service = UnifiedAgentCatalogService()
+
+
+__all__ = [
+    "UnifiedAgentCatalogService",
+    "UnifiedAgentHealthCheckItemRecord",
+    "UnifiedAgentHealthCheckSummaryRecord",
+    "unified_agent_catalog_service",
+]

--- a/backend/app/features/agents_catalog/service.py
+++ b/backend/app/features/agents_catalog/service.py
@@ -21,6 +21,7 @@ from app.features.health_check_helpers import (
     build_health_check_item_fields,
     build_health_snapshot_update,
 )
+from app.features.health_reason_codes import AgentHealthReasonCode
 from app.features.hub_agents.runtime import (
     HubA2ARuntimeNotFoundError,
     HubA2ARuntimeValidationError,
@@ -78,12 +79,6 @@ class UnifiedAgentCatalogService:
     """Current-user catalog aggregation across personal/shared/built-in agents."""
 
     _non_personal_sources = ("shared", "builtin")
-    _reason_card_validation_failed = "card_validation_failed"
-    _reason_runtime_validation_failed = "runtime_validation_failed"
-    _reason_agent_unavailable = "agent_unavailable"
-    _reason_client_reset_required = "client_reset_required"
-    _reason_credential_required = "credential_required"
-    _reason_unexpected_error = "unexpected_error"
 
     @staticmethod
     def _extract_validation_error(validation: Any) -> str:
@@ -472,13 +467,13 @@ class UnifiedAgentCatalogService:
                         if snapshot is not None
                         else 0
                     )
-                    reason_code = self._reason_card_validation_failed
+                    reason_code = AgentHealthReasonCode.CARD_VALIDATION_FAILED
                     error_message = self._normalize_health_error(
                         self._extract_validation_error(validation)
                     )
             except HubA2AUserCredentialRequiredError as exc:
                 health_status = A2AAgent.HEALTH_UNAVAILABLE
-                reason_code = self._reason_credential_required
+                reason_code = AgentHealthReasonCode.CREDENTIAL_REQUIRED
                 error_message = self._normalize_health_error(str(exc))
             except HubA2ARuntimeValidationError as exc:
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -486,7 +481,7 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
-                reason_code = self._reason_runtime_validation_failed
+                reason_code = AgentHealthReasonCode.RUNTIME_VALIDATION_FAILED
                 error_message = self._normalize_health_error(str(exc))
             except HubA2ARuntimeNotFoundError as exc:
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -494,7 +489,7 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
-                reason_code = self._reason_agent_unavailable
+                reason_code = AgentHealthReasonCode.AGENT_UNAVAILABLE
                 error_message = self._normalize_health_error(str(exc))
             except A2AAgentUnavailableError as exc:
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -502,7 +497,7 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
-                reason_code = self._reason_agent_unavailable
+                reason_code = AgentHealthReasonCode.AGENT_UNAVAILABLE
                 error_message = self._normalize_health_error(str(exc))
             except A2AClientResetRequiredError as exc:
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -510,7 +505,7 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
-                reason_code = self._reason_client_reset_required
+                reason_code = AgentHealthReasonCode.CLIENT_RESET_REQUIRED
                 error_message = self._normalize_health_error(str(exc))
             except Exception as exc:  # noqa: BLE001
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -518,7 +513,7 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
-                reason_code = self._reason_unexpected_error
+                reason_code = AgentHealthReasonCode.UNEXPECTED_ERROR
                 error_message = self._normalize_health_error(str(exc))
 
             pending_updates.append(

--- a/backend/app/features/agents_catalog/service.py
+++ b/backend/app/features/agents_catalog/service.py
@@ -44,6 +44,7 @@ class UnifiedAgentHealthCheckItemRecord:
     checked_at: datetime
     skipped_cooldown: bool
     error: str | None
+    reason_code: str | None
 
 
 @dataclass(frozen=True)
@@ -66,12 +67,19 @@ class _AvailabilitySnapshotRecord:
     last_health_check_at: datetime | None
     last_successful_health_check_at: datetime | None
     last_health_check_error: str | None
+    last_health_check_reason_code: str | None
 
 
 class UnifiedAgentCatalogService:
     """Current-user catalog aggregation across personal/shared/built-in agents."""
 
     _non_personal_sources = ("shared", "builtin")
+    _reason_card_validation_failed = "card_validation_failed"
+    _reason_runtime_validation_failed = "runtime_validation_failed"
+    _reason_agent_unavailable = "agent_unavailable"
+    _reason_client_reset_required = "client_reset_required"
+    _reason_credential_required = "credential_required"
+    _reason_unexpected_error = "unexpected_error"
 
     @staticmethod
     def _extract_validation_error(validation: Any) -> str:
@@ -180,6 +188,9 @@ class UnifiedAgentCatalogService:
                     datetime | None, row.last_successful_health_check_at
                 ),
                 last_health_check_error=cast(str | None, row.last_health_check_error),
+                last_health_check_reason_code=cast(
+                    str | None, row.last_health_check_reason_code
+                ),
             )
         return snapshots
 
@@ -270,6 +281,11 @@ class UnifiedAgentCatalogService:
                         if built_in_snapshot is not None
                         else None
                     ),
+                    "last_health_check_reason_code": (
+                        built_in_snapshot.last_health_check_reason_code
+                        if built_in_snapshot is not None
+                        else None
+                    ),
                     "description": built_in_profile.description,
                     "runtime": built_in_profile.runtime,
                     "resources": list(built_in_profile.resources),
@@ -289,6 +305,7 @@ class UnifiedAgentCatalogService:
                 "health_status": record.health_status,
                 "last_health_check_at": record.last_health_check_at,
                 "last_health_check_error": record.last_health_check_error,
+                "last_health_check_reason_code": record.last_health_check_reason_code,
                 "extra_headers": dict(record.extra_headers),
                 "invoke_metadata_defaults": dict(record.invoke_metadata_defaults),
             }
@@ -314,6 +331,11 @@ class UnifiedAgentCatalogService:
                 ),
                 "last_health_check_error": (
                     snapshots[("shared", str(record.id))].last_health_check_error
+                    if ("shared", str(record.id)) in snapshots
+                    else None
+                ),
+                "last_health_check_reason_code": (
+                    snapshots[("shared", str(record.id))].last_health_check_reason_code
                     if ("shared", str(record.id)) in snapshots
                     else None
                 ),
@@ -350,6 +372,7 @@ class UnifiedAgentCatalogService:
                 checked_at=item.checked_at,
                 skipped_cooldown=item.skipped_cooldown,
                 error=item.error,
+                reason_code=item.reason_code,
             )
             for item in personal_items
         ]
@@ -399,6 +422,7 @@ class UnifiedAgentCatalogService:
                         checked_at=snapshot.last_health_check_at,
                         skipped_cooldown=True,
                         error=snapshot.last_health_check_error,
+                        reason_code=snapshot.last_health_check_reason_code,
                     )
                 )
                 continue
@@ -406,6 +430,7 @@ class UnifiedAgentCatalogService:
             checked += 1
             health_status = A2AAgent.HEALTH_HEALTHY
             error_message: str | None = None
+            reason_code: str | None = None
             consecutive_failures = 0
             try:
                 runtime = await hub_a2a_runtime_builder.build(
@@ -423,11 +448,13 @@ class UnifiedAgentCatalogService:
                         if snapshot is not None
                         else 0
                     )
+                    reason_code = self._reason_card_validation_failed
                     error_message = self._normalize_health_error(
                         self._extract_validation_error(validation)
                     )
             except HubA2AUserCredentialRequiredError as exc:
                 health_status = A2AAgent.HEALTH_UNAVAILABLE
+                reason_code = self._reason_credential_required
                 error_message = self._normalize_health_error(str(exc))
             except HubA2ARuntimeValidationError as exc:
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -435,17 +462,31 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
+                reason_code = self._reason_runtime_validation_failed
                 error_message = self._normalize_health_error(str(exc))
-            except (
-                HubA2ARuntimeNotFoundError,
-                A2AAgentUnavailableError,
-                A2AClientResetRequiredError,
-            ) as exc:
+            except HubA2ARuntimeNotFoundError as exc:
                 health_status, consecutive_failures = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                     if snapshot is not None
                     else 0
                 )
+                reason_code = self._reason_agent_unavailable
+                error_message = self._normalize_health_error(str(exc))
+            except A2AAgentUnavailableError as exc:
+                health_status, consecutive_failures = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                    if snapshot is not None
+                    else 0
+                )
+                reason_code = self._reason_agent_unavailable
+                error_message = self._normalize_health_error(str(exc))
+            except A2AClientResetRequiredError as exc:
+                health_status, consecutive_failures = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                    if snapshot is not None
+                    else 0
+                )
+                reason_code = self._reason_client_reset_required
                 error_message = self._normalize_health_error(str(exc))
             except Exception as exc:  # noqa: BLE001
                 health_status, consecutive_failures = self._resolve_failure_status(
@@ -453,6 +494,7 @@ class UnifiedAgentCatalogService:
                     if snapshot is not None
                     else 0
                 )
+                reason_code = self._reason_unexpected_error
                 error_message = self._normalize_health_error(str(exc))
 
             pending_updates.append(
@@ -473,6 +515,7 @@ class UnifiedAgentCatalogService:
                             )
                         ),
                         "last_health_check_error": error_message,
+                        "last_health_check_reason_code": reason_code,
                     },
                 )
             )
@@ -485,6 +528,7 @@ class UnifiedAgentCatalogService:
                     checked_at=now,
                     skipped_cooldown=False,
                     error=error_message,
+                    reason_code=reason_code,
                 )
             )
 
@@ -508,6 +552,7 @@ class UnifiedAgentCatalogService:
                         checked_at=snapshot.last_health_check_at,
                         skipped_cooldown=True,
                         error=snapshot.last_health_check_error,
+                        reason_code=snapshot.last_health_check_reason_code,
                     )
                 )
             else:
@@ -548,6 +593,7 @@ class UnifiedAgentCatalogService:
                                 )
                             ),
                             "last_health_check_error": error_message,
+                            "last_health_check_reason_code": None,
                         },
                     )
                 )
@@ -560,6 +606,7 @@ class UnifiedAgentCatalogService:
                         checked_at=now,
                         skipped_cooldown=False,
                         error=error_message,
+                        reason_code=None,
                     )
                 )
 

--- a/backend/app/features/auth/router.py
+++ b/backend/app/features/auth/router.py
@@ -14,11 +14,12 @@ from app.api.routing import StrictAPIRouter
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.security import (
+    REFRESH_TOKEN_TYPE,
     build_jwks_document,
     create_user_access_token,
     create_user_refresh_token,
     validate_password_strength,
-    verify_refresh_token_claims,
+    verify_jwt_token_claims,
 )
 from app.db.locking import set_postgres_local_timeouts
 from app.db.models.user import User
@@ -450,7 +451,7 @@ async def refresh_access_token(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing refresh token"
         )
 
-    claims = verify_refresh_token_claims(cookie)
+    claims = verify_jwt_token_claims(cookie, expected_type=REFRESH_TOKEN_TYPE)
     phase_timings_ms["jwt_verify"] = (time.perf_counter() - phase_started) * 1000.0
     phase_started = time.perf_counter()
     if not claims:
@@ -694,7 +695,11 @@ async def logout_user(
         await commit_safely(db)
         raise
     cookie = request.cookies.get(settings.auth_refresh_cookie_name)
-    claims = verify_refresh_token_claims(cookie) if cookie else None
+    claims = (
+        verify_jwt_token_claims(cookie, expected_type=REFRESH_TOKEN_TYPE)
+        if cookie
+        else None
+    )
     user_id: UUID | None = None
     session_id: UUID | None = None
     if claims is not None:

--- a/backend/app/features/auth/schemas.py
+++ b/backend/app/features/auth/schemas.py
@@ -42,7 +42,7 @@ class RegisterRequest(BaseModel):
         json_schema_extra={
             "example": {
                 "email": "alice@example.com",
-                "password": "Pass123!",  # pragma: allowlist secret
+                "password": "Pass123!",
                 "name": "Alice",
                 "timezone": "UTC",
                 "invite_code": "abcd1234",
@@ -72,7 +72,7 @@ class LoginRequest(BaseModel):
         json_schema_extra={
             "example": {
                 "email": "alice@example.com",
-                "password": "Pass123!",  # pragma: allowlist secret
+                "password": "Pass123!",
             }
         }
     )
@@ -161,9 +161,9 @@ class PasswordChangeRequest(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "current_password": "OldPass!23",  # pragma: allowlist secret
-                "new_password": "N3wPass!23",  # pragma: allowlist secret
-                "new_password_confirm": "N3wPass!23",  # pragma: allowlist secret
+                "current_password": "OldPass!23",
+                "new_password": "N3wPass!23",
+                "new_password_confirm": "N3wPass!23",
             }
         }
     )

--- a/backend/app/features/health_check_helpers.py
+++ b/backend/app/features/health_check_helpers.py
@@ -1,0 +1,47 @@
+"""Shared helpers for agent health check result assembly."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def build_health_snapshot_update(
+    *,
+    health_status: str,
+    healthy_status: str,
+    checked_at: datetime,
+    consecutive_failures: int,
+    previous_last_successful_at: datetime | None,
+    error_message: str | None,
+    reason_code: str | None,
+) -> dict[str, Any]:
+    return {
+        "health_status": health_status,
+        "consecutive_health_check_failures": consecutive_failures,
+        "last_health_check_at": checked_at,
+        "last_successful_health_check_at": (
+            checked_at
+            if health_status == healthy_status
+            else previous_last_successful_at
+        ),
+        "last_health_check_error": error_message,
+        "last_health_check_reason_code": reason_code,
+    }
+
+
+def build_health_check_item_fields(
+    *,
+    health_status: str,
+    checked_at: datetime,
+    skipped_cooldown: bool,
+    error: str | None,
+    reason_code: str | None,
+) -> dict[str, Any]:
+    return {
+        "health_status": health_status,
+        "checked_at": checked_at,
+        "skipped_cooldown": skipped_cooldown,
+        "error": error,
+        "reason_code": reason_code,
+    }

--- a/backend/app/features/health_reason_codes.py
+++ b/backend/app/features/health_reason_codes.py
@@ -1,0 +1,14 @@
+"""Shared structured reason codes for agent health check results."""
+
+from __future__ import annotations
+
+
+class AgentHealthReasonCode:
+    """Canonical persisted reason codes for agent health checks."""
+
+    CARD_VALIDATION_FAILED = "card_validation_failed"
+    RUNTIME_VALIDATION_FAILED = "runtime_validation_failed"
+    AGENT_UNAVAILABLE = "agent_unavailable"
+    CLIENT_RESET_REQUIRED = "client_reset_required"
+    CREDENTIAL_REQUIRED = "credential_required"
+    UNEXPECTED_ERROR = "unexpected_error"

--- a/backend/app/features/personal_agents/router.py
+++ b/backend/app/features/personal_agents/router.py
@@ -80,6 +80,7 @@ def _build_response(record: A2AAgentRecord) -> A2AAgentResponse:
         "last_health_check_at": record.last_health_check_at,
         "last_successful_health_check_at": record.last_successful_health_check_at,
         "last_health_check_error": record.last_health_check_error,
+        "last_health_check_reason_code": record.last_health_check_reason_code,
         "tags": record.tags,
         "extra_headers": record.extra_headers,
         "invoke_metadata_defaults": record.invoke_metadata_defaults,
@@ -342,6 +343,7 @@ async def check_agents_health(
                 checked_at=item.checked_at,
                 skipped_cooldown=item.skipped_cooldown,
                 error=item.error,
+                reason_code=cast(Any, item.reason_code),
             )
             for item in items
         ],
@@ -396,6 +398,7 @@ async def check_single_agent_health(
                 checked_at=item.checked_at,
                 skipped_cooldown=item.skipped_cooldown,
                 error=item.error,
+                reason_code=cast(Any, item.reason_code),
             )
             for item in items
         ],

--- a/backend/app/features/personal_agents/schemas.py
+++ b/backend/app/features/personal_agents/schemas.py
@@ -12,6 +12,13 @@ from app.schemas.pagination import ListResponse, Pagination
 
 A2AAuthType = Literal["none", "bearer", "basic"]
 A2AAgentHealthStatus = Literal["unknown", "healthy", "degraded", "unavailable"]
+A2AAgentHealthReasonCode = Literal[
+    "card_validation_failed",
+    "runtime_validation_failed",
+    "agent_unavailable",
+    "client_reset_required",
+    "unexpected_error",
+]
 A2AAgentHealthBucket = Literal[
     "all",
     "healthy",
@@ -72,6 +79,7 @@ class A2AAgentResponse(A2AAgentBase):
     last_health_check_at: Optional[datetime] = None
     last_successful_health_check_at: Optional[datetime] = None
     last_health_check_error: Optional[str] = None
+    last_health_check_reason_code: Optional[A2AAgentHealthReasonCode] = None
     token_last4: Optional[str] = Field(
         default=None, description="Last four characters of the stored token"
     )
@@ -114,6 +122,7 @@ class A2AAgentHealthCheckItem(BaseModel):
     checked_at: datetime
     skipped_cooldown: bool = False
     error: Optional[str] = None
+    reason_code: Optional[A2AAgentHealthReasonCode] = None
 
 
 class A2AAgentHealthCheckSummary(BaseModel):
@@ -135,6 +144,7 @@ __all__ = [
     "A2AAgentCreate",
     "A2AAgentHealthBucket",
     "A2AAgentHealthCheckItem",
+    "A2AAgentHealthReasonCode",
     "A2AAgentHealthCheckResponse",
     "A2AAgentHealthCheckSummary",
     "A2AAgentHealthStatus",

--- a/backend/app/features/personal_agents/service.py
+++ b/backend/app/features/personal_agents/service.py
@@ -48,6 +48,16 @@ class A2AAgentValidationError(A2AAgentError):
     """Raised when payload validation fails."""
 
 
+class A2AAgentHealthReasonCode:
+    """Structured reason codes for persisted personal agent health results."""
+
+    CARD_VALIDATION_FAILED = "card_validation_failed"
+    RUNTIME_VALIDATION_FAILED = "runtime_validation_failed"
+    AGENT_UNAVAILABLE = "agent_unavailable"
+    CLIENT_RESET_REQUIRED = "client_reset_required"
+    UNEXPECTED_ERROR = "unexpected_error"
+
+
 @dataclass(frozen=True)
 class A2AAgentRecord:
     id: UUID
@@ -62,6 +72,7 @@ class A2AAgentRecord:
     last_health_check_at: datetime | None
     last_successful_health_check_at: datetime | None
     last_health_check_error: str | None
+    last_health_check_reason_code: str | None
     tags: list[str]
     extra_headers: dict[str, str]
     invoke_metadata_defaults: dict[str, str]
@@ -86,6 +97,7 @@ class A2AAgentHealthCheckItemRecord:
     checked_at: datetime
     skipped_cooldown: bool
     error: str | None
+    reason_code: str | None
 
 
 @dataclass(frozen=True)
@@ -112,6 +124,7 @@ class _A2AAgentHealthSnapshot:
     health_status: str
     consecutive_health_check_failures: int
     last_health_check_at: datetime | None
+    last_health_check_reason_code: str | None
     credential: A2AAgentCredential | None
 
 
@@ -157,6 +170,10 @@ class A2AAgentService(AgentValidationMixin):
             last_health_check_error=cast(
                 str | None,
                 getattr(agent, "last_health_check_error", None),
+            ),
+            last_health_check_reason_code=cast(
+                str | None,
+                getattr(agent, "last_health_check_reason_code", None),
             ),
             tags=cast(list[str], agent.tags or []),
             extra_headers=cast(dict[str, str], agent.extra_headers or {}),
@@ -309,6 +326,7 @@ class A2AAgentService(AgentValidationMixin):
                         checked_at=snapshot.last_health_check_at,
                         skipped_cooldown=True,
                         error=None,
+                        reason_code=snapshot.last_health_check_reason_code,
                     )
                 )
                 continue
@@ -339,6 +357,7 @@ class A2AAgentService(AgentValidationMixin):
                                 "last_health_check_at": now,
                                 "last_successful_health_check_at": now,
                                 "last_health_check_error": None,
+                                "last_health_check_reason_code": None,
                             },
                         )
                     )
@@ -350,6 +369,7 @@ class A2AAgentService(AgentValidationMixin):
                             checked_at=now,
                             skipped_cooldown=False,
                             error=None,
+                            reason_code=None,
                         )
                     )
                     continue
@@ -357,6 +377,7 @@ class A2AAgentService(AgentValidationMixin):
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
+                reason_code = A2AAgentHealthReasonCode.CARD_VALIDATION_FAILED
                 error_message = self._normalize_health_error(
                     self._extract_validation_error(validation)
                 )
@@ -368,6 +389,7 @@ class A2AAgentService(AgentValidationMixin):
                             "consecutive_health_check_failures": failure_count,
                             "last_health_check_at": now,
                             "last_health_check_error": error_message,
+                            "last_health_check_reason_code": reason_code,
                         },
                     )
                 )
@@ -379,16 +401,14 @@ class A2AAgentService(AgentValidationMixin):
                         checked_at=now,
                         skipped_cooldown=False,
                         error=error_message,
+                        reason_code=reason_code,
                     )
                 )
-            except (
-                A2AAgentUnavailableError,
-                A2AClientResetRequiredError,
-                A2ARuntimeValidationError,
-            ) as exc:
+            except A2ARuntimeValidationError as exc:
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
+                reason_code = A2AAgentHealthReasonCode.RUNTIME_VALIDATION_FAILED
                 error_message = self._normalize_health_error(str(exc))
                 pending_updates.append(
                     (
@@ -398,6 +418,7 @@ class A2AAgentService(AgentValidationMixin):
                             "consecutive_health_check_failures": failure_count,
                             "last_health_check_at": now,
                             "last_health_check_error": error_message,
+                            "last_health_check_reason_code": reason_code,
                         },
                     )
                 )
@@ -409,12 +430,72 @@ class A2AAgentService(AgentValidationMixin):
                         checked_at=now,
                         skipped_cooldown=False,
                         error=error_message,
+                        reason_code=reason_code,
+                    )
+                )
+            except A2AAgentUnavailableError as exc:
+                next_status, failure_count = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                )
+                reason_code = A2AAgentHealthReasonCode.AGENT_UNAVAILABLE
+                error_message = self._normalize_health_error(str(exc))
+                pending_updates.append(
+                    (
+                        snapshot.agent_id,
+                        {
+                            "health_status": next_status,
+                            "consecutive_health_check_failures": failure_count,
+                            "last_health_check_at": now,
+                            "last_health_check_error": error_message,
+                            "last_health_check_reason_code": reason_code,
+                        },
+                    )
+                )
+                status_counts[next_status] += 1
+                items.append(
+                    A2AAgentHealthCheckItemRecord(
+                        agent_id=snapshot.agent_id,
+                        health_status=next_status,
+                        checked_at=now,
+                        skipped_cooldown=False,
+                        error=error_message,
+                        reason_code=reason_code,
+                    )
+                )
+            except A2AClientResetRequiredError as exc:
+                next_status, failure_count = self._resolve_failure_status(
+                    snapshot.consecutive_health_check_failures
+                )
+                reason_code = A2AAgentHealthReasonCode.CLIENT_RESET_REQUIRED
+                error_message = self._normalize_health_error(str(exc))
+                pending_updates.append(
+                    (
+                        snapshot.agent_id,
+                        {
+                            "health_status": next_status,
+                            "consecutive_health_check_failures": failure_count,
+                            "last_health_check_at": now,
+                            "last_health_check_error": error_message,
+                            "last_health_check_reason_code": reason_code,
+                        },
+                    )
+                )
+                status_counts[next_status] += 1
+                items.append(
+                    A2AAgentHealthCheckItemRecord(
+                        agent_id=snapshot.agent_id,
+                        health_status=next_status,
+                        checked_at=now,
+                        skipped_cooldown=False,
+                        error=error_message,
+                        reason_code=reason_code,
                     )
                 )
             except Exception as exc:  # noqa: BLE001
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
+                reason_code = A2AAgentHealthReasonCode.UNEXPECTED_ERROR
                 error_message = self._normalize_health_error(str(exc))
                 pending_updates.append(
                     (
@@ -424,6 +505,7 @@ class A2AAgentService(AgentValidationMixin):
                             "consecutive_health_check_failures": failure_count,
                             "last_health_check_at": now,
                             "last_health_check_error": error_message,
+                            "last_health_check_reason_code": reason_code,
                         },
                     )
                 )
@@ -435,6 +517,7 @@ class A2AAgentService(AgentValidationMixin):
                         checked_at=now,
                         skipped_cooldown=False,
                         error=error_message,
+                        reason_code=reason_code,
                     )
                 )
 
@@ -889,6 +972,10 @@ class A2AAgentService(AgentValidationMixin):
                     last_health_check_at=cast(
                         datetime | None,
                         getattr(agent, "last_health_check_at", None),
+                    ),
+                    last_health_check_reason_code=cast(
+                        str | None,
+                        getattr(agent, "last_health_check_reason_code", None),
                     ),
                     credential=cast(A2AAgentCredential | None, credential),
                 )

--- a/backend/app/features/personal_agents/service.py
+++ b/backend/app/features/personal_agents/service.py
@@ -28,6 +28,7 @@ from app.features.health_check_helpers import (
     build_health_check_item_fields,
     build_health_snapshot_update,
 )
+from app.features.health_reason_codes import AgentHealthReasonCode
 from app.features.personal_agents.runtime import (
     A2ARuntimeValidationError,
     a2a_runtime_builder,
@@ -50,16 +51,6 @@ class A2AAgentNotFoundError(A2AAgentError):
 
 class A2AAgentValidationError(A2AAgentError):
     """Raised when payload validation fails."""
-
-
-class A2AAgentHealthReasonCode:
-    """Structured reason codes for persisted personal agent health results."""
-
-    CARD_VALIDATION_FAILED = "card_validation_failed"
-    RUNTIME_VALIDATION_FAILED = "runtime_validation_failed"
-    AGENT_UNAVAILABLE = "agent_unavailable"
-    CLIENT_RESET_REQUIRED = "client_reset_required"
-    UNEXPECTED_ERROR = "unexpected_error"
 
 
 @dataclass(frozen=True)
@@ -402,7 +393,7 @@ class A2AAgentService(AgentValidationMixin):
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
-                reason_code = A2AAgentHealthReasonCode.CARD_VALIDATION_FAILED
+                reason_code = AgentHealthReasonCode.CARD_VALIDATION_FAILED
                 error_message = self._normalize_health_error(
                     self._extract_validation_error(validation)
                 )
@@ -434,7 +425,7 @@ class A2AAgentService(AgentValidationMixin):
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
-                reason_code = A2AAgentHealthReasonCode.RUNTIME_VALIDATION_FAILED
+                reason_code = AgentHealthReasonCode.RUNTIME_VALIDATION_FAILED
                 error_message = self._normalize_health_error(str(exc))
                 pending_updates.append(
                     (
@@ -464,7 +455,7 @@ class A2AAgentService(AgentValidationMixin):
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
-                reason_code = A2AAgentHealthReasonCode.AGENT_UNAVAILABLE
+                reason_code = AgentHealthReasonCode.AGENT_UNAVAILABLE
                 error_message = self._normalize_health_error(str(exc))
                 pending_updates.append(
                     (
@@ -494,7 +485,7 @@ class A2AAgentService(AgentValidationMixin):
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
-                reason_code = A2AAgentHealthReasonCode.CLIENT_RESET_REQUIRED
+                reason_code = AgentHealthReasonCode.CLIENT_RESET_REQUIRED
                 error_message = self._normalize_health_error(str(exc))
                 pending_updates.append(
                     (
@@ -524,7 +515,7 @@ class A2AAgentService(AgentValidationMixin):
                 next_status, failure_count = self._resolve_failure_status(
                     snapshot.consecutive_health_check_failures
                 )
-                reason_code = A2AAgentHealthReasonCode.UNEXPECTED_ERROR
+                reason_code = AgentHealthReasonCode.UNEXPECTED_ERROR
                 error_message = self._normalize_health_error(str(exc))
                 pending_updates.append(
                     (

--- a/backend/app/features/personal_agents/service.py
+++ b/backend/app/features/personal_agents/service.py
@@ -24,6 +24,10 @@ from app.features.agents_shared.common import (
     get_agent_credential,
     upsert_agent_credential,
 )
+from app.features.health_check_helpers import (
+    build_health_check_item_fields,
+    build_health_snapshot_update,
+)
 from app.features.personal_agents.runtime import (
     A2ARuntimeValidationError,
     a2a_runtime_builder,
@@ -124,6 +128,7 @@ class _A2AAgentHealthSnapshot:
     health_status: str
     consecutive_health_check_failures: int
     last_health_check_at: datetime | None
+    last_successful_health_check_at: datetime | None
     last_health_check_reason_code: str | None
     credential: A2AAgentCredential | None
 
@@ -309,6 +314,29 @@ class A2AAgentService(AgentValidationMixin):
         checked = 0
         skipped_cooldown = 0
 
+        def _append_item(
+            *,
+            agent_id: UUID,
+            health_status: str,
+            checked_at: datetime,
+            skipped: bool,
+            error: str | None,
+            reason_code: str | None,
+        ) -> None:
+            status_counts[health_status] += 1
+            items.append(
+                A2AAgentHealthCheckItemRecord(
+                    agent_id=agent_id,
+                    **build_health_check_item_fields(
+                        health_status=health_status,
+                        checked_at=checked_at,
+                        skipped_cooldown=skipped,
+                        error=error,
+                        reason_code=reason_code,
+                    ),
+                )
+            )
+
         for snapshot in snapshots:
             now = utc_now()
             if (
@@ -318,16 +346,13 @@ class A2AAgentService(AgentValidationMixin):
             ):
                 skipped_cooldown += 1
                 status = self._normalize_health_status(snapshot.health_status)
-                status_counts[status] += 1
-                items.append(
-                    A2AAgentHealthCheckItemRecord(
-                        agent_id=snapshot.agent_id,
-                        health_status=status,
-                        checked_at=snapshot.last_health_check_at,
-                        skipped_cooldown=True,
-                        error=None,
-                        reason_code=snapshot.last_health_check_reason_code,
-                    )
+                _append_item(
+                    agent_id=snapshot.agent_id,
+                    health_status=status,
+                    checked_at=snapshot.last_health_check_at,
+                    skipped=True,
+                    error=None,
+                    reason_code=snapshot.last_health_check_reason_code,
                 )
                 continue
 
@@ -351,26 +376,26 @@ class A2AAgentService(AgentValidationMixin):
                     pending_updates.append(
                         (
                             snapshot.agent_id,
-                            {
-                                "health_status": next_status,
-                                "consecutive_health_check_failures": 0,
-                                "last_health_check_at": now,
-                                "last_successful_health_check_at": now,
-                                "last_health_check_error": None,
-                                "last_health_check_reason_code": None,
-                            },
+                            build_health_snapshot_update(
+                                health_status=next_status,
+                                healthy_status=A2AAgent.HEALTH_HEALTHY,
+                                checked_at=now,
+                                consecutive_failures=0,
+                                previous_last_successful_at=(
+                                    snapshot.last_successful_health_check_at
+                                ),
+                                error_message=None,
+                                reason_code=None,
+                            ),
                         )
                     )
-                    status_counts[next_status] += 1
-                    items.append(
-                        A2AAgentHealthCheckItemRecord(
-                            agent_id=snapshot.agent_id,
-                            health_status=next_status,
-                            checked_at=now,
-                            skipped_cooldown=False,
-                            error=None,
-                            reason_code=None,
-                        )
+                    _append_item(
+                        agent_id=snapshot.agent_id,
+                        health_status=next_status,
+                        checked_at=now,
+                        skipped=False,
+                        error=None,
+                        reason_code=None,
                     )
                     continue
 
@@ -384,25 +409,26 @@ class A2AAgentService(AgentValidationMixin):
                 pending_updates.append(
                     (
                         snapshot.agent_id,
-                        {
-                            "health_status": next_status,
-                            "consecutive_health_check_failures": failure_count,
-                            "last_health_check_at": now,
-                            "last_health_check_error": error_message,
-                            "last_health_check_reason_code": reason_code,
-                        },
+                        build_health_snapshot_update(
+                            health_status=next_status,
+                            healthy_status=A2AAgent.HEALTH_HEALTHY,
+                            checked_at=now,
+                            consecutive_failures=failure_count,
+                            previous_last_successful_at=(
+                                snapshot.last_successful_health_check_at
+                            ),
+                            error_message=error_message,
+                            reason_code=reason_code,
+                        ),
                     )
                 )
-                status_counts[next_status] += 1
-                items.append(
-                    A2AAgentHealthCheckItemRecord(
-                        agent_id=snapshot.agent_id,
-                        health_status=next_status,
-                        checked_at=now,
-                        skipped_cooldown=False,
-                        error=error_message,
-                        reason_code=reason_code,
-                    )
+                _append_item(
+                    agent_id=snapshot.agent_id,
+                    health_status=next_status,
+                    checked_at=now,
+                    skipped=False,
+                    error=error_message,
+                    reason_code=reason_code,
                 )
             except A2ARuntimeValidationError as exc:
                 next_status, failure_count = self._resolve_failure_status(
@@ -413,25 +439,26 @@ class A2AAgentService(AgentValidationMixin):
                 pending_updates.append(
                     (
                         snapshot.agent_id,
-                        {
-                            "health_status": next_status,
-                            "consecutive_health_check_failures": failure_count,
-                            "last_health_check_at": now,
-                            "last_health_check_error": error_message,
-                            "last_health_check_reason_code": reason_code,
-                        },
+                        build_health_snapshot_update(
+                            health_status=next_status,
+                            healthy_status=A2AAgent.HEALTH_HEALTHY,
+                            checked_at=now,
+                            consecutive_failures=failure_count,
+                            previous_last_successful_at=(
+                                snapshot.last_successful_health_check_at
+                            ),
+                            error_message=error_message,
+                            reason_code=reason_code,
+                        ),
                     )
                 )
-                status_counts[next_status] += 1
-                items.append(
-                    A2AAgentHealthCheckItemRecord(
-                        agent_id=snapshot.agent_id,
-                        health_status=next_status,
-                        checked_at=now,
-                        skipped_cooldown=False,
-                        error=error_message,
-                        reason_code=reason_code,
-                    )
+                _append_item(
+                    agent_id=snapshot.agent_id,
+                    health_status=next_status,
+                    checked_at=now,
+                    skipped=False,
+                    error=error_message,
+                    reason_code=reason_code,
                 )
             except A2AAgentUnavailableError as exc:
                 next_status, failure_count = self._resolve_failure_status(
@@ -442,25 +469,26 @@ class A2AAgentService(AgentValidationMixin):
                 pending_updates.append(
                     (
                         snapshot.agent_id,
-                        {
-                            "health_status": next_status,
-                            "consecutive_health_check_failures": failure_count,
-                            "last_health_check_at": now,
-                            "last_health_check_error": error_message,
-                            "last_health_check_reason_code": reason_code,
-                        },
+                        build_health_snapshot_update(
+                            health_status=next_status,
+                            healthy_status=A2AAgent.HEALTH_HEALTHY,
+                            checked_at=now,
+                            consecutive_failures=failure_count,
+                            previous_last_successful_at=(
+                                snapshot.last_successful_health_check_at
+                            ),
+                            error_message=error_message,
+                            reason_code=reason_code,
+                        ),
                     )
                 )
-                status_counts[next_status] += 1
-                items.append(
-                    A2AAgentHealthCheckItemRecord(
-                        agent_id=snapshot.agent_id,
-                        health_status=next_status,
-                        checked_at=now,
-                        skipped_cooldown=False,
-                        error=error_message,
-                        reason_code=reason_code,
-                    )
+                _append_item(
+                    agent_id=snapshot.agent_id,
+                    health_status=next_status,
+                    checked_at=now,
+                    skipped=False,
+                    error=error_message,
+                    reason_code=reason_code,
                 )
             except A2AClientResetRequiredError as exc:
                 next_status, failure_count = self._resolve_failure_status(
@@ -471,25 +499,26 @@ class A2AAgentService(AgentValidationMixin):
                 pending_updates.append(
                     (
                         snapshot.agent_id,
-                        {
-                            "health_status": next_status,
-                            "consecutive_health_check_failures": failure_count,
-                            "last_health_check_at": now,
-                            "last_health_check_error": error_message,
-                            "last_health_check_reason_code": reason_code,
-                        },
+                        build_health_snapshot_update(
+                            health_status=next_status,
+                            healthy_status=A2AAgent.HEALTH_HEALTHY,
+                            checked_at=now,
+                            consecutive_failures=failure_count,
+                            previous_last_successful_at=(
+                                snapshot.last_successful_health_check_at
+                            ),
+                            error_message=error_message,
+                            reason_code=reason_code,
+                        ),
                     )
                 )
-                status_counts[next_status] += 1
-                items.append(
-                    A2AAgentHealthCheckItemRecord(
-                        agent_id=snapshot.agent_id,
-                        health_status=next_status,
-                        checked_at=now,
-                        skipped_cooldown=False,
-                        error=error_message,
-                        reason_code=reason_code,
-                    )
+                _append_item(
+                    agent_id=snapshot.agent_id,
+                    health_status=next_status,
+                    checked_at=now,
+                    skipped=False,
+                    error=error_message,
+                    reason_code=reason_code,
                 )
             except Exception as exc:  # noqa: BLE001
                 next_status, failure_count = self._resolve_failure_status(
@@ -500,25 +529,26 @@ class A2AAgentService(AgentValidationMixin):
                 pending_updates.append(
                     (
                         snapshot.agent_id,
-                        {
-                            "health_status": next_status,
-                            "consecutive_health_check_failures": failure_count,
-                            "last_health_check_at": now,
-                            "last_health_check_error": error_message,
-                            "last_health_check_reason_code": reason_code,
-                        },
+                        build_health_snapshot_update(
+                            health_status=next_status,
+                            healthy_status=A2AAgent.HEALTH_HEALTHY,
+                            checked_at=now,
+                            consecutive_failures=failure_count,
+                            previous_last_successful_at=(
+                                snapshot.last_successful_health_check_at
+                            ),
+                            error_message=error_message,
+                            reason_code=reason_code,
+                        ),
                     )
                 )
-                status_counts[next_status] += 1
-                items.append(
-                    A2AAgentHealthCheckItemRecord(
-                        agent_id=snapshot.agent_id,
-                        health_status=next_status,
-                        checked_at=now,
-                        skipped_cooldown=False,
-                        error=error_message,
-                        reason_code=reason_code,
-                    )
+                _append_item(
+                    agent_id=snapshot.agent_id,
+                    health_status=next_status,
+                    checked_at=now,
+                    skipped=False,
+                    error=error_message,
+                    reason_code=reason_code,
                 )
 
         if pending_updates:
@@ -972,6 +1002,10 @@ class A2AAgentService(AgentValidationMixin):
                     last_health_check_at=cast(
                         datetime | None,
                         getattr(agent, "last_health_check_at", None),
+                    ),
+                    last_successful_health_check_at=cast(
+                        datetime | None,
+                        getattr(agent, "last_successful_health_check_at", None),
                     ),
                     last_health_check_reason_code=cast(
                         str | None,

--- a/backend/app/features/schedules/self_management_jobs_service.py
+++ b/backend/app/features/schedules/self_management_jobs_service.py
@@ -37,9 +37,6 @@ class SelfManagementJobsService:
             raise ValueError("Authenticated user id is required")
         return user_id
 
-    def _timezone(self, user: User) -> str:
-        return cast(str, user.timezone or "UTC")
-
     def supports_prompt_update(self, payload: A2AScheduleTaskUpdate) -> bool:
         """Return whether the payload maps cleanly to the first-wave prompt update."""
 

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -20,12 +20,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.security import (
+    SELF_MANAGEMENT_INTERRUPT_TOKEN_TYPE,
     create_self_management_access_token,
     create_self_management_interrupt_token,
     get_self_management_interrupt_conversation_id,
     get_self_management_interrupt_message,
     get_self_management_interrupt_tool_names,
-    verify_self_management_interrupt_token_claims,
+    verify_jwt_token_claims,
 )
 from app.db.models.agent_message import AgentMessage
 from app.db.models.user import User
@@ -354,7 +355,10 @@ class SelfManagementBuiltInAgentService:
             interrupt = asked_interrupts.get(request_id)
             if interrupt is None:
                 continue
-            claims = verify_self_management_interrupt_token_claims(request_id)
+            claims = verify_jwt_token_claims(
+                request_id,
+                expected_type=SELF_MANAGEMENT_INTERRUPT_TOKEN_TYPE,
+            )
             if claims is None:
                 expired_request_ids.append(request_id)
                 continue
@@ -509,7 +513,10 @@ class SelfManagementBuiltInAgentService:
         reply: str,
         agent_message_id: UUID | None = None,
     ) -> SelfManagementBuiltInAgentRunResult:
-        claims = verify_self_management_interrupt_token_claims(request_id)
+        claims = verify_jwt_token_claims(
+            request_id,
+            expected_type=SELF_MANAGEMENT_INTERRUPT_TOKEN_TYPE,
+        )
         if claims is None:
             raise SelfManagementBuiltInAgentUnavailableError(
                 "The write approval request is invalid or expired."

--- a/backend/app/features/self_management_shared/self_management_toolkit.py
+++ b/backend/app/features/self_management_shared/self_management_toolkit.py
@@ -699,6 +699,7 @@ class SelfManagementToolkit:
                 else None
             ),
             "last_health_check_error": record.last_health_check_error,
+            "last_health_check_reason_code": record.last_health_check_reason_code,
             "tags": list(record.tags),
             "extra_headers": dict(record.extra_headers),
             "invoke_metadata_defaults": dict(record.invoke_metadata_defaults),
@@ -729,6 +730,7 @@ class SelfManagementToolkit:
                     "checked_at": item.checked_at.isoformat(),
                     "skipped_cooldown": bool(item.skipped_cooldown),
                     "error": item.error,
+                    "reason_code": item.reason_code,
                 }
                 for item in items
             ],

--- a/backend/app/features/sessions/support.py
+++ b/backend/app/features/sessions/support.py
@@ -193,28 +193,6 @@ class SessionHubSupport:
             raise ValueError("message_id_conflict")
         return message
 
-    async def find_latest_message_by_sender(
-        self,
-        db: AsyncSession,
-        *,
-        user_id: UUID,
-        conversation_id: UUID,
-        sender: str,
-    ) -> AgentMessage | None:
-        stmt = (
-            select(AgentMessage)
-            .where(
-                and_(
-                    AgentMessage.user_id == user_id,
-                    AgentMessage.conversation_id == conversation_id,
-                    AgentMessage.sender == sender,
-                )
-            )
-            .order_by(AgentMessage.created_at.desc(), AgentMessage.id.desc())
-            .limit(1)
-        )
-        return cast(AgentMessage | None, await db.scalar(stmt))
-
     async def ensure_idempotent_user_query(
         self,
         db: AsyncSession,

--- a/backend/app/integrations/a2a_client/adapters/jsonrpc_common.py
+++ b/backend/app/integrations/a2a_client/adapters/jsonrpc_common.py
@@ -9,9 +9,7 @@ from uuid import uuid4
 from a2a.client import ClientCallInterceptor
 
 from app.integrations.a2a_client.errors import A2APeerProtocolError
-from app.integrations.a2a_error_contract import (
-    build_protocol_error_from_jsonrpc_error as build_shared_protocol_error,
-)
+from app.integrations.a2a_error_contract import build_protocol_error_from_jsonrpc_error
 
 
 def build_jsonrpc_payload(
@@ -46,19 +44,6 @@ async def apply_jsonrpc_interceptors(
             None,
         )
     return final_payload, final_http_kwargs
-
-
-def build_protocol_error_from_jsonrpc_error(
-    error: dict[str, Any],
-    *,
-    fallback_message: str,
-    http_status: int | None,
-) -> A2APeerProtocolError:
-    return build_shared_protocol_error(
-        error,
-        fallback_message=fallback_message,
-        http_status=http_status,
-    )
 
 
 def parse_jsonrpc_error_payload(

--- a/backend/app/integrations/a2a_extensions/interrupt_extension_service.py
+++ b/backend/app/integrations/a2a_extensions/interrupt_extension_service.py
@@ -142,7 +142,10 @@ class InterruptExtensionService:
             return ExtensionCallResult(success=True, result=resp.result, meta=meta)
 
         error = resp.error or {}
-        error_details = self._support.build_interrupt_business_error_details(error, ext)
+        error_details = self._support.build_upstream_error_details(
+            error=error,
+            business_code_map=ext.business_code_map,
+        )
         self._support.record_extension_metric(
             metric_key, success=False, error_code=error_details.error_code
         )

--- a/backend/app/integrations/a2a_extensions/opencode_discovery_service.py
+++ b/backend/app/integrations/a2a_extensions/opencode_discovery_service.py
@@ -77,7 +77,10 @@ class OpencodeDiscoveryService:
             )
 
         error = resp.error or {}
-        error_details = self._support.build_business_error_details(error, ext)
+        error_details = self._support.build_upstream_error_details(
+            error=error,
+            business_code_map=ext.business_code_map,
+        )
         self._support.record_extension_metric(
             metric_key, success=False, error_code=error_details.error_code
         )

--- a/backend/app/integrations/a2a_extensions/session_extension_service.py
+++ b/backend/app/integrations/a2a_extensions/session_extension_service.py
@@ -632,7 +632,10 @@ class SessionExtensionService:
             return ExtensionCallResult(success=True, result=resolved_result, meta=meta)
 
         error = resp.error or {}
-        error_details = self._support.build_business_error_details(error, ext)
+        error_details = self._support.build_upstream_error_details(
+            error=error,
+            business_code_map=ext.business_code_map,
+        )
         self._support.record_extension_metric(
             metric_key, success=False, error_code=error_details.error_code
         )

--- a/backend/app/integrations/a2a_extensions/session_query.py
+++ b/backend/app/integrations/a2a_extensions/session_query.py
@@ -186,18 +186,6 @@ def _resolve_message_cursor_pagination(
     )
 
 
-def _resolve_method_contract_optional_params(
-    params: Dict[str, Any],
-    *,
-    method_name: str,
-) -> set[str]:
-    return _resolve_method_contract_param_names(
-        params,
-        method_name=method_name,
-        field_name="optional",
-    )
-
-
 def _resolve_method_contract_param_names(
     params: Dict[str, Any],
     *,
@@ -337,9 +325,10 @@ def _resolve_session_list_filters(
     *,
     list_sessions_method: str,
 ) -> SessionListFiltersContract:
-    optional_params = _resolve_method_contract_optional_params(
+    optional_params = _resolve_method_contract_param_names(
         params,
         method_name=list_sessions_method,
+        field_name="optional",
     )
     if not optional_params:
         return SessionListFiltersContract()

--- a/backend/app/integrations/a2a_extensions/shared_support.py
+++ b/backend/app/integrations/a2a_extensions/shared_support.py
@@ -30,11 +30,6 @@ from app.integrations.a2a_error_contract import (
 from app.integrations.a2a_extensions.errors import A2AExtensionUpstreamError
 from app.integrations.a2a_extensions.jsonrpc import JsonRpcClient, JsonRpcResponse
 from app.integrations.a2a_extensions.metrics import a2a_extension_metrics
-from app.integrations.a2a_extensions.types import (
-    ResolvedExtension,
-    ResolvedInterruptCallbackExtension,
-    ResolvedProviderDiscoveryExtension,
-)
 from app.runtime.a2a_proxy_service import a2a_proxy_service
 from app.utils.outbound_url import (
     OutboundURLNotAllowedError,
@@ -220,46 +215,6 @@ class A2AExtensionSupport:
             business_code_map=business_code_map,
             default_error_code="upstream_error",
             source="upstream_a2a",
-        )
-
-    @staticmethod
-    def build_business_error_details(
-        error: Dict[str, Any],
-        ext: ResolvedExtension | ResolvedProviderDiscoveryExtension,
-    ) -> A2AUpstreamErrorDetails:
-        return A2AExtensionSupport.build_upstream_error_details(
-            error=error,
-            business_code_map=ext.business_code_map,
-        )
-
-    @staticmethod
-    def map_business_error_code(
-        error: Dict[str, Any],
-        ext: ResolvedExtension | ResolvedProviderDiscoveryExtension,
-    ) -> str:
-        return A2AExtensionSupport.map_upstream_error_code(
-            error=error,
-            business_code_map=ext.business_code_map,
-        )
-
-    @staticmethod
-    def build_interrupt_business_error_details(
-        error: Dict[str, Any],
-        ext: ResolvedInterruptCallbackExtension,
-    ) -> A2AUpstreamErrorDetails:
-        return A2AExtensionSupport.build_upstream_error_details(
-            error=error,
-            business_code_map=ext.business_code_map,
-        )
-
-    @staticmethod
-    def map_interrupt_business_error_code(
-        error: Dict[str, Any],
-        ext: ResolvedInterruptCallbackExtension,
-    ) -> str:
-        return A2AExtensionSupport.map_upstream_error_code(
-            error=error,
-            business_code_map=ext.business_code_map,
         )
 
     @staticmethod

--- a/backend/app/integrations/a2a_extensions/shared_support.py
+++ b/backend/app/integrations/a2a_extensions/shared_support.py
@@ -19,13 +19,7 @@ from app.integrations.a2a_error_contract import (
     build_upstream_error_details,
 )
 from app.integrations.a2a_error_contract import (
-    coerce_jsonrpc_error_code as coerce_jsonrpc_numeric_code,
-)
-from app.integrations.a2a_error_contract import (
     map_upstream_error_code as map_upstream_error_code_token,
-)
-from app.integrations.a2a_error_contract import (
-    normalize_error_data_type as normalize_upstream_error_data_type,
 )
 from app.integrations.a2a_extensions.errors import A2AExtensionUpstreamError
 from app.integrations.a2a_extensions.jsonrpc import JsonRpcClient, JsonRpcResponse
@@ -171,14 +165,6 @@ class A2AExtensionSupport:
                 source="upstream_http",
                 upstream_error={"message": str(exc), "type": type(exc).__name__},
             ) from exc
-
-    @staticmethod
-    def coerce_jsonrpc_error_code(error: Dict[str, Any]) -> Optional[int]:
-        return coerce_jsonrpc_numeric_code(error)
-
-    @staticmethod
-    def normalize_error_data_type(error: Dict[str, Any]) -> Optional[str]:
-        return normalize_upstream_error_data_type(error)
 
     @staticmethod
     def map_upstream_error_code(

--- a/backend/app/middleware/debug_logging.py
+++ b/backend/app/middleware/debug_logging.py
@@ -25,7 +25,7 @@ from app.core.logging import (
     set_request_id,
     set_user_context,
 )
-from app.core.security import verify_access_token
+from app.core.security import ACCESS_TOKEN_TYPE, verify_jwt_token
 from app.utils.logging_redaction import (
     redact_headers_for_logging,
     redact_query_params_for_logging,
@@ -48,7 +48,10 @@ class DebugLoggingMiddleware(BaseHTTPMiddleware):
         if auth_header:
             scheme, _, credentials = auth_header.partition(" ")
             if scheme.lower() == "bearer" and credentials:
-                user_id = verify_access_token(credentials)
+                user_id = verify_jwt_token(
+                    credentials,
+                    expected_type=ACCESS_TOKEN_TYPE,
+                )
                 if user_id:
                     set_user_context(user_id)
                     set_actor_context(

--- a/backend/scripts/run_vulture.sh
+++ b/backend/scripts/run_vulture.sh
@@ -3,13 +3,22 @@
 set -euo pipefail
 
 MODE="${1:-strict}"
+STRICT_ARGS=(app tests --min-confidence 80)
+EXPLORATORY_ARGS=(
+  app
+  tests
+  --ignore-names
+  "pytestmark,model_config"
+  --ignore-decorators
+  "@app.get,@app.post,@app.put,@app.patch,@app.delete,@app.websocket,@router.get,@router.post,@router.put,@router.patch,@router.delete,@router.websocket,@field_validator,@model_validator,@validator,@root_validator"
+)
 
 case "$MODE" in
   strict)
-    exec uv run --with vulture vulture app tests --min-confidence 80
+    exec uv run --with vulture vulture "${STRICT_ARGS[@]}"
     ;;
   exploratory)
-    exec uv run --with vulture vulture app tests
+    exec uv run --with vulture vulture "${EXPLORATORY_ARGS[@]}"
     ;;
   *)
     echo "Usage: scripts/run_vulture.sh [strict|exploratory]" >&2

--- a/backend/scripts/run_vulture.sh
+++ b/backend/scripts/run_vulture.sh
@@ -10,7 +10,7 @@ EXPLORATORY_ARGS=(
   --ignore-names
   "pytestmark,model_config"
   --ignore-decorators
-  "@app.get,@app.post,@app.put,@app.patch,@app.delete,@app.websocket,@router.get,@router.post,@router.put,@router.patch,@router.delete,@router.websocket,@field_validator,@model_validator,@validator,@root_validator"
+  "@app.get,@app.post,@app.put,@app.patch,@app.delete,@app.websocket,@router.get,@router.post,@router.put,@router.patch,@router.delete,@router.websocket,@field_validator,@model_validator,@validator,@root_validator,@mcp.tool"
 )
 
 case "$MODE" in

--- a/backend/tests/agents_catalog/test_agents_catalog_routes.py
+++ b/backend/tests/agents_catalog/test_agents_catalog_routes.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import settings
+from app.features.agents_catalog import router as agents_catalog_router
+from app.features.agents_catalog.service import unified_agent_catalog_service
+from tests.support.api_utils import create_test_client
+from tests.support.utils import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest.mark.asyncio
+async def test_list_current_user_agent_catalog_returns_unified_items(
+    async_session_maker,
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(
+        async_db_session,
+        email="catalog-user@example.com",
+        is_superuser=False,
+    )
+
+    async def _fake_list_catalog(db, *, user_id):
+        assert user_id == user.id
+        return [
+            {
+                "id": "self-management-assistant",
+                "source": "builtin",
+                "name": "A2A Client Hub Assistant",
+                "card_url": "builtin://self-management-assistant",
+                "auth_type": "none",
+                "enabled": True,
+                "health_status": "healthy",
+                "last_health_check_at": None,
+                "last_health_check_error": None,
+                "description": "Built-in self-management assistant",
+                "runtime": "swival",
+                "resources": ["agents", "sessions"],
+            },
+            {
+                "id": "shared-agent-1",
+                "source": "shared",
+                "name": "Shared Agent",
+                "card_url": "https://example.com/shared.json",
+                "auth_type": "bearer",
+                "enabled": True,
+                "health_status": "unknown",
+                "last_health_check_at": None,
+                "last_health_check_error": None,
+                "credential_mode": "user",
+                "credential_configured": False,
+                "credential_display_hint": None,
+            },
+        ]
+
+    monkeypatch.setattr(
+        unified_agent_catalog_service,
+        "list_catalog",
+        _fake_list_catalog,
+    )
+
+    async with create_test_client(
+        agents_catalog_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as client:
+        response = await client.get(f"{settings.api_v1_prefix}/me/agents/catalog")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["source"] for item in payload["items"]] == ["builtin", "shared"]
+    assert payload["items"][0]["runtime"] == "swival"
+    assert payload["items"][1]["credential_mode"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_check_current_user_agent_catalog_health_returns_summary_and_items(
+    async_session_maker,
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(
+        async_db_session,
+        email="catalog-health@example.com",
+        is_superuser=False,
+    )
+    checked_at = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+
+    async def _fake_check_catalog_health(db, *, user_id, force: bool = False):
+        assert user_id == user.id
+        assert force is False
+        return (
+            SimpleNamespace(
+                requested=3,
+                checked=3,
+                skipped_cooldown=0,
+                healthy=2,
+                degraded=0,
+                unavailable=0,
+                unknown=1,
+            ),
+            [
+                SimpleNamespace(
+                    agent_id="personal-1",
+                    agent_source="personal",
+                    health_status="healthy",
+                    checked_at=checked_at,
+                    skipped_cooldown=False,
+                    error=None,
+                ),
+                SimpleNamespace(
+                    agent_id="shared-1",
+                    agent_source="shared",
+                    health_status="unknown",
+                    checked_at=checked_at,
+                    skipped_cooldown=False,
+                    error="User credential required",
+                ),
+                SimpleNamespace(
+                    agent_id="self-management-assistant",
+                    agent_source="builtin",
+                    health_status="healthy",
+                    checked_at=checked_at,
+                    skipped_cooldown=False,
+                    error=None,
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(
+        unified_agent_catalog_service,
+        "check_catalog_health",
+        _fake_check_catalog_health,
+    )
+
+    async with create_test_client(
+        agents_catalog_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as client:
+        response = await client.post(f"{settings.api_v1_prefix}/me/agents/check-health")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["summary"] == {
+        "requested": 3,
+        "checked": 3,
+        "skipped_cooldown": 0,
+        "healthy": 2,
+        "degraded": 0,
+        "unavailable": 0,
+        "unknown": 1,
+    }
+    assert payload["items"][1] == {
+        "agent_id": "shared-1",
+        "agent_source": "shared",
+        "health_status": "unknown",
+        "checked_at": "2026-04-13T12:00:00Z",
+        "skipped_cooldown": False,
+        "error": "User credential required",
+    }

--- a/backend/tests/agents_catalog/test_agents_catalog_routes.py
+++ b/backend/tests/agents_catalog/test_agents_catalog_routes.py
@@ -39,6 +39,7 @@ async def test_list_current_user_agent_catalog_returns_unified_items(
                 "health_status": "healthy",
                 "last_health_check_at": None,
                 "last_health_check_error": None,
+                "last_health_check_reason_code": None,
                 "description": "Built-in self-management assistant",
                 "runtime": "swival",
                 "resources": ["agents", "sessions"],
@@ -53,6 +54,7 @@ async def test_list_current_user_agent_catalog_returns_unified_items(
                 "health_status": "unknown",
                 "last_health_check_at": None,
                 "last_health_check_error": None,
+                "last_health_check_reason_code": None,
                 "credential_mode": "user",
                 "credential_configured": False,
                 "credential_display_hint": None,
@@ -114,6 +116,7 @@ async def test_check_current_user_agent_catalog_health_returns_summary_and_items
                     checked_at=checked_at,
                     skipped_cooldown=False,
                     error=None,
+                    reason_code=None,
                 ),
                 SimpleNamespace(
                     agent_id="shared-1",
@@ -122,6 +125,7 @@ async def test_check_current_user_agent_catalog_health_returns_summary_and_items
                     checked_at=checked_at,
                     skipped_cooldown=False,
                     error="User credential required",
+                    reason_code="credential_required",
                 ),
                 SimpleNamespace(
                     agent_id="self-management-assistant",
@@ -130,6 +134,7 @@ async def test_check_current_user_agent_catalog_health_returns_summary_and_items
                     checked_at=checked_at,
                     skipped_cooldown=False,
                     error=None,
+                    reason_code=None,
                 ),
             ],
         )
@@ -166,4 +171,5 @@ async def test_check_current_user_agent_catalog_health_returns_summary_and_items
         "checked_at": "2026-04-13T12:00:00Z",
         "skipped_cooldown": False,
         "error": "User credential required",
+        "reason_code": "credential_required",
     }

--- a/backend/tests/agents_catalog/test_agents_catalog_service.py
+++ b/backend/tests/agents_catalog/test_agents_catalog_service.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.db.models.user_agent_availability_snapshot import UserAgentAvailabilitySnapshot
+from app.features.agents_catalog.service import unified_agent_catalog_service
+from app.features.hub_agents.runtime import HubA2AUserCredentialRequiredError
+from tests.support.utils import create_user
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest.mark.asyncio
+async def test_list_catalog_reads_persisted_shared_and_builtin_snapshots(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(
+        async_db_session,
+        email="catalog-snapshots@example.com",
+        is_superuser=False,
+    )
+    shared_agent_id = str(uuid4())
+    checked_at = datetime(2026, 4, 13, 12, 0, tzinfo=UTC)
+
+    async_db_session.add_all(
+        [
+            UserAgentAvailabilitySnapshot(
+                user_id=user.id,
+                agent_source="shared",
+                agent_id=shared_agent_id,
+                health_status="healthy",
+                last_health_check_at=checked_at,
+                last_successful_health_check_at=checked_at,
+            ),
+            UserAgentAvailabilitySnapshot(
+                user_id=user.id,
+                agent_source="builtin",
+                agent_id="self-management-assistant",
+                health_status="unavailable",
+                last_health_check_at=checked_at,
+                last_health_check_error="Built-in runtime unavailable",
+            ),
+        ]
+    )
+    await async_db_session.flush()
+
+    async def _fake_list_all_agents(db, *, user_id):
+        assert user_id == user.id
+        return []
+
+    async def _fake_list_visible_agents_for_user(db, *, user_id, page, size):
+        assert user_id == user.id
+        assert page == 1
+        return (
+            [
+                SimpleNamespace(
+                    id=shared_agent_id,
+                    name="Shared Agent",
+                    card_url="https://example.com/shared.json",
+                    auth_type="none",
+                    credential_mode="none",
+                    credential_configured=True,
+                    credential_display_hint=None,
+                )
+            ],
+            1,
+        )
+
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.a2a_agent_service.list_all_agents",
+        _fake_list_all_agents,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.hub_a2a_agent_service.list_visible_agents_for_user",
+        _fake_list_visible_agents_for_user,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.self_management_built_in_agent_service.get_profile",
+        lambda: SimpleNamespace(
+            agent_id="self-management-assistant",
+            name="A2A Client Hub Assistant",
+            description="Built-in assistant",
+            runtime="swival",
+            configured=True,
+            resources=("agents",),
+        ),
+    )
+
+    items = await unified_agent_catalog_service.list_catalog(
+        async_db_session,
+        user_id=user.id,
+    )
+
+    by_source = {item["source"]: item for item in items}
+    assert by_source["shared"]["health_status"] == "healthy"
+    assert by_source["shared"]["last_health_check_at"] == checked_at
+    assert by_source["builtin"]["health_status"] == "unavailable"
+    assert (
+        by_source["builtin"]["last_health_check_error"]
+        == "Built-in runtime unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_catalog_health_persists_shared_and_builtin_snapshots(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(
+        async_db_session,
+        email="catalog-health-persist@example.com",
+        is_superuser=False,
+    )
+    shared_agent_id = uuid4()
+
+    async def _fake_check_agents_health(*, user_id, force: bool = False):
+        assert user_id == user.id
+        assert force is True
+        return (
+            SimpleNamespace(
+                requested=0,
+                checked=0,
+                skipped_cooldown=0,
+                healthy=0,
+                degraded=0,
+                unavailable=0,
+                unknown=0,
+            ),
+            [],
+        )
+
+    async def _fake_list_visible_agents_for_user(db, *, user_id, page, size):
+        assert user_id == user.id
+        assert page == 1
+        return (
+            [
+                SimpleNamespace(
+                    id=shared_agent_id,
+                    name="Shared Agent",
+                    card_url="https://example.com/shared.json",
+                    auth_type="none",
+                    credential_mode="none",
+                    credential_configured=True,
+                    credential_display_hint=None,
+                )
+            ],
+            1,
+        )
+
+    async def _fake_build(db, *, user_id, agent_id):
+        assert user_id == user.id
+        assert agent_id == shared_agent_id
+        return SimpleNamespace(resolved=object())
+
+    async def _fake_validate(*, gateway, resolved):
+        assert resolved is not None
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.a2a_agent_service.check_agents_health",
+        _fake_check_agents_health,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.hub_a2a_agent_service.list_visible_agents_for_user",
+        _fake_list_visible_agents_for_user,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.hub_a2a_runtime_builder.build",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.fetch_and_validate_agent_card",
+        _fake_validate,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.get_a2a_service",
+        lambda: SimpleNamespace(gateway=object()),
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.self_management_built_in_agent_service.get_profile",
+        lambda: SimpleNamespace(
+            agent_id="self-management-assistant",
+            name="A2A Client Hub Assistant",
+            description="Built-in assistant",
+            runtime="swival",
+            configured=True,
+            resources=("agents",),
+        ),
+    )
+
+    summary, items = await unified_agent_catalog_service.check_catalog_health(
+        async_db_session,
+        user_id=user.id,
+        force=True,
+    )
+
+    assert summary.requested == 2
+    assert summary.healthy == 2
+    assert {(item.agent_source, item.health_status) for item in items} == {
+        ("shared", "healthy"),
+        ("builtin", "healthy"),
+    }
+
+    snapshots = (
+        await async_db_session.scalars(
+            select(UserAgentAvailabilitySnapshot).where(
+                UserAgentAvailabilitySnapshot.user_id == user.id
+            )
+        )
+    ).all()
+    assert {
+        (row.agent_source, row.agent_id, row.health_status) for row in snapshots
+    } == {
+        ("shared", str(shared_agent_id), "healthy"),
+        ("builtin", "self-management-assistant", "healthy"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_check_catalog_health_marks_missing_shared_credential_unavailable(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = await create_user(
+        async_db_session,
+        email="catalog-health-credential@example.com",
+        is_superuser=False,
+    )
+    shared_agent_id = uuid4()
+
+    async def _fake_check_agents_health(*, user_id, force: bool = False):
+        assert user_id == user.id
+        assert force is True
+        return (
+            SimpleNamespace(
+                requested=0,
+                checked=0,
+                skipped_cooldown=0,
+                healthy=0,
+                degraded=0,
+                unavailable=0,
+                unknown=0,
+            ),
+            [],
+        )
+
+    async def _fake_list_visible_agents_for_user(db, *, user_id, page, size):
+        assert user_id == user.id
+        assert page == 1
+        return (
+            [
+                SimpleNamespace(
+                    id=shared_agent_id,
+                    name="Shared Agent",
+                    card_url="https://example.com/shared.json",
+                    auth_type="bearer",
+                    credential_mode="user",
+                    credential_configured=False,
+                    credential_display_hint=None,
+                )
+            ],
+            1,
+        )
+
+    async def _fake_build(db, *, user_id, agent_id):
+        raise HubA2AUserCredentialRequiredError("User credential required")
+
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.a2a_agent_service.check_agents_health",
+        _fake_check_agents_health,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.hub_a2a_agent_service.list_visible_agents_for_user",
+        _fake_list_visible_agents_for_user,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.hub_a2a_runtime_builder.build",
+        _fake_build,
+    )
+    monkeypatch.setattr(
+        "app.features.agents_catalog.service.self_management_built_in_agent_service.get_profile",
+        lambda: SimpleNamespace(
+            agent_id="self-management-assistant",
+            name="A2A Client Hub Assistant",
+            description="Built-in assistant",
+            runtime="swival",
+            configured=False,
+            resources=(),
+        ),
+    )
+
+    summary, items = await unified_agent_catalog_service.check_catalog_health(
+        async_db_session,
+        user_id=user.id,
+        force=True,
+    )
+
+    assert summary.requested == 1
+    assert summary.unavailable == 1
+    assert items[0].agent_source == "shared"
+    assert items[0].health_status == "unavailable"
+    assert items[0].error == "User credential required"
+
+    snapshot = await async_db_session.scalar(
+        select(UserAgentAvailabilitySnapshot).where(
+            UserAgentAvailabilitySnapshot.user_id == user.id,
+            UserAgentAvailabilitySnapshot.agent_source == "shared",
+            UserAgentAvailabilitySnapshot.agent_id == str(shared_agent_id),
+        )
+    )
+    assert snapshot is not None
+    assert snapshot.health_status == "unavailable"
+    assert snapshot.last_health_check_error == "User credential required"

--- a/backend/tests/agents_catalog/test_agents_catalog_service.py
+++ b/backend/tests/agents_catalog/test_agents_catalog_service.py
@@ -37,6 +37,7 @@ async def test_list_catalog_reads_persisted_shared_and_builtin_snapshots(
                 health_status="healthy",
                 last_health_check_at=checked_at,
                 last_successful_health_check_at=checked_at,
+                last_health_check_reason_code=None,
             ),
             UserAgentAvailabilitySnapshot(
                 user_id=user.id,
@@ -45,6 +46,7 @@ async def test_list_catalog_reads_persisted_shared_and_builtin_snapshots(
                 health_status="unavailable",
                 last_health_check_at=checked_at,
                 last_health_check_error="Built-in runtime unavailable",
+                last_health_check_reason_code="agent_unavailable",
             ),
         ]
     )
@@ -100,11 +102,13 @@ async def test_list_catalog_reads_persisted_shared_and_builtin_snapshots(
     by_source = {item["source"]: item for item in items}
     assert by_source["shared"]["health_status"] == "healthy"
     assert by_source["shared"]["last_health_check_at"] == checked_at
+    assert by_source["shared"]["last_health_check_reason_code"] is None
     assert by_source["builtin"]["health_status"] == "unavailable"
     assert (
         by_source["builtin"]["last_health_check_error"]
         == "Built-in runtime unavailable"
     )
+    assert by_source["builtin"]["last_health_check_reason_code"] == "agent_unavailable"
 
 
 @pytest.mark.asyncio
@@ -206,6 +210,7 @@ async def test_check_catalog_health_persists_shared_and_builtin_snapshots(
         ("shared", "healthy"),
         ("builtin", "healthy"),
     }
+    assert all(item.reason_code is None for item in items)
 
     snapshots = (
         await async_db_session.scalars(
@@ -215,10 +220,16 @@ async def test_check_catalog_health_persists_shared_and_builtin_snapshots(
         )
     ).all()
     assert {
-        (row.agent_source, row.agent_id, row.health_status) for row in snapshots
+        (
+            row.agent_source,
+            row.agent_id,
+            row.health_status,
+            row.last_health_check_reason_code,
+        )
+        for row in snapshots
     } == {
-        ("shared", str(shared_agent_id), "healthy"),
-        ("builtin", "self-management-assistant", "healthy"),
+        ("shared", str(shared_agent_id), "healthy", None),
+        ("builtin", "self-management-assistant", "healthy", None),
     }
 
 
@@ -306,6 +317,7 @@ async def test_check_catalog_health_marks_missing_shared_credential_unavailable(
     assert items[0].agent_source == "shared"
     assert items[0].health_status == "unavailable"
     assert items[0].error == "User credential required"
+    assert items[0].reason_code == "credential_required"
 
     snapshot = await async_db_session.scalar(
         select(UserAgentAvailabilitySnapshot).where(
@@ -317,3 +329,4 @@ async def test_check_catalog_health_marks_missing_shared_credential_unavailable(
     assert snapshot is not None
     assert snapshot.health_status == "unavailable"
     assert snapshot.last_health_check_error == "User credential required"
+    assert snapshot.last_health_check_reason_code == "credential_required"

--- a/backend/tests/auth/test_auth.py
+++ b/backend/tests/auth/test_auth.py
@@ -16,12 +16,13 @@ from starlette.requests import Request
 from app.core.config import settings
 from app.core.security import (
     DUMMY_PASSWORD_HASH,
+    REFRESH_TOKEN_TYPE,
     build_jwks_document,
     create_user_refresh_token,
     create_user_token,
     get_password_hash,
+    verify_jwt_token_claims,
     verify_password,
-    verify_refresh_token_claims,
 )
 from app.db.models.auth_audit_event import AuthAuditEvent
 from app.db.models.auth_refresh_session import AuthRefreshSession
@@ -235,7 +236,7 @@ async def test_refresh_rotates_cookie_and_returns_new_access_token(
     assert after
     assert after != before
 
-    claims = verify_refresh_token_claims(after)
+    claims = verify_jwt_token_claims(after, expected_type=REFRESH_TOKEN_TYPE)
     assert claims is not None
     assert claims.session_id is not None
 
@@ -271,7 +272,9 @@ async def test_refresh_tolerates_recent_rotated_token_reuse_from_second_tab(
     assert login_response.status_code == 200
     initial_cookie = client.cookies.get(settings.auth_refresh_cookie_name)
     assert initial_cookie
-    initial_claims = verify_refresh_token_claims(initial_cookie)
+    initial_claims = verify_jwt_token_claims(
+        initial_cookie, expected_type=REFRESH_TOKEN_TYPE
+    )
     assert initial_claims is not None
 
     async with create_test_client(
@@ -294,7 +297,9 @@ async def test_refresh_tolerates_recent_rotated_token_reuse_from_second_tab(
 
         rotated_cookie = client.cookies.get(settings.auth_refresh_cookie_name)
         assert rotated_cookie
-        rotated_claims = verify_refresh_token_claims(rotated_cookie)
+        rotated_claims = verify_jwt_token_claims(
+            rotated_cookie, expected_type=REFRESH_TOKEN_TYPE
+        )
         assert rotated_claims is not None
 
         stale_refresh = await second_tab_client.post(
@@ -309,7 +314,9 @@ async def test_refresh_tolerates_recent_rotated_token_reuse_from_second_tab(
             path=settings.auth_refresh_cookie_path,
         )
         assert healed_cookie
-        healed_claims = verify_refresh_token_claims(healed_cookie)
+        healed_claims = verify_jwt_token_claims(
+            healed_cookie, expected_type=REFRESH_TOKEN_TYPE
+        )
         assert healed_claims is not None
         assert healed_claims.session_id == rotated_claims.session_id
         assert healed_claims.jwt_id == rotated_claims.jwt_id
@@ -1435,7 +1442,7 @@ async def test_jwks_endpoint_exposes_active_key(client: AsyncClient) -> None:
     assert body["keys"][0]["kid"] == settings.jwt_key_id
 
 
-async def test_verify_refresh_token_claims_accepts_previous_key_without_kid(
+async def test_verify_jwt_token_claims_accepts_previous_key_without_kid_for_refresh(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     previous_private_key = rsa.generate_private_key(
@@ -1473,7 +1480,7 @@ async def test_verify_refresh_token_claims_accepts_previous_key_without_kid(
         algorithm=settings.jwt_algorithm,
     )
 
-    claims = verify_refresh_token_claims(token)
+    claims = verify_jwt_token_claims(token, expected_type=REFRESH_TOKEN_TYPE)
     assert claims is not None
 
 

--- a/backend/tests/auth/test_auth.py
+++ b/backend/tests/auth/test_auth.py
@@ -47,6 +47,14 @@ LEGACY_BCRYPT_HASH = "".join(
 LONG_UTF8_PASSWORD = "Aa" * 34 + "1!" + "界"
 
 
+@pytest.fixture(autouse=True)
+def trusted_cookie_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep cookie-auth tests deterministic across local env overrides."""
+
+    monkeypatch.setattr(settings, "auth_cookie_trusted_origins", [TRUSTED_ORIGIN])
+    monkeypatch.setattr(settings, "backend_cors_origins", [TRUSTED_ORIGIN])
+
+
 async def run_in_session(async_session_maker, coro_fn):
     async with async_session_maker() as session:
         return await coro_fn(session)

--- a/backend/tests/auth/test_auth.py
+++ b/backend/tests/auth/test_auth.py
@@ -44,7 +44,7 @@ LEGACY_BCRYPT_HASH = "".join(
         "oAHOBdMIkrTmNtd/4am6",
     )
 )
-LONG_UTF8_PASSWORD = "Aa" * 34 + "1!" + "界"  # pragma: allowlist secret
+LONG_UTF8_PASSWORD = "Aa" * 34 + "1!" + "界"
 
 
 async def run_in_session(async_session_maker, coro_fn):
@@ -1117,7 +1117,7 @@ async def test_register_accepts_password_longer_than_72_utf8_bytes(
 async def test_authenticate_user_not_found_runs_dummy_hash_verification(
     async_db_session,
 ) -> None:
-    password = "NotUsed!1"  # pragma: allowlist secret
+    password = "NotUsed!1"
 
     with patch(
         "app.features.auth.service.verify_password", return_value=False

--- a/backend/tests/auth/test_auth.py
+++ b/backend/tests/auth/test_auth.py
@@ -18,8 +18,8 @@ from app.core.security import (
     DUMMY_PASSWORD_HASH,
     REFRESH_TOKEN_TYPE,
     build_jwks_document,
+    create_user_access_token,
     create_user_refresh_token,
-    create_user_token,
     get_password_hash,
     verify_jwt_token_claims,
     verify_password,
@@ -661,7 +661,7 @@ async def test_logout_all_revokes_all_refresh_sessions(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    access_token = create_user_token(user.id)
+    access_token = create_user_access_token(user.id)
 
     logout_all_response = await client.post(
         f"{settings.api_v1_prefix}/auth/logout-all",
@@ -703,7 +703,7 @@ async def test_logout_all_blocks_legacy_refresh_tokens(
 
     user = await run_in_session(async_session_maker, fetch_user)
     legacy_refresh = create_user_refresh_token(user.id)
-    access_token = create_user_token(user.id)
+    access_token = create_user_access_token(user.id)
 
     logout_all_response = await client.post(
         f"{settings.api_v1_prefix}/auth/logout-all",
@@ -740,7 +740,7 @@ async def test_change_password_updates_credentials(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    token = create_user_token(user.id)
+    token = create_user_access_token(user.id)
     login_response = await client.post(
         f"{settings.api_v1_prefix}/auth/login",
         json={"email": payload["email"], "password": payload["password"]},
@@ -805,7 +805,7 @@ async def test_change_password_blocks_legacy_refresh_tokens(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    access_token = create_user_token(user.id)
+    access_token = create_user_access_token(user.id)
     legacy_refresh = create_user_refresh_token(user.id)
 
     change_response = await client.post(
@@ -844,7 +844,7 @@ async def test_change_password_rejects_wrong_current_password(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    token = create_user_token(user.id)
+    token = create_user_access_token(user.id)
 
     response = await client.post(
         f"{settings.api_v1_prefix}/auth/password/change",
@@ -877,7 +877,7 @@ async def test_change_password_enforces_strength_rules(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    token = create_user_token(user.id)
+    token = create_user_access_token(user.id)
 
     response = await client.post(
         f"{settings.api_v1_prefix}/auth/password/change",
@@ -1246,7 +1246,7 @@ async def test_change_password_accepts_new_password_longer_than_72_utf8_bytes(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    token = create_user_token(user.id)
+    token = create_user_access_token(user.id)
 
     response = await client.post(
         f"{settings.api_v1_prefix}/auth/password/change",
@@ -1317,7 +1317,7 @@ async def test_me_endpoint_returns_current_user(
         return result.scalar_one()
 
     user = await run_in_session(async_session_maker, fetch_user)
-    token = create_user_token(user.id)
+    token = create_user_access_token(user.id)
 
     response = await client.get(
         f"{settings.api_v1_prefix}/auth/me",
@@ -1357,7 +1357,7 @@ async def test_me_endpoint_rejects_disabled_user(
 
     user_id = await run_in_session(async_session_maker, disable)
 
-    token = create_user_token(user_id)
+    token = create_user_access_token(user_id)
     response = await client.get(
         f"{settings.api_v1_prefix}/auth/me",
         headers={"Authorization": f"Bearer {token}"},

--- a/backend/tests/client/test_a2a_client.py
+++ b/backend/tests/client/test_a2a_client.py
@@ -982,14 +982,20 @@ async def test_stream_with_fallback_downgrades_to_blocking_when_streaming_is_not
         selected_transport="JSONRPC",
     )
 
-    class _UnsupportedStreamAdapter:
-        async def stream_message(self, _request):
+    class _UnsupportedStreamIterator:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
             raise A2APeerProtocolError(
                 "Unknown method: SendStreamingMessage",
                 error_code="method_not_supported",
                 rpc_code=-32601,
             )
-            yield  # pragma: no cover
+
+    class _UnsupportedStreamAdapter:
+        def stream_message(self, _request):
+            return _UnsupportedStreamIterator()
 
     a2a_client = A2AClient("http://example-agent.internal:24020")
     a2a_client._get_peer_descriptor = AsyncMock(return_value=descriptor)

--- a/backend/tests/extensions/test_a2a_extensions_service.py
+++ b/backend/tests/extensions/test_a2a_extensions_service.py
@@ -744,23 +744,23 @@ async def test_resolve_invoke_metadata_fetches_card_and_returns_contract(
 def test_map_business_error_code_supports_dynamic_declared_codes() -> None:
     ext = _resolved_extension()
     assert (
-        A2AExtensionSupport.map_business_error_code(
-            {"code": -32005},
-            ext,
+        A2AExtensionSupport.map_upstream_error_code(
+            error={"code": -32005},
+            business_code_map=ext.business_code_map,
         )
         == "upstream_payload_error"
     )
     assert (
-        A2AExtensionSupport.map_business_error_code(
-            {"code": "-32001"},
-            ext,
+        A2AExtensionSupport.map_upstream_error_code(
+            error={"code": "-32001"},
+            business_code_map=ext.business_code_map,
         )
         == "session_not_found"
     )
     assert (
-        A2AExtensionSupport.map_business_error_code(
-            {"code": -32006},
-            ext,
+        A2AExtensionSupport.map_upstream_error_code(
+            error={"code": -32006},
+            business_code_map=ext.business_code_map,
         )
         == "session_forbidden"
     )
@@ -769,22 +769,22 @@ def test_map_business_error_code_supports_dynamic_declared_codes() -> None:
 def test_map_business_error_code_prefers_error_data_type() -> None:
     ext = _resolved_extension()
     assert (
-        A2AExtensionSupport.map_business_error_code(
-            {
+        A2AExtensionSupport.map_upstream_error_code(
+            error={
                 "code": -32001,
                 "data": {"type": "METHOD_DISABLED"},
             },
-            ext,
+            business_code_map=ext.business_code_map,
         )
         == "method_disabled"
     )
     assert (
-        A2AExtensionSupport.map_business_error_code(
-            {
+        A2AExtensionSupport.map_upstream_error_code(
+            error={
                 "code": -32003,
                 "data": {"type": "UPSTREAM_UNAUTHORIZED"},
             },
-            ext,
+            business_code_map=ext.business_code_map,
         )
         == "upstream_unauthorized"
     )
@@ -793,9 +793,9 @@ def test_map_business_error_code_prefers_error_data_type() -> None:
 def test_map_business_error_code_maps_jsonrpc_invalid_params() -> None:
     ext = _resolved_extension()
     assert (
-        A2AExtensionSupport.map_business_error_code(
-            {"code": -32602},
-            ext,
+        A2AExtensionSupport.map_upstream_error_code(
+            error={"code": -32602},
+            business_code_map=ext.business_code_map,
         )
         == "invalid_params"
     )
@@ -813,22 +813,22 @@ def test_map_interrupt_business_error_code_prefers_error_data_type() -> None:
         business_code_map={-32004: "interrupt_request_not_found"},
     )
     assert (
-        A2AExtensionSupport.map_interrupt_business_error_code(
-            {
+        A2AExtensionSupport.map_upstream_error_code(
+            error={
                 "code": -32004,
                 "data": {"type": "INTERRUPT_REQUEST_EXPIRED"},
             },
-            ext,
+            business_code_map=ext.business_code_map,
         )
         == "interrupt_request_expired"
     )
     assert (
-        A2AExtensionSupport.map_interrupt_business_error_code(
-            {
+        A2AExtensionSupport.map_upstream_error_code(
+            error={
                 "code": -32602,
                 "data": {"type": "INTERRUPT_TYPE_MISMATCH"},
             },
-            ext,
+            business_code_map=ext.business_code_map,
         )
         == "interrupt_type_mismatch"
     )

--- a/backend/tests/personal_agents/test_a2a_health_service.py
+++ b/backend/tests/personal_agents/test_a2a_health_service.py
@@ -141,6 +141,7 @@ async def test_check_agents_health_marks_agent_unavailable_after_threshold(
     assert len(items) == 1
     assert items[0].health_status == A2AAgent.HEALTH_UNAVAILABLE
     assert items[0].error == "Connection failed"
+    assert items[0].reason_code == "card_validation_failed"
 
     refreshed = await async_db_session.scalar(
         select(A2AAgent).where(A2AAgent.id == record.id)
@@ -150,6 +151,7 @@ async def test_check_agents_health_marks_agent_unavailable_after_threshold(
     assert refreshed.health_status == A2AAgent.HEALTH_UNAVAILABLE
     assert refreshed.consecutive_health_check_failures == 3
     assert refreshed.last_health_check_error == "Connection failed"
+    assert refreshed.last_health_check_reason_code == "card_validation_failed"
     assert refreshed.last_health_check_at is not None
 
 
@@ -211,6 +213,7 @@ async def test_check_agents_health_marks_agent_healthy_and_resets_failures(
     assert len(items) == 1
     assert items[0].health_status == A2AAgent.HEALTH_HEALTHY
     assert items[0].error is None
+    assert items[0].reason_code is None
 
     refreshed = await async_db_session.scalar(
         select(A2AAgent).where(A2AAgent.id == record.id)
@@ -220,5 +223,6 @@ async def test_check_agents_health_marks_agent_healthy_and_resets_failures(
     assert refreshed.health_status == A2AAgent.HEALTH_HEALTHY
     assert refreshed.consecutive_health_check_failures == 0
     assert refreshed.last_health_check_error is None
+    assert refreshed.last_health_check_reason_code is None
     assert refreshed.last_health_check_at is not None
     assert refreshed.last_successful_health_check_at is not None

--- a/backend/tests/personal_agents/test_a2a_routes.py
+++ b/backend/tests/personal_agents/test_a2a_routes.py
@@ -639,6 +639,7 @@ async def test_personal_agents_health_check_routes_return_summary_and_items(
                 checked_at=checked_at,
                 skipped_cooldown=False,
                 error=None,
+                reason_code=None,
             )
         ]
         return summary, items
@@ -677,6 +678,7 @@ async def test_personal_agents_health_check_routes_return_summary_and_items(
         assert len(single_payload["items"]) == 1
         assert single_payload["items"][0]["agent_id"] == str(record.id)
         assert single_payload["items"][0]["health_status"] == "healthy"
+        assert single_payload["items"][0]["reason_code"] is None
 
     assert captured_calls == [
         {

--- a/backend/tests/personal_agents/test_self_management_agents_service.py
+++ b/backend/tests/personal_agents/test_self_management_agents_service.py
@@ -130,6 +130,7 @@ async def test_self_management_agents_service_checks_agent_health(
                     checked_at=record.updated_at,
                     skipped_cooldown=not force,
                     error=None,
+                    reason_code=None,
                 )
             ],
         )

--- a/backend/tests/runtime/test_logging_redaction.py
+++ b/backend/tests/runtime/test_logging_redaction.py
@@ -55,9 +55,7 @@ def test_redact_query_params_for_logging():
 
 def test_redact_url_for_logging():
     assert (
-        redact_url_for_logging(
-            "https://user:pass@example.com/path?query=val#frag"  # pragma: allowlist secret
-        )
+        redact_url_for_logging("https://user:pass@example.com/path?query=val#frag")
         == "https://example.com"
     )
     assert (

--- a/backend/tests/runtime/test_self_management_actor_context.py
+++ b/backend/tests/runtime/test_self_management_actor_context.py
@@ -39,7 +39,7 @@ def _build_user(*, is_superuser: bool) -> User:
         id=uuid4(),
         email=f"user-{uuid4().hex[:8]}@example.com",
         name="Test User",
-        password_hash="test-password-hash",  # pragma: allowlist secret
+        password_hash="test-password-hash",
         is_superuser=is_superuser,
         timezone="UTC",
     )

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1316,14 +1316,16 @@ async def test_built_in_agent_interrupt_recovery_route_persists_expired_interrup
     assert interrupt_result.interrupt is not None
     await async_db_session.commit()
 
-    original_verify = (
-        self_management_agent_service_module.verify_self_management_interrupt_token_claims
-    )
+    original_verify = self_management_agent_service_module.verify_jwt_token_claims
     invalid_request_id = interrupt_result.interrupt.request_id
     monkeypatch.setattr(
         self_management_agent_service_module,
-        "verify_self_management_interrupt_token_claims",
-        lambda token: None if token == invalid_request_id else original_verify(token),
+        "verify_jwt_token_claims",
+        lambda token, *, expected_type: (
+            None
+            if token == invalid_request_id
+            else original_verify(token, expected_type=expected_type)
+        ),
     )
 
     async with create_test_client(
@@ -1385,14 +1387,16 @@ async def test_built_in_agent_recovery_skips_invalid_interrupt_requests(
     )
     assert interrupt_result.interrupt is not None
 
-    original_verify = (
-        self_management_agent_service_module.verify_self_management_interrupt_token_claims
-    )
+    original_verify = self_management_agent_service_module.verify_jwt_token_claims
     invalid_request_id = interrupt_result.interrupt.request_id
     monkeypatch.setattr(
         self_management_agent_service_module,
-        "verify_self_management_interrupt_token_claims",
-        lambda token: None if token == invalid_request_id else original_verify(token),
+        "verify_jwt_token_claims",
+        lambda token, *, expected_type: (
+            None
+            if token == invalid_request_id
+            else original_verify(token, expected_type=expected_type)
+        ),
     )
 
     recovered = await self_management_built_in_agent_service.recover_pending_interrupts(

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -284,10 +284,7 @@ async def test_built_in_agent_run_uses_swival_with_authenticated_mcp_server(
     assert _FakeSwivalSession.last_init_kwargs["provider"] == "openai"
     assert _FakeSwivalSession.last_init_kwargs["model"] == "gpt-test"
     assert _FakeSwivalSession.last_init_kwargs["base_url"] == "https://example.com/v1"
-    assert (
-        _FakeSwivalSession.last_init_kwargs["api_key"]
-        == "test-api-key"  # pragma: allowlist secret
-    )
+    assert _FakeSwivalSession.last_init_kwargs["api_key"] == "test-api-key"
     assert _FakeSwivalSession.last_init_kwargs["reasoning_effort"] == "medium"
     assert _FakeSwivalSession.last_init_kwargs["max_turns"] == 6
     assert _FakeSwivalSession.last_init_kwargs["max_output_tokens"] == 2048

--- a/backend/tests/runtime/test_self_management_mcp.py
+++ b/backend/tests/runtime/test_self_management_mcp.py
@@ -214,6 +214,7 @@ async def test_execute_self_management_mcp_operation_supports_agent_health_check
                     checked_at=agent.updated_at,
                     skipped_cooldown=not force,
                     error=None,
+                    reason_code=None,
                 )
             ],
         )

--- a/backend/tests/runtime/test_self_management_toolkit.py
+++ b/backend/tests/runtime/test_self_management_toolkit.py
@@ -149,6 +149,7 @@ async def test_self_management_toolkit_checks_agent_health(
                     checked_at=record.updated_at,
                     skipped_cooldown=not force,
                     error=None,
+                    reason_code=None,
                 )
             ],
         )

--- a/backend/tests/runtime/test_self_management_web_agent.py
+++ b/backend/tests/runtime/test_self_management_web_agent.py
@@ -20,7 +20,7 @@ def _build_user(*, is_superuser: bool = False) -> User:
         id=uuid4(),
         email=f"user-{uuid4().hex[:8]}@example.com",
         name="Web Agent User",
-        password_hash="test-password-hash",  # pragma: allowlist secret
+        password_hash="test-password-hash",
         is_superuser=is_superuser,
         timezone="UTC",
     )

--- a/backend/tests/runtime/test_settings_security_baseline.py
+++ b/backend/tests/runtime/test_settings_security_baseline.py
@@ -91,7 +91,7 @@ def test_rejects_invalid_jwt_private_key_pem(
     monkeypatch.setenv(
         "JWT_PRIVATE_KEY_PEM",
         (
-            "-----BEGIN PRIVATE KEY-----\n"  # pragma: allowlist secret
+            "-----BEGIN PRIVATE KEY-----\n"
             "not-valid-pem\n"
             "-----END PRIVATE KEY-----\n"
         ),

--- a/frontend/components/chat/ModelPickerModal.tsx
+++ b/frontend/components/chat/ModelPickerModal.tsx
@@ -8,11 +8,11 @@ import {
   A2AExtensionCallError,
   listModelProviders,
   listModels,
+  type ExtensionAgentSource,
   type ModelSummary,
   type ModelProviderSummary,
 } from "@/lib/api/a2aExtensions";
 import { type SharedModelSelection } from "@/lib/chat-utils";
-import { type AgentSource } from "@/store/agents";
 
 const PROVIDER_LIST_CONTENT_CONTAINER_STYLE = {
   paddingRight: 8,
@@ -100,7 +100,7 @@ export function ModelPickerModal({
   visible: boolean;
   onClose: () => void;
   agentId?: string | null;
-  source: AgentSource;
+  source: ExtensionAgentSource;
   providerDiscoveryStatus: GenericCapabilityStatus;
   workingDirectory?: string | null;
   selectedModel: SharedModelSelection | null;

--- a/frontend/hooks/__tests__/useAgentListQueries.test.tsx
+++ b/frontend/hooks/__tests__/useAgentListQueries.test.tsx
@@ -20,14 +20,9 @@ jest.mock("@/lib/api/hubA2aAgentsUser", () => ({
   listHubAgentsPage: jest.fn(),
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 const mockedUsePaginatedList = jest.mocked(usePaginatedList);
 const mockedListAgentsPage = jest.mocked(listAgentsPage);

--- a/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
+++ b/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
@@ -21,10 +21,9 @@ const mocks = {
   checkAgentHealth: jest.fn(),
   createAgent: jest.fn(),
   deleteAgent: jest.fn(),
-  listAgents: jest.fn(),
+  listAgentsCatalog: jest.fn(),
   updateAgent: jest.fn(),
   validateAgentCard: jest.fn(),
-  listHubAgents: jest.fn(),
   validateHubAgentCard: jest.fn(),
 };
 
@@ -41,13 +40,15 @@ jest.mock("@/lib/api/a2aAgents", () => ({
   checkAgentHealth: (...args: unknown[]) => mocks.checkAgentHealth(...args),
   createAgent: (...args: unknown[]) => mocks.createAgent(...args),
   deleteAgent: (...args: unknown[]) => mocks.deleteAgent(...args),
-  listAgents: (...args: unknown[]) => mocks.listAgents(...args),
   updateAgent: (...args: unknown[]) => mocks.updateAgent(...args),
   validateAgentCard: (...args: unknown[]) => mocks.validateAgentCard(...args),
 }));
 
+jest.mock("@/lib/api/agentsCatalog", () => ({
+  listAgentsCatalog: (...args: unknown[]) => mocks.listAgentsCatalog(...args),
+}));
+
 jest.mock("@/lib/api/hubA2aAgentsUser", () => ({
-  listHubAgents: (...args: unknown[]) => mocks.listHubAgents(...args),
   validateHubAgentCard: (...args: unknown[]) =>
     mocks.validateHubAgentCard(...args),
 }));
@@ -105,24 +106,19 @@ describe("useAgentsCatalogQuery mutations", () => {
   });
 
   it("does not hydrate editable basic username from server hint", async () => {
-    mocks.listAgents.mockResolvedValue({
+    mocks.listAgentsCatalog.mockResolvedValue({
       items: [
         {
           id: "agent-basic",
+          source: "personal",
           name: "Basic Agent",
           card_url: "https://example.com/basic.json",
           auth_type: "basic",
-          username_hint: "alice",
           enabled: true,
-          tags: [],
-          extra_headers: {},
-          invoke_metadata_defaults: {},
-          created_at: "2026-02-12T00:00:00.000Z",
-          updated_at: "2026-02-12T00:01:00.000Z",
+          health_status: "unknown",
         },
       ],
     });
-    mocks.listHubAgents.mockResolvedValue({ items: [] });
 
     const { result } = renderHook(() => useAgentsCatalogQuery(), {
       wrapper: createWrapper(queryClient),

--- a/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
+++ b/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { ApiRequestError } from "@/lib/api/client";
 import { queryKeys } from "@/lib/queryKeys";
 import { type AgentConfig, useAgentStore } from "@/store/agents";
+import { createMockAgentConfig } from "@/test-utils/agentFixtures";
 import {
   cleanupTestQueryClient,
   createTestQueryClient,
@@ -48,23 +49,6 @@ jest.mock("@/lib/api/hubA2aAgentsUser", () => ({
   validateHubAgentCard: (...args: unknown[]) =>
     mocks.validateHubAgentCard(...args),
 }));
-
-const buildAgent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
-  id: "agent-1",
-  source: "personal",
-  name: "Agent One",
-  cardUrl: "https://example.com/agent-1.json",
-  authType: "none",
-  bearerToken: "",
-  apiKeyHeader: DEFAULT_API_KEY_HEADER,
-  apiKeyValue: "",
-  basicUsername: "",
-  basicPassword: "",
-  extraHeaders: [],
-  invokeMetadataDefaults: [],
-  status: "idle",
-  ...overrides,
-});
 
 const createWrapper = (queryClient: QueryClient) => {
   return ({ children }: PropsWithChildren) => (
@@ -137,8 +121,8 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("updates cache and clears active agent on delete", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({ id: "agent-1" }),
-      buildAgent({ id: "agent-2", source: "shared" }),
+      createMockAgentConfig({ id: "agent-1" }),
+      createMockAgentConfig({ id: "agent-2", source: "shared" }),
     ]);
     useAgentStore.setState({ activeAgentId: "agent-1" });
     mocks.deleteAgent.mockResolvedValue({});
@@ -154,7 +138,7 @@ describe("useAgentsCatalogQuery mutations", () => {
     expect(mocks.deleteAgent).toHaveBeenCalledWith("agent-1");
     expect(
       queryClient.getQueryData<AgentConfig[]>(queryKeys.agents.catalog()),
-    ).toEqual([buildAgent({ id: "agent-2", source: "shared" })]);
+    ).toEqual([createMockAgentConfig({ id: "agent-2", source: "shared" })]);
     expect(useAgentStore.getState().activeAgentId).toBeNull();
     expect(
       queryClient.getQueryState(queryKeys.agents.catalog())?.isInvalidated,
@@ -163,7 +147,7 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("clears transient validation state when an update changes the card identity", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         status: "error",
         lastError: "network",
@@ -214,7 +198,7 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("preserves transient validation state when an update keeps the same card identity", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         status: "error",
         lastError: "network",
@@ -262,7 +246,7 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("removes missing agent during validate and clears active selection", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({ id: "agent-1" }),
+      createMockAgentConfig({ id: "agent-1" }),
     ]);
     useAgentStore.setState({ activeAgentId: "agent-1" });
 
@@ -295,7 +279,7 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("stores validation success metadata after successful validation", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({ id: "agent-1" }),
+      createMockAgentConfig({ id: "agent-1" }),
     ]);
 
     mocks.validateAgentCard.mockResolvedValue({
@@ -336,7 +320,7 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("keeps warning-only validation responses in success state", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({ id: "agent-1" }),
+      createMockAgentConfig({ id: "agent-1" }),
     ]);
 
     mocks.validateAgentCard.mockResolvedValue({
@@ -366,7 +350,7 @@ describe("useAgentsCatalogQuery mutations", () => {
 
   it("appends newly created agent to cache without full refetch", async () => {
     queryClient.setQueryData(queryKeys.agents.catalog(), [
-      buildAgent({ id: "shared-1", source: "shared" }),
+      createMockAgentConfig({ id: "shared-1", source: "shared" }),
     ]);
 
     mocks.createAgent.mockResolvedValue({

--- a/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
+++ b/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
@@ -28,14 +28,9 @@ const mocks = {
   validateHubAgentCard: jest.fn(),
 };
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 jest.mock("@/lib/api/a2aAgents", () => ({
   checkAgentHealth: (...args: unknown[]) => mocks.checkAgentHealth(...args),

--- a/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
+++ b/frontend/hooks/__tests__/useAgentsCatalogQuery.test.tsx
@@ -9,6 +9,7 @@ import {
   useUpdateAgentMutation,
   useValidateAgentMutation,
 } from "@/hooks/useAgentsCatalogQuery";
+import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { ApiRequestError } from "@/lib/api/client";
 import { queryKeys } from "@/lib/queryKeys";
 import { type AgentConfig, useAgentStore } from "@/store/agents";
@@ -60,7 +61,7 @@ const buildAgent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
   cardUrl: "https://example.com/agent-1.json",
   authType: "none",
   bearerToken: "",
-  apiKeyHeader: "X-API-Key",
+  apiKeyHeader: DEFAULT_API_KEY_HEADER,
   apiKeyValue: "",
   basicUsername: "",
   basicPassword: "",
@@ -416,7 +417,7 @@ describe("useAgentsCatalogQuery mutations", () => {
         cardUrl: "https://example.com/new.json",
         authType: "none",
         bearerToken: "",
-        apiKeyHeader: "X-API-Key",
+        apiKeyHeader: DEFAULT_API_KEY_HEADER,
         apiKeyValue: "",
         basicUsername: "",
         basicPassword: "",
@@ -462,7 +463,7 @@ describe("useAgentsCatalogQuery mutations", () => {
           cardUrl: "https://example.com/new.json",
           authType: "none",
           bearerToken: "",
-          apiKeyHeader: "X-API-Key",
+          apiKeyHeader: DEFAULT_API_KEY_HEADER,
           apiKeyValue: "",
           basicUsername: "",
           basicPassword: "",

--- a/frontend/hooks/__tests__/useChatHistoryQuery.test.tsx
+++ b/frontend/hooks/__tests__/useChatHistoryQuery.test.tsx
@@ -13,14 +13,9 @@ jest.mock("@/lib/api/sessions", () => ({
   listSessionMessagesPage: jest.fn(),
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 const mockedUsePaginatedList = jest.mocked(usePaginatedList);
 const mockedListSessionMessagesPage = jest.mocked(listSessionMessagesPage);

--- a/frontend/hooks/__tests__/usePaginatedList.test.tsx
+++ b/frontend/hooks/__tests__/usePaginatedList.test.tsx
@@ -16,14 +16,9 @@ jest.mock("@/lib/toast", () => ({
   },
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 type Item = { id: string };
 

--- a/frontend/hooks/__tests__/useScheduledJobExecutionsQuery.test.tsx
+++ b/frontend/hooks/__tests__/useScheduledJobExecutionsQuery.test.tsx
@@ -12,14 +12,9 @@ jest.mock("@/lib/api/scheduledJobs", () => ({
   listScheduledJobExecutionsPage: jest.fn(),
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 const mockedUsePaginatedList = jest.mocked(usePaginatedList);
 const mockedListScheduledJobExecutionsPage = jest.mocked(

--- a/frontend/hooks/__tests__/useScheduledJobsQuery.test.tsx
+++ b/frontend/hooks/__tests__/useScheduledJobsQuery.test.tsx
@@ -8,14 +8,9 @@ jest.mock("@/hooks/usePaginatedList", () => ({
   usePaginatedList: jest.fn(),
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 const mockedUsePaginatedList = jest.mocked(usePaginatedList);
 

--- a/frontend/hooks/__tests__/useSessionsDirectoryQuery.test.tsx
+++ b/frontend/hooks/__tests__/useSessionsDirectoryQuery.test.tsx
@@ -12,14 +12,9 @@ jest.mock("@/lib/api/sessions", () => ({
   listSessionsPage: jest.fn(),
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 const mockedUsePaginatedList = jest.mocked(usePaginatedList);
 const mockedListDirectoryPage = jest.mocked(listSessionsPage);

--- a/frontend/hooks/useAgentsCatalogQuery.ts
+++ b/frontend/hooks/useAgentsCatalogQuery.ts
@@ -65,6 +65,7 @@ const toAgentConfig = (
   healthStatus: agent.health_status,
   lastHealthCheckAt: agent.last_health_check_at ?? undefined,
   lastHealthCheckError: agent.last_health_check_error ?? undefined,
+  lastHealthCheckReasonCode: agent.last_health_check_reason_code ?? undefined,
   credentialMode: agent.credential_mode ?? undefined,
   credentialConfigured: agent.credential_configured ?? undefined,
   credentialDisplayHint: agent.credential_display_hint ?? undefined,
@@ -98,6 +99,7 @@ const toPersonalAgentConfig = (agent: A2AAgentResponse): AgentConfig => ({
   healthStatus: agent.health_status,
   lastHealthCheckAt: agent.last_health_check_at ?? undefined,
   lastHealthCheckError: agent.last_health_check_error ?? undefined,
+  lastHealthCheckReasonCode: agent.last_health_check_reason_code ?? undefined,
 });
 
 const getCatalogCache = (catalog: AgentConfig[] | undefined) => catalog ?? [];

--- a/frontend/hooks/useAgentsCatalogQuery.ts
+++ b/frontend/hooks/useAgentsCatalogQuery.ts
@@ -16,23 +16,16 @@ import {
   checkAgentHealth,
   createAgent,
   deleteAgent,
-  listAgents,
   updateAgent,
   validateAgentCard,
   type A2AAgentResponse,
 } from "@/lib/api/a2aAgents";
+import {
+  listAgentsCatalog,
+  type UnifiedAgentCatalogItemResponse,
+} from "@/lib/api/agentsCatalog";
 import { ApiRequestError } from "@/lib/api/client";
-import {
-  listHubAgents,
-  validateHubAgentCard,
-  type HubA2AAgentUserResponse,
-} from "@/lib/api/hubA2aAgentsUser";
-import {
-  getSelfManagementBuiltInAgentProfile,
-  SELF_MANAGEMENT_BUILT_IN_AGENT_CARD_URL,
-  SELF_MANAGEMENT_BUILT_IN_AGENT_ID,
-  type SelfManagementBuiltInAgentProfileResponse,
-} from "@/lib/api/selfManagementAgent";
+import { validateHubAgentCard } from "@/lib/api/hubA2aAgentsUser";
 import { queryKeys } from "@/lib/queryKeys";
 import { type AgentConfig, useAgentStore } from "@/store/agents";
 
@@ -45,7 +38,42 @@ type UpdateAgentPayload = Partial<
   Omit<AgentConfig, "id" | "source" | "status" | "lastCheckedAt" | "lastError">
 >;
 
-const toAgentConfig = (agent: A2AAgentResponse): AgentConfig => ({
+const toAgentConfig = (
+  agent: UnifiedAgentCatalogItemResponse,
+): AgentConfig => ({
+  id: agent.id,
+  source: agent.source,
+  name: agent.name,
+  cardUrl: agent.card_url,
+  authType:
+    agent.auth_type === "bearer"
+      ? "bearer"
+      : agent.auth_type === "basic"
+        ? "basic"
+        : "none",
+  bearerToken: "",
+  apiKeyHeader: "X-API-Key",
+  apiKeyValue: "",
+  basicUsername: "",
+  basicPassword: "",
+  extraHeaders: headersToEntries(agent.extra_headers ?? {}),
+  invokeMetadataDefaults: headersToEntries(
+    agent.invoke_metadata_defaults ?? {},
+  ),
+  status: "idle",
+  enabled: agent.enabled,
+  healthStatus: agent.health_status,
+  lastHealthCheckAt: agent.last_health_check_at ?? undefined,
+  lastHealthCheckError: agent.last_health_check_error ?? undefined,
+  credentialMode: agent.credential_mode ?? undefined,
+  credentialConfigured: agent.credential_configured ?? undefined,
+  credentialDisplayHint: agent.credential_display_hint ?? undefined,
+  description: agent.description ?? undefined,
+  runtime: agent.runtime ?? undefined,
+  resources: agent.resources ?? undefined,
+});
+
+const toPersonalAgentConfig = (agent: A2AAgentResponse): AgentConfig => ({
   id: agent.id,
   source: "personal",
   name: agent.name,
@@ -66,40 +94,10 @@ const toAgentConfig = (agent: A2AAgentResponse): AgentConfig => ({
     agent.invoke_metadata_defaults ?? {},
   ),
   status: "idle",
-});
-
-const toSharedAgentConfig = (agent: HubA2AAgentUserResponse): AgentConfig => ({
-  id: agent.id,
-  source: "shared",
-  name: agent.name,
-  cardUrl: agent.card_url,
-  authType: "none",
-  bearerToken: "",
-  apiKeyHeader: "X-API-Key",
-  apiKeyValue: "",
-  basicUsername: "",
-  basicPassword: "",
-  extraHeaders: [],
-  invokeMetadataDefaults: [],
-  status: "idle",
-});
-
-const toSelfManagementBuiltInAgentConfig = (
-  profile: SelfManagementBuiltInAgentProfileResponse,
-): AgentConfig => ({
-  id: profile.id,
-  source: "shared",
-  name: profile.name,
-  cardUrl: SELF_MANAGEMENT_BUILT_IN_AGENT_CARD_URL,
-  authType: "none",
-  bearerToken: "",
-  apiKeyHeader: "X-API-Key",
-  apiKeyValue: "",
-  basicUsername: "",
-  basicPassword: "",
-  extraHeaders: [],
-  invokeMetadataDefaults: [],
-  status: "idle",
+  enabled: agent.enabled,
+  healthStatus: agent.health_status,
+  lastHealthCheckAt: agent.last_health_check_at ?? undefined,
+  lastHealthCheckError: agent.last_health_check_error ?? undefined,
 });
 
 const getCatalogCache = (catalog: AgentConfig[] | undefined) => catalog ?? [];
@@ -164,57 +162,9 @@ export function useAgentsCatalogQuery(enabled = true) {
       const previousAgents = getCatalogCache(
         queryClient.getQueryData<AgentConfig[]>(queryKeys.agents.catalog()),
       );
-
-      const [personalResult, sharedResult, selfManagementProfileResult] =
-        await Promise.allSettled([
-          listAgents(1, 200),
-          listHubAgents(1, 200),
-          getSelfManagementBuiltInAgentProfile(),
-        ]);
-
-      if (
-        personalResult.status === "rejected" &&
-        sharedResult.status === "rejected" &&
-        selfManagementProfileResult.status === "rejected"
-      ) {
-        throw (
-          personalResult.reason ??
-          sharedResult.reason ??
-          selfManagementProfileResult.reason
-        );
-      }
-
-      const personalAgents =
-        personalResult.status === "fulfilled"
-          ? personalResult.value.items.map(toAgentConfig)
-          : previousAgents.filter((agent) => agent.source === "personal");
-
-      const sharedAgents =
-        sharedResult.status === "fulfilled"
-          ? sharedResult.value.items.map(toSharedAgentConfig)
-          : previousAgents.filter(
-              (agent) =>
-                agent.source === "shared" &&
-                agent.id !== SELF_MANAGEMENT_BUILT_IN_AGENT_ID,
-            );
-
-      const previousSelfManagementAgents = previousAgents.filter(
-        (agent) => agent.id === SELF_MANAGEMENT_BUILT_IN_AGENT_ID,
-      );
-      const selfManagementAgents =
-        selfManagementProfileResult.status === "fulfilled" &&
-        selfManagementProfileResult.value.configured
-          ? [
-              toSelfManagementBuiltInAgentConfig(
-                selfManagementProfileResult.value,
-              ),
-            ]
-          : previousSelfManagementAgents;
-
-      return mergeTransientAgentState(
-        [...personalAgents, ...sharedAgents, ...selfManagementAgents],
-        previousAgents,
-      );
+      const response = await listAgentsCatalog();
+      const nextAgents = response.items.map(toAgentConfig);
+      return mergeTransientAgentState(nextAgents, previousAgents);
     },
   });
 
@@ -238,7 +188,8 @@ export function useCreateAgentMutation() {
     onSuccess: async (response) => {
       queryClient.setQueryData<AgentConfig[] | undefined>(
         queryKeys.agents.catalog(),
-        (catalog) => upsertAgentInCatalog(catalog, toAgentConfig(response)),
+        (catalog) =>
+          upsertAgentInCatalog(catalog, toPersonalAgentConfig(response)),
       );
       try {
         await checkAgentHealth(response.id, true);
@@ -289,7 +240,11 @@ export function useUpdateAgentMutation() {
       queryClient.setQueryData<AgentConfig[] | undefined>(
         queryKeys.agents.catalog(),
         (catalog) =>
-          upsertAgentInCatalog(catalog, toAgentConfig(response), variables.id),
+          upsertAgentInCatalog(
+            catalog,
+            toPersonalAgentConfig(response),
+            variables.id,
+          ),
       );
       await refreshActiveCatalogQuery(queryClient);
     },
@@ -356,9 +311,14 @@ export function useValidateAgentMutation() {
       let response;
       try {
         response =
-          agent.source === "shared"
-            ? await validateHubAgentCard(agentId)
-            : await validateAgentCard(agentId);
+          agent.source === "builtin"
+            ? {
+                success: true,
+                message: "Built-in agent is managed by the local runtime.",
+              }
+            : agent.source === "shared"
+              ? await validateHubAgentCard(agentId)
+              : await validateAgentCard(agentId);
       } catch (error) {
         if (isNotFoundError(error)) {
           throw toNotFoundError();

--- a/frontend/hooks/useAgentsCatalogQuery.ts
+++ b/frontend/hooks/useAgentsCatalogQuery.ts
@@ -10,7 +10,7 @@ import {
   toValidationErrorMessage,
   upsertAgentInCatalog,
 } from "@/lib/agentCatalogCache";
-import { headersToEntries } from "@/lib/agentHeaders";
+import { DEFAULT_API_KEY_HEADER, headersToEntries } from "@/lib/agentHeaders";
 import { buildAgentUpsertPayload } from "@/lib/agentUpsert";
 import {
   checkAgentHealth,
@@ -52,7 +52,7 @@ const toAgentConfig = (
         ? "basic"
         : "none",
   bearerToken: "",
-  apiKeyHeader: "X-API-Key",
+  apiKeyHeader: DEFAULT_API_KEY_HEADER,
   apiKeyValue: "",
   basicUsername: "",
   basicPassword: "",
@@ -86,7 +86,7 @@ const toPersonalAgentConfig = (agent: A2AAgentResponse): AgentConfig => ({
         ? "basic"
         : "none",
   bearerToken: "",
-  apiKeyHeader: "X-API-Key",
+  apiKeyHeader: DEFAULT_API_KEY_HEADER,
   apiKeyValue: "",
   basicUsername: "",
   basicPassword: "",

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -4,6 +4,7 @@ import {
   A2AExtensionCallError,
   rejectQuestionInterrupt,
   replyElicitationInterrupt,
+  type ExtensionAgentSource,
   replyPermissionInterrupt,
   replyPermissionsInterrupt,
   replyQuestionInterrupt,
@@ -13,7 +14,6 @@ import { ApiRequestError } from "@/lib/api/client";
 import { type ResolvedRuntimeInterruptRecord } from "@/lib/chat-utils";
 import { toast } from "@/lib/toast";
 import { normalizeWorkingDirectory } from "@/lib/workingDirectory";
-import type { AgentSource } from "@/store/agents";
 
 const TERMINAL_INTERRUPT_ERROR_CODES = new Set([
   "interrupt_request_expired",
@@ -28,7 +28,7 @@ type ResolvedInterruptKeyInput = {
 
 type UseChatInterruptControllerParams = {
   activeAgentId?: string | null;
-  agentSource?: AgentSource | null;
+  agentSource?: ExtensionAgentSource | null;
   conversationId?: string;
   pendingInterrupt: PendingRuntimeInterrupt | null;
   lastResolvedInterrupt: ResolvedRuntimeInterruptRecord | null;

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -587,6 +587,11 @@ export function useChatScreenController({
       if (!currentSession) {
         throw new Error("Conversation session is unavailable.");
       }
+      if (nextAgentSource !== "personal" && nextAgentSource !== "shared") {
+        throw new Error(
+          "Built-in agents do not support upstream session control.",
+        );
+      }
       const response =
         nextAgentSource === "shared"
           ? await invokeHubAgent(
@@ -790,6 +795,9 @@ export function useChatScreenController({
           externalSessionId,
         };
         const createdAt = new Date().toISOString();
+        if (nextAgentSource !== "personal" && nextAgentSource !== "shared") {
+          throw new Error("Built-in agents do not support session commands.");
+        }
         const result = await commandSession({
           source: nextAgentSource,
           agentId: nextAgentId,
@@ -935,6 +943,9 @@ export function useChatScreenController({
       };
 
       try {
+        if (nextAgentSource !== "personal" && nextAgentSource !== "shared") {
+          return;
+        }
         const result = await recoverInterrupts({
           source: nextAgentSource,
           agentId: nextAgentId,
@@ -1020,7 +1031,10 @@ export function useChatScreenController({
     handleElicitationReply,
   } = useChatInterruptController({
     activeAgentId,
-    agentSource: agent?.source,
+    agentSource:
+      agent?.source === "personal" || agent?.source === "shared"
+        ? agent.source
+        : null,
     conversationId,
     pendingInterrupt,
     lastResolvedInterrupt,
@@ -1230,7 +1244,7 @@ export function useChatScreenController({
       return;
     }
     const nextAgentSource = agent?.source;
-    if (!nextAgentSource) {
+    if (nextAgentSource !== "personal" && nextAgentSource !== "shared") {
       return;
     }
     recoverPendingInterrupts({
@@ -1302,6 +1316,9 @@ export function useChatScreenController({
         boundExternalSessionId &&
         interruptRecoveryStatus === "supported"
       ) {
+        if (agent.source !== "personal" && agent.source !== "shared") {
+          return;
+        }
         recoverPendingInterrupts({
           nextConversationId: conversationId,
           nextAgentId: activeAgentId,
@@ -1538,7 +1555,11 @@ export function useChatScreenController({
   }, []);
 
   const handleInterruptStream = useCallback(() => {
-    if (!conversationId || !activeAgentId || !agent?.source) {
+    if (
+      !conversationId ||
+      !activeAgentId ||
+      (agent?.source !== "personal" && agent?.source !== "shared")
+    ) {
       return;
     }
     const runInterrupt = async () => {

--- a/frontend/hooks/useExtensionCapabilitiesQuery.ts
+++ b/frontend/hooks/useExtensionCapabilitiesQuery.ts
@@ -5,6 +5,7 @@ import { queryKeys } from "@/lib/queryKeys";
 import { type AgentSource } from "@/store/agents";
 
 export type GenericCapabilityStatus = "unknown" | "supported" | "unsupported";
+type ExtensionQuerySource = Extract<AgentSource, "personal" | "shared">;
 type SessionControlMethodCapability = {
   declared: boolean;
   consumedByHub: boolean;
@@ -43,19 +44,23 @@ export const useExtensionCapabilitiesQuery = ({
 }) => {
   const resolvedAgentId = agentId?.trim() || null;
   const resolvedSource = source ?? null;
+  const extensionSource =
+    resolvedSource === "personal" || resolvedSource === "shared"
+      ? resolvedSource
+      : null;
 
   const query = useQuery({
-    enabled: enabled && Boolean(resolvedAgentId && resolvedSource),
+    enabled: enabled && Boolean(resolvedAgentId && extensionSource),
     queryKey:
-      resolvedAgentId && resolvedSource
+      resolvedAgentId && extensionSource
         ? queryKeys.agents.extensionCapabilities({
             agentId: resolvedAgentId,
-            source: resolvedSource,
+            source: extensionSource,
           })
         : (["agents", "extension-capabilities", "idle"] as const),
     queryFn: async () =>
       await getExtensionCapabilities({
-        source: resolvedSource as AgentSource,
+        source: extensionSource as ExtensionQuerySource,
         agentId: resolvedAgentId as string,
       }),
     staleTime: 5 * 60_000,

--- a/frontend/lib/__tests__/agentCatalogCache.test.ts
+++ b/frontend/lib/__tests__/agentCatalogCache.test.ts
@@ -7,30 +7,12 @@ import {
   toValidationErrorMessage,
   upsertAgentInCatalog,
 } from "@/lib/agentCatalogCache";
-import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
-import { type AgentConfig } from "@/store/agents";
-
-const buildAgent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
-  id: "agent-1",
-  source: "personal",
-  name: "Agent One",
-  cardUrl: "https://example.com/agent-1.json",
-  authType: "none",
-  bearerToken: "",
-  apiKeyHeader: DEFAULT_API_KEY_HEADER,
-  apiKeyValue: "",
-  basicUsername: "",
-  basicPassword: "",
-  extraHeaders: [],
-  invokeMetadataDefaults: [],
-  status: "idle",
-  ...overrides,
-});
+import { createMockAgentConfig } from "@/test-utils/agentFixtures";
 
 describe("agentCatalogCache", () => {
   it("merges transient status fields from previous catalog", () => {
     const previous = [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         status: "error",
         lastCheckedAt: "2026-02-12T01:02:03.000Z",
@@ -38,10 +20,12 @@ describe("agentCatalogCache", () => {
       }),
     ];
 
-    const next = [buildAgent({ id: "agent-1", name: "Agent One Updated" })];
+    const next = [
+      createMockAgentConfig({ id: "agent-1", name: "Agent One Updated" }),
+    ];
 
     expect(mergeTransientAgentState(next, previous)).toEqual([
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         name: "Agent One Updated",
         status: "error",
@@ -53,7 +37,7 @@ describe("agentCatalogCache", () => {
 
   it("drops validation state when the agent card identity changes", () => {
     const previous = [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         status: "success",
         lastCheckedAt: "2026-02-12T01:02:03.000Z",
@@ -61,7 +45,7 @@ describe("agentCatalogCache", () => {
     ];
 
     const next = [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         cardUrl: "https://example.com/agent-1-updated.json",
       }),
@@ -72,8 +56,8 @@ describe("agentCatalogCache", () => {
 
   it("updates a specific agent in catalog", () => {
     const catalog = [
-      buildAgent({ id: "agent-1" }),
-      buildAgent({ id: "agent-2" }),
+      createMockAgentConfig({ id: "agent-1" }),
+      createMockAgentConfig({ id: "agent-2" }),
     ];
 
     const updated = patchAgentInCatalog(catalog, "agent-2", (agent) => ({
@@ -88,17 +72,17 @@ describe("agentCatalogCache", () => {
 
   it("upserts agent and preserves transient status from previous record", () => {
     const catalog = [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         status: "success",
         lastError: "old",
       }),
-      buildAgent({ id: "agent-2" }),
+      createMockAgentConfig({ id: "agent-2" }),
     ];
 
     const updated = upsertAgentInCatalog(
       catalog,
-      buildAgent({ id: "agent-1", name: "Renamed", status: "idle" }),
+      createMockAgentConfig({ id: "agent-1", name: "Renamed", status: "idle" }),
       "agent-1",
     );
 
@@ -113,7 +97,7 @@ describe("agentCatalogCache", () => {
 
   it("drops transient validation state on upsert when card identity changes", () => {
     const catalog = [
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         status: "success",
         lastCheckedAt: "2026-02-12T01:02:03.000Z",
@@ -122,7 +106,7 @@ describe("agentCatalogCache", () => {
 
     const updated = upsertAgentInCatalog(
       catalog,
-      buildAgent({
+      createMockAgentConfig({
         id: "agent-1",
         cardUrl: "https://example.com/agent-1-updated.json",
       }),
@@ -139,17 +123,17 @@ describe("agentCatalogCache", () => {
 
   it("removes agent from catalog", () => {
     const catalog = [
-      buildAgent({ id: "agent-1" }),
-      buildAgent({ id: "agent-2" }),
+      createMockAgentConfig({ id: "agent-1" }),
+      createMockAgentConfig({ id: "agent-2" }),
     ];
 
     expect(removeAgentFromCatalog(catalog, "agent-1")).toEqual([
-      buildAgent({ id: "agent-2" }),
+      createMockAgentConfig({ id: "agent-2" }),
     ]);
   });
 
   it("decides whether active agent should be cleared", () => {
-    const catalog = [buildAgent({ id: "agent-1" })];
+    const catalog = [createMockAgentConfig({ id: "agent-1" })];
 
     expect(shouldClearActiveAgent("agent-1", catalog)).toBe(false);
     expect(shouldClearActiveAgent("missing", catalog)).toBe(true);

--- a/frontend/lib/__tests__/agentCatalogCache.test.ts
+++ b/frontend/lib/__tests__/agentCatalogCache.test.ts
@@ -7,22 +7,24 @@ import {
   toValidationErrorMessage,
   upsertAgentInCatalog,
 } from "@/lib/agentCatalogCache";
-import { createMockAgentConfig } from "@/test-utils/agentFixtures";
+import {
+  createMockAgentCatalog,
+  createMockAgentConfig,
+} from "@/test-utils/agentFixtures";
 
 describe("agentCatalogCache", () => {
   it("merges transient status fields from previous catalog", () => {
-    const previous = [
-      createMockAgentConfig({
-        id: "agent-1",
-        status: "error",
-        lastCheckedAt: "2026-02-12T01:02:03.000Z",
-        lastError: "timeout",
-      }),
-    ];
+    const previous = createMockAgentCatalog({
+      id: "agent-1",
+      status: "error",
+      lastCheckedAt: "2026-02-12T01:02:03.000Z",
+      lastError: "timeout",
+    });
 
-    const next = [
-      createMockAgentConfig({ id: "agent-1", name: "Agent One Updated" }),
-    ];
+    const next = createMockAgentCatalog({
+      id: "agent-1",
+      name: "Agent One Updated",
+    });
 
     expect(mergeTransientAgentState(next, previous)).toEqual([
       createMockAgentConfig({
@@ -36,29 +38,25 @@ describe("agentCatalogCache", () => {
   });
 
   it("drops validation state when the agent card identity changes", () => {
-    const previous = [
-      createMockAgentConfig({
-        id: "agent-1",
-        status: "success",
-        lastCheckedAt: "2026-02-12T01:02:03.000Z",
-      }),
-    ];
+    const previous = createMockAgentCatalog({
+      id: "agent-1",
+      status: "success",
+      lastCheckedAt: "2026-02-12T01:02:03.000Z",
+    });
 
-    const next = [
-      createMockAgentConfig({
-        id: "agent-1",
-        cardUrl: "https://example.com/agent-1-updated.json",
-      }),
-    ];
+    const next = createMockAgentCatalog({
+      id: "agent-1",
+      cardUrl: "https://example.com/agent-1-updated.json",
+    });
 
     expect(mergeTransientAgentState(next, previous)).toEqual(next);
   });
 
   it("updates a specific agent in catalog", () => {
-    const catalog = [
-      createMockAgentConfig({ id: "agent-1" }),
-      createMockAgentConfig({ id: "agent-2" }),
-    ];
+    const catalog = createMockAgentCatalog(
+      { id: "agent-1" },
+      { id: "agent-2" },
+    );
 
     const updated = patchAgentInCatalog(catalog, "agent-2", (agent) => ({
       ...agent,
@@ -71,14 +69,14 @@ describe("agentCatalogCache", () => {
   });
 
   it("upserts agent and preserves transient status from previous record", () => {
-    const catalog = [
-      createMockAgentConfig({
+    const catalog = createMockAgentCatalog(
+      {
         id: "agent-1",
         status: "success",
         lastError: "old",
-      }),
-      createMockAgentConfig({ id: "agent-2" }),
-    ];
+      },
+      { id: "agent-2" },
+    );
 
     const updated = upsertAgentInCatalog(
       catalog,
@@ -96,13 +94,11 @@ describe("agentCatalogCache", () => {
   });
 
   it("drops transient validation state on upsert when card identity changes", () => {
-    const catalog = [
-      createMockAgentConfig({
-        id: "agent-1",
-        status: "success",
-        lastCheckedAt: "2026-02-12T01:02:03.000Z",
-      }),
-    ];
+    const catalog = createMockAgentCatalog({
+      id: "agent-1",
+      status: "success",
+      lastCheckedAt: "2026-02-12T01:02:03.000Z",
+    });
 
     const updated = upsertAgentInCatalog(
       catalog,
@@ -122,10 +118,10 @@ describe("agentCatalogCache", () => {
   });
 
   it("removes agent from catalog", () => {
-    const catalog = [
-      createMockAgentConfig({ id: "agent-1" }),
-      createMockAgentConfig({ id: "agent-2" }),
-    ];
+    const catalog = createMockAgentCatalog(
+      { id: "agent-1" },
+      { id: "agent-2" },
+    );
 
     expect(removeAgentFromCatalog(catalog, "agent-1")).toEqual([
       createMockAgentConfig({ id: "agent-2" }),
@@ -133,7 +129,7 @@ describe("agentCatalogCache", () => {
   });
 
   it("decides whether active agent should be cleared", () => {
-    const catalog = [createMockAgentConfig({ id: "agent-1" })];
+    const catalog = createMockAgentCatalog({ id: "agent-1" });
 
     expect(shouldClearActiveAgent("agent-1", catalog)).toBe(false);
     expect(shouldClearActiveAgent("missing", catalog)).toBe(true);

--- a/frontend/lib/__tests__/agentCatalogCache.test.ts
+++ b/frontend/lib/__tests__/agentCatalogCache.test.ts
@@ -7,6 +7,7 @@ import {
   toValidationErrorMessage,
   upsertAgentInCatalog,
 } from "@/lib/agentCatalogCache";
+import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { type AgentConfig } from "@/store/agents";
 
 const buildAgent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
@@ -16,7 +17,7 @@ const buildAgent = (overrides: Partial<AgentConfig> = {}): AgentConfig => ({
   cardUrl: "https://example.com/agent-1.json",
   authType: "none",
   bearerToken: "",
-  apiKeyHeader: "X-API-Key",
+  apiKeyHeader: DEFAULT_API_KEY_HEADER,
   apiKeyValue: "",
   basicUsername: "",
   basicPassword: "",

--- a/frontend/lib/agentHeaders.ts
+++ b/frontend/lib/agentHeaders.ts
@@ -7,6 +7,8 @@ export type HeaderEntry = {
 
 export type HeaderEntryWithId = HeaderEntry & { id: string };
 
+export const DEFAULT_API_KEY_HEADER = "X-API-Key"; // pragma: allowlist secret
+
 export const buildHeaderObject = (items: HeaderEntry[]) =>
   items.reduce<Record<string, string>>((acc, item) => {
     const key = item.key.trim();

--- a/frontend/lib/api/a2aAgents.ts
+++ b/frontend/lib/api/a2aAgents.ts
@@ -10,6 +10,12 @@ export type A2AAgentHealthStatus =
   | "healthy"
   | "degraded"
   | "unavailable";
+export type A2AAgentHealthReasonCode =
+  | "card_validation_failed"
+  | "runtime_validation_failed"
+  | "agent_unavailable"
+  | "client_reset_required"
+  | "unexpected_error";
 export type A2AAgentHealthBucket = "all" | A2AAgentHealthStatus | "attention";
 
 export type A2AAgentCardValidationResponse = {
@@ -35,6 +41,7 @@ export type A2AAgentResponse = {
   last_health_check_at?: string | null;
   last_successful_health_check_at?: string | null;
   last_health_check_error?: string | null;
+  last_health_check_reason_code?: A2AAgentHealthReasonCode | null;
   tags: string[];
   extra_headers: Record<string, string>;
   invoke_metadata_defaults: Record<string, string>;
@@ -78,6 +85,7 @@ type A2AAgentHealthCheckResponse = {
     checked_at: string;
     skipped_cooldown: boolean;
     error?: string | null;
+    reason_code?: A2AAgentHealthReasonCode | null;
   }[];
 };
 

--- a/frontend/lib/api/a2aAgents.ts
+++ b/frontend/lib/api/a2aAgents.ts
@@ -208,12 +208,6 @@ export const validateAgentCard = (agentId: string) =>
     },
   );
 
-export const checkAgentsHealth = (force = false) =>
-  apiRequest<A2AAgentHealthCheckResponse>("/me/a2a/agents/check-health", {
-    method: "POST",
-    query: { force: force ? "true" : "false" },
-  });
-
 export const checkAgentHealth = (agentId: string, force = true) =>
   apiRequest<A2AAgentHealthCheckResponse>(
     `/me/a2a/agents/${agentId}/check-health`,

--- a/frontend/lib/api/a2aExtensions.ts
+++ b/frontend/lib/api/a2aExtensions.ts
@@ -144,7 +144,7 @@ export const assertExtensionSuccess = (response: A2AExtensionResponse) => {
   });
 };
 
-type ExtensionAgentSource = "personal" | "shared";
+export type ExtensionAgentSource = "personal" | "shared";
 
 export type ModelProviderSummary = {
   provider_id: string;

--- a/frontend/lib/api/a2aExtensions.ts
+++ b/frontend/lib/api/a2aExtensions.ts
@@ -168,12 +168,6 @@ export type ModelSummary = {
   connected?: boolean;
 };
 
-export type RequestExecutionOptionsCapability = NonNullable<
-  A2AExtensionCapabilities["requestExecutionOptions"]
->;
-export type SessionAppendCapability =
-  A2AExtensionCapabilities["sessionControl"]["append"];
-
 type InterruptAckResult = {
   ok: true;
   requestId: string;

--- a/frontend/lib/api/agentsCatalog.ts
+++ b/frontend/lib/api/agentsCatalog.ts
@@ -1,0 +1,61 @@
+import { apiRequest } from "@/lib/api/client";
+
+export type UnifiedAgentSource = "personal" | "shared" | "builtin";
+export type UnifiedAgentHealthStatus =
+  | "unknown"
+  | "healthy"
+  | "degraded"
+  | "unavailable";
+
+export type UnifiedAgentCatalogItemResponse = {
+  id: string;
+  source: UnifiedAgentSource;
+  name: string;
+  card_url: string;
+  auth_type: "none" | "bearer" | "basic";
+  enabled: boolean;
+  health_status: UnifiedAgentHealthStatus;
+  last_health_check_at?: string | null;
+  last_health_check_error?: string | null;
+  credential_mode?: "none" | "shared" | "user" | null;
+  credential_configured?: boolean | null;
+  credential_display_hint?: string | null;
+  description?: string | null;
+  runtime?: string | null;
+  resources?: string[] | null;
+  extra_headers?: Record<string, string> | null;
+  invoke_metadata_defaults?: Record<string, string> | null;
+};
+
+export type UnifiedAgentCatalogResponse = {
+  items: UnifiedAgentCatalogItemResponse[];
+};
+
+export type UnifiedAgentHealthCheckResponse = {
+  summary: {
+    requested: number;
+    checked: number;
+    skipped_cooldown: number;
+    healthy: number;
+    degraded: number;
+    unavailable: number;
+    unknown: number;
+  };
+  items: {
+    agent_id: string;
+    agent_source: UnifiedAgentSource;
+    health_status: UnifiedAgentHealthStatus;
+    checked_at: string;
+    skipped_cooldown: boolean;
+    error?: string | null;
+  }[];
+};
+
+export const listAgentsCatalog = () =>
+  apiRequest<UnifiedAgentCatalogResponse>("/me/agents/catalog");
+
+export const checkAgentsCatalogHealth = (force = false) =>
+  apiRequest<UnifiedAgentHealthCheckResponse>("/me/agents/check-health", {
+    method: "POST",
+    query: { force: force ? "true" : "false" },
+  });

--- a/frontend/lib/api/agentsCatalog.ts
+++ b/frontend/lib/api/agentsCatalog.ts
@@ -6,6 +6,13 @@ export type UnifiedAgentHealthStatus =
   | "healthy"
   | "degraded"
   | "unavailable";
+export type UnifiedAgentHealthReasonCode =
+  | "card_validation_failed"
+  | "runtime_validation_failed"
+  | "agent_unavailable"
+  | "client_reset_required"
+  | "credential_required"
+  | "unexpected_error";
 
 export type UnifiedAgentCatalogItemResponse = {
   id: string;
@@ -17,6 +24,7 @@ export type UnifiedAgentCatalogItemResponse = {
   health_status: UnifiedAgentHealthStatus;
   last_health_check_at?: string | null;
   last_health_check_error?: string | null;
+  last_health_check_reason_code?: UnifiedAgentHealthReasonCode | null;
   credential_mode?: "none" | "shared" | "user" | null;
   credential_configured?: boolean | null;
   credential_display_hint?: string | null;
@@ -48,6 +56,7 @@ export type UnifiedAgentHealthCheckResponse = {
     checked_at: string;
     skipped_cooldown: boolean;
     error?: string | null;
+    reason_code?: UnifiedAgentHealthReasonCode | null;
   }[];
 };
 

--- a/frontend/lib/api/selfManagementAgent.ts
+++ b/frontend/lib/api/selfManagementAgent.ts
@@ -2,8 +2,6 @@ import type { PendingRuntimeInterrupt } from "@/lib/api/chat-utils";
 import { apiRequest } from "@/lib/api/client";
 
 export const SELF_MANAGEMENT_BUILT_IN_AGENT_ID = "self-management-assistant";
-export const SELF_MANAGEMENT_BUILT_IN_AGENT_CARD_URL =
-  "builtin://self-management-assistant";
 
 export const isSelfManagementBuiltInAgent = (agentId?: string | null) =>
   (agentId ?? "").trim() === SELF_MANAGEMENT_BUILT_IN_AGENT_ID;

--- a/frontend/lib/sessionDirectoryPresentation.ts
+++ b/frontend/lib/sessionDirectoryPresentation.ts
@@ -3,12 +3,12 @@ import { formatLocalDateTimeYmdHm } from "@/lib/datetime";
 
 type SessionAgentLookup = {
   name: string;
-  source: "personal" | "shared";
+  source: "personal" | "shared" | "builtin";
 };
 
 type SessionAgentPresentation = {
   name: string;
-  tone: "personal" | "shared" | "unknown";
+  tone: "personal" | "shared" | "builtin" | "unknown";
 };
 
 export const resolveSessionAgentPresentation = (
@@ -26,7 +26,7 @@ export const resolveSessionAgentPresentation = (
   }
 
   if (item.agent_source === "builtin") {
-    return { name: "A2A Client Hub Assistant", tone: "shared" };
+    return { name: "A2A Client Hub Assistant", tone: "builtin" };
   }
 
   if (item.agent_source === "personal" || item.agent_source === "shared") {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
         "prettier": "^3.3.3",
         "react-test-renderer": "19.1.2",
         "tailwindcss": "^3.4.14",
+        "ts-prune": "^0.10.3",
         "typescript": "~5.9.2"
       }
     },
@@ -3781,6 +3782,50 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@ts-morph/common": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.12.3.tgz",
+      "integrity": "sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3920,6 +3965,13 @@
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.17",
@@ -5431,6 +5483,13 @@
         "node": ">= 0.12.0"
       }
     },
+    "node_modules/code-block-writer": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
+      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
@@ -5629,6 +5688,33 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -12239,6 +12325,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12295,6 +12388,16 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/picocolors": {
@@ -15279,6 +15382,16 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/true-myth": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/true-myth/-/true-myth-4.1.1.tgz",
+      "integrity": "sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -15333,6 +15446,45 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/ts-morph": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-13.0.3.tgz",
+      "integrity": "sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.12.3",
+        "code-block-writer": "^11.0.0"
+      }
+    },
+    "node_modules/ts-prune": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-prune/-/ts-prune-0.10.3.tgz",
+      "integrity": "sha512-iS47YTbdIcvN8Nh/1BFyziyUqmjXz7GVzWu02RaZXqb+e/3Qe1B7IQ4860krOeCGUeJmterAlaM2FRH0Ue0hjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^6.2.1",
+        "cosmiconfig": "^7.0.1",
+        "json5": "^2.1.3",
+        "lodash": "^4.17.21",
+        "true-myth": "^4.1.0",
+        "ts-morph": "^13.0.1"
+      },
+      "bin": {
+        "ts-prune": "lib/index.js"
+      }
+    },
+    "node_modules/ts-prune/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,8 @@
     "lint": "eslint app components hooks lib screens services store --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
     "test": "jest",
-    "check-types": "export NODE_OPTIONS=\"--max-old-space-size=1024\" && tsc --noEmit"
+    "check-types": "export NODE_OPTIONS=\"--max-old-space-size=1024\" && tsc --noEmit",
+    "check-unused-exports": "bash scripts/check-unused-exports.sh"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
@@ -77,6 +78,7 @@
     "prettier": "^3.3.3",
     "react-test-renderer": "19.1.2",
     "tailwindcss": "^3.4.14",
+    "ts-prune": "^0.10.3",
     "typescript": "~5.9.2"
   },
   "overrides": {

--- a/frontend/screens/AgentFormScreen.tsx
+++ b/frontend/screens/AgentFormScreen.tsx
@@ -22,6 +22,7 @@ import { usePreventRemoveWhenDirty } from "@/hooks/usePreventRemoveWhenDirty";
 import { type AgentAuthType } from "@/lib/agentAuth";
 import { AGENT_ERROR_MESSAGES } from "@/lib/agentCatalogCache";
 import { executeWithAdminAutoAllowlist } from "@/lib/agentCreateAllowlist";
+import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { createProxyAllowlistEntry } from "@/lib/api/adminProxyAllowlist";
 import {
   deleteHubAgentCredential,
@@ -115,7 +116,7 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
   );
   const [bearerToken, setBearerToken] = useState(agent?.bearerToken ?? "");
   const [apiKeyHeader, setApiKeyHeader] = useState(
-    agent?.apiKeyHeader ?? "X-API-Key",
+    agent?.apiKeyHeader ?? DEFAULT_API_KEY_HEADER,
   );
   const [apiKeyValue, setApiKeyValue] = useState(agent?.apiKeyValue ?? "");
   const [basicUsername, setBasicUsername] = useState(
@@ -191,7 +192,7 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
     setCardUrl(agent.cardUrl ?? "");
     setAuthType(agent.authType ?? "none");
     setBearerToken(agent.bearerToken ?? "");
-    setApiKeyHeader(agent.apiKeyHeader ?? "X-API-Key");
+    setApiKeyHeader(agent.apiKeyHeader ?? DEFAULT_API_KEY_HEADER);
     setApiKeyValue(agent.apiKeyValue ?? "");
     setBasicUsername(agent.basicUsername ?? "");
     setBasicPassword(agent.basicPassword ?? "");
@@ -205,7 +206,7 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
       cardUrl: agent.cardUrl ?? "",
       authType: agent.authType ?? "none",
       bearerToken: agent.bearerToken ?? "",
-      apiKeyHeader: agent.apiKeyHeader ?? "X-API-Key",
+      apiKeyHeader: agent.apiKeyHeader ?? DEFAULT_API_KEY_HEADER,
       apiKeyValue: agent.apiKeyValue ?? "",
       basicUsername: agent.basicUsername ?? "",
       basicPassword: agent.basicPassword ?? "",
@@ -318,7 +319,7 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
     }
     setAuthType(nextType);
     setBearerToken("");
-    setApiKeyHeader("X-API-Key");
+    setApiKeyHeader(DEFAULT_API_KEY_HEADER);
     setApiKeyValue("");
     setBasicUsername("");
     setBasicPassword("");
@@ -766,7 +767,7 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
           <View className="gap-3">
             <Input
               label="Header Name"
-              placeholder="e.g., X-API-Key"
+              placeholder={`e.g., ${DEFAULT_API_KEY_HEADER}`}
               value={apiKeyHeader}
               onChangeText={setApiKeyHeader}
             />

--- a/frontend/screens/AgentFormScreen.tsx
+++ b/frontend/screens/AgentFormScreen.tsx
@@ -146,6 +146,9 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
 
   const goBackOrHome = useCallback(() => backOrHome(router), [router]);
   const isSharedAgent = Boolean(agentId && agent && agent.source === "shared");
+  const isBuiltInAgent = Boolean(
+    agentId && agent && agent.source === "builtin",
+  );
   const sharedCredentialQuery = useQuery({
     queryKey: ["agents", "shared-credential", agentId ?? "none"],
     queryFn: () => getHubAgentCredentialStatus(agentId!),
@@ -651,6 +654,36 @@ export function AgentFormScreen({ agentId }: AgentFormScreenProps) {
               This shared agent does not require credentials.
             </Text>
           )}
+        </View>
+      </ScreenContainer>
+    );
+  }
+
+  if (isBuiltInAgent) {
+    return (
+      <ScreenContainer>
+        <PageHeader
+          title="Agent"
+          subtitle="This built-in agent is provided by the local runtime and cannot be edited here."
+          rightElement={<BackButton variant="outline" onPress={handleCancel} />}
+        />
+        <View className="mt-8 rounded-2xl bg-surface p-6 shadow-sm">
+          <Text className="text-base font-bold text-white">Built-in agent</Text>
+          <Text className="mt-2 text-[11px] font-medium text-slate-400">
+            This entry is read-only. Its behavior is managed by the local
+            self-management runtime.
+          </Text>
+          <View className="mt-5 gap-2">
+            <Text className="text-xs text-slate-300">Name: {agent?.name}</Text>
+            <Text className="text-xs text-slate-400">
+              URL: {agent?.cardUrl}
+            </Text>
+            {agent?.runtime ? (
+              <Text className="text-xs text-slate-400">
+                Runtime: {agent.runtime}
+              </Text>
+            ) : null}
+          </View>
         </View>
       </ScreenContainer>
     );

--- a/frontend/screens/AgentListScreen.tsx
+++ b/frontend/screens/AgentListScreen.tsx
@@ -24,10 +24,10 @@ const HEALTH_BADGE_STYLES: Record<
   NonNullable<AgentConfig["healthStatus"]>,
   { label: string }
 > = {
-  healthy: { label: "Healthy" },
-  degraded: { label: "Degraded" },
+  healthy: { label: "Available" },
+  degraded: { label: "Needs attention" },
   unavailable: { label: "Unavailable" },
-  unknown: { label: "Unknown" },
+  unknown: { label: "Not checked" },
 };
 
 const SOURCE_LABELS: Record<AgentConfig["source"], string> = {
@@ -44,36 +44,6 @@ const SOURCE_SORT_ORDER: Record<AgentConfig["source"], number> = {
 
 const resolveHealthStatus = (agent: AgentConfig) =>
   agent.healthStatus ?? "unknown";
-
-const patchCatalogHealth = (
-  catalog: AgentConfig[] | undefined,
-  items: {
-    agent_id: string;
-    agent_source: AgentConfig["source"];
-    health_status: NonNullable<AgentConfig["healthStatus"]>;
-    checked_at: string;
-    error?: string | null;
-  }[],
-) => {
-  if (!catalog) {
-    return catalog;
-  }
-  const byKey = new Map(
-    items.map((item) => [`${item.agent_source}:${item.agent_id}`, item]),
-  );
-  return catalog.map((agent) => {
-    const match = byKey.get(`${agent.source}:${agent.id}`);
-    if (!match) {
-      return agent;
-    }
-    return {
-      ...agent,
-      healthStatus: match.health_status,
-      lastHealthCheckAt: match.checked_at,
-      lastHealthCheckError: match.error ?? undefined,
-    };
-  });
-};
 
 export function AgentListScreen() {
   const router = useRouter();
@@ -128,14 +98,17 @@ export function AgentListScreen() {
 
   const batchHealthMutation = useMutation({
     mutationFn: async () => checkAgentsCatalogHealth(false),
-    onSuccess: async (response) => {
-      queryClient.setQueryData<AgentConfig[] | undefined>(
-        queryKeys.agents.catalog(),
-        (catalog) => patchCatalogHealth(catalog, response.items),
-      );
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.agents.listRoot(),
-      });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.refetchQueries({
+          queryKey: queryKeys.agents.catalog(),
+          exact: true,
+          type: "active",
+        }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.agents.listRoot(),
+        }),
+      ]);
     },
     onError: (mutationError) => {
       const message =
@@ -372,7 +345,7 @@ export function AgentListScreen() {
     <ScreenContainer className="flex-1 bg-background px-5 sm:px-6">
       <PageHeader
         title="Agents"
-        subtitle="Browse and manage all available agents in one place."
+        subtitle="Browse agents and check whether each one is available to you."
         rightElement={
           <View className="flex-row gap-2">
             <AccountEntryButton />

--- a/frontend/screens/AgentListScreen.tsx
+++ b/frontend/screens/AgentListScreen.tsx
@@ -1,7 +1,7 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { FlatList, RefreshControl, ScrollView, Text, View } from "react-native";
+import { useCallback, useMemo } from "react";
+import { FlatList, RefreshControl, Text, View } from "react-native";
 
 import { AccountEntryButton } from "@/components/auth/AccountEntryButton";
 import { ScreenContainer } from "@/components/layout/ScreenContainer";
@@ -9,151 +9,108 @@ import { PAGE_HEADER_CONTENT_GAP } from "@/components/layout/spacing";
 import { Button } from "@/components/ui/Button";
 import { IconButton } from "@/components/ui/IconButton";
 import { PageHeader } from "@/components/ui/PageHeader";
-import {
-  usePersonalAgentsListQuery,
-  useSharedAgentsListQuery,
-} from "@/hooks/useAgentListQueries";
-import {
-  checkAgentsHealth,
-  type A2AAgentHealthStatus,
-  type A2AAgentResponse,
-} from "@/lib/api/a2aAgents";
-import { type HubA2AAgentUserResponse } from "@/lib/api/hubA2aAgentsUser";
-import {
-  getSelfManagementBuiltInAgentProfile,
-  type SelfManagementBuiltInAgentProfileResponse,
-} from "@/lib/api/selfManagementAgent";
+import { useAgentsCatalogQuery } from "@/hooks/useAgentsCatalogQuery";
+import { checkAgentsCatalogHealth } from "@/lib/api/agentsCatalog";
 import { formatLocalDateTime } from "@/lib/datetime";
 import { blurActiveElement } from "@/lib/focus";
 import { queryKeys } from "@/lib/queryKeys";
 import { buildChatRoute } from "@/lib/routes";
 import { toast } from "@/lib/toast";
-import { useAgentStore } from "@/store/agents";
+import { type AgentConfig, useAgentStore } from "@/store/agents";
 import { useChatStore } from "@/store/chat";
 import { useSessionStore } from "@/store/session";
 
-const PERSONAL_PAGE_SIZE = 12;
-const SHARED_PAGE_SIZE = 8;
-const SELF_MANAGEMENT_BUILT_IN_PROFILE_QUERY_KEY = [
-  "self-management-built-in-agent",
-  "profile",
-] as const;
-
 const HEALTH_BADGE_STYLES: Record<
-  A2AAgentResponse["health_status"],
+  NonNullable<AgentConfig["healthStatus"]>,
   { label: string }
 > = {
-  healthy: {
-    label: "Healthy",
-  },
-  degraded: {
-    label: "Degraded",
-  },
-  unavailable: {
-    label: "Unavailable",
-  },
-  unknown: {
-    label: "Unknown",
-  },
+  healthy: { label: "Healthy" },
+  degraded: { label: "Degraded" },
+  unavailable: { label: "Unavailable" },
+  unknown: { label: "Unknown" },
 };
 
-const PERSONAL_HEALTH_FILTERS: A2AAgentHealthStatus[] = [
-  "healthy",
-  "degraded",
-  "unavailable",
-  "unknown",
-];
+const SOURCE_LABELS: Record<AgentConfig["source"], string> = {
+  personal: "PERSONAL",
+  shared: "SHARED",
+  builtin: "BUILT-IN",
+};
+
+const SOURCE_SORT_ORDER: Record<AgentConfig["source"], number> = {
+  builtin: 0,
+  personal: 1,
+  shared: 2,
+};
+
+const resolveHealthStatus = (agent: AgentConfig) =>
+  agent.healthStatus ?? "unknown";
+
+const patchCatalogHealth = (
+  catalog: AgentConfig[] | undefined,
+  items: {
+    agent_id: string;
+    agent_source: AgentConfig["source"];
+    health_status: NonNullable<AgentConfig["healthStatus"]>;
+    checked_at: string;
+    error?: string | null;
+  }[],
+) => {
+  if (!catalog) {
+    return catalog;
+  }
+  const byKey = new Map(
+    items.map((item) => [`${item.agent_source}:${item.agent_id}`, item]),
+  );
+  return catalog.map((agent) => {
+    const match = byKey.get(`${agent.source}:${agent.id}`);
+    if (!match) {
+      return agent;
+    }
+    return {
+      ...agent,
+      healthStatus: match.health_status,
+      lastHealthCheckAt: match.checked_at,
+      lastHealthCheckError: match.error ?? undefined,
+    };
+  });
+};
 
 export function AgentListScreen() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const user = useSessionStore((state) => state.user);
   const setActiveAgent = useAgentStore((state) => state.setActiveAgent);
-  const [activeView, setActiveView] = useState<"personal" | "shared">(
-    "personal",
-  );
-  const [activePersonalHealthFilter, setActivePersonalHealthFilter] =
-    useState<A2AAgentHealthStatus>("healthy");
-  const isPersonalView = activeView === "personal";
+  const {
+    data: agents = [],
+    isLoading,
+    isRefetching,
+    refetch,
+    error,
+  } = useAgentsCatalogQuery(true);
 
-  const personalQuery = usePersonalAgentsListQuery({
-    size: PERSONAL_PAGE_SIZE,
-    healthBucket: activePersonalHealthFilter,
-    enabled: isPersonalView,
-  });
-
-  const sharedQuery = useSharedAgentsListQuery({
-    size: SHARED_PAGE_SIZE,
-    enabled: !isPersonalView,
-  });
-  const builtInAgentProfileQuery = useQuery({
-    queryKey: SELF_MANAGEMENT_BUILT_IN_PROFILE_QUERY_KEY,
-    enabled: !isPersonalView,
-    queryFn: getSelfManagementBuiltInAgentProfile,
-  });
-  const builtInAgentProfile =
-    builtInAgentProfileQuery.data?.configured === true
-      ? builtInAgentProfileQuery.data
-      : null;
-
-  const invalidateAgentQueries = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.listRoot() }),
-      queryClient.invalidateQueries({
-        queryKey: queryKeys.agents.sharedListRoot(),
-      }),
-      queryClient.invalidateQueries({ queryKey: queryKeys.agents.catalog() }),
-    ]);
-  };
-
-  const batchHealthMutation = useMutation({
-    mutationFn: async () => checkAgentsHealth(false),
-    onSuccess: async () => {
-      await invalidateAgentQueries();
-    },
-    onError: (error) => {
-      const message =
-        error instanceof Error
-          ? error.message
-          : "Could not check agent availability.";
-      toast.error("Availability check failed", message);
-    },
-  });
-
-  const counts = personalQuery.counts;
-  const visiblePersonalHealthFilters = useMemo(
+  const orderedAgents = useMemo(
     () =>
-      PERSONAL_HEALTH_FILTERS.filter((status) => (counts?.[status] ?? 0) > 0),
-    [counts],
+      [...agents].sort((left, right) => {
+        const sourceDelta =
+          SOURCE_SORT_ORDER[left.source] - SOURCE_SORT_ORDER[right.source];
+        if (sourceDelta !== 0) {
+          return sourceDelta;
+        }
+        return left.name.localeCompare(right.name);
+      }),
+    [agents],
   );
-  const totalPersonalAgents = useMemo(() => {
-    if (!counts) {
-      return 0;
-    }
-    return (
-      counts.healthy + counts.degraded + counts.unavailable + counts.unknown
-    );
-  }, [counts]);
-  const selectedFilterLabel =
-    HEALTH_BADGE_STYLES[activePersonalHealthFilter].label.toLowerCase();
 
-  useEffect(() => {
-    if (!isPersonalView) {
-      return;
-    }
-    if ((counts?.[activePersonalHealthFilter] ?? 0) > 0) {
-      return;
-    }
-    const fallbackFilter = visiblePersonalHealthFilters[0];
-    if (fallbackFilter && fallbackFilter !== activePersonalHealthFilter) {
-      setActivePersonalHealthFilter(fallbackFilter);
-    }
-  }, [
-    activePersonalHealthFilter,
-    counts,
-    isPersonalView,
-    visiblePersonalHealthFilters,
-  ]);
+  const counts = useMemo(
+    () => ({
+      builtin: orderedAgents.filter((agent) => agent.source === "builtin")
+        .length,
+      personal: orderedAgents.filter((agent) => agent.source === "personal")
+        .length,
+      shared: orderedAgents.filter((agent) => agent.source === "shared").length,
+    }),
+    [orderedAgents],
+  );
 
   const handleChat = useCallback(
     (agentId: string) => {
@@ -161,7 +118,6 @@ export function AgentListScreen() {
       const chatStore = useChatStore.getState();
       const latestSessionId =
         chatStore.getLatestConversationIdByAgentId(agentId);
-
       const conversationId =
         latestSessionId ?? chatStore.generateConversationId();
       blurActiveElement();
@@ -170,402 +126,253 @@ export function AgentListScreen() {
     [router, setActiveAgent],
   );
 
-  const handleRefresh = useCallback(async () => {
-    if (activeView === "personal") {
-      await personalQuery.refresh();
-      return;
-    }
-    await sharedQuery.refresh();
-  }, [activeView, personalQuery, sharedQuery]);
-
-  const handleLoadMore = useCallback(async () => {
-    if (activeView === "personal") {
-      if (!personalQuery.hasMore || personalQuery.loadingMore) {
-        return;
-      }
-      await personalQuery.loadMore();
-      return;
-    }
-
-    if (!sharedQuery.hasMore || sharedQuery.loadingMore) {
-      return;
-    }
-    await sharedQuery.loadMore();
-  }, [activeView, personalQuery, sharedQuery]);
-
-  const onRefresh = useCallback(() => handleRefresh(), [handleRefresh]);
-  const onEndReached = useCallback(() => handleLoadMore(), [handleLoadMore]);
-  const toggleActiveView = useCallback(() => {
-    setActiveView((currentView) =>
-      currentView === "personal" ? "shared" : "personal",
-    );
-  }, []);
-
-  const activeViewButtonLabel = isPersonalView ? "My" : "Shared";
-  const activeViewButtonIcon = isPersonalView ? "person-outline" : "people";
-
-  const renderPersonalAgentItem = useCallback(
-    ({ item: agent }: { item: A2AAgentResponse }) => {
-      const showCheckedAt = agent.health_status !== "healthy";
-      const checkedAtLabel = agent.last_health_check_at
-        ? `Checked ${formatLocalDateTime(agent.last_health_check_at)}`
-        : "Not checked yet";
-
-      return (
-        <View className="mb-4 overflow-hidden rounded-2xl bg-surface shadow-sm">
-          <View className="px-4 py-4">
-            <Text
-              className="text-[13px] font-semibold text-white"
-              numberOfLines={1}
-            >
-              {agent.name}
-            </Text>
-            {!agent.enabled || showCheckedAt ? (
-              <View className="mt-3 flex-row items-center justify-between gap-3">
-                {agent.enabled ? (
-                  <View className="flex-1" />
-                ) : (
-                  <Text className="text-xs text-slate-400" numberOfLines={1}>
-                    Disabled
-                  </Text>
-                )}
-                {showCheckedAt ? (
-                  <Text
-                    className="flex-1 text-right text-xs text-slate-500"
-                    numberOfLines={1}
-                  >
-                    {checkedAtLabel}
-                  </Text>
-                ) : null}
-              </View>
-            ) : null}
-            {agent.last_health_check_error ? (
-              <Text className="mt-2 text-xs text-rose-200" numberOfLines={2}>
-                {agent.last_health_check_error}
-              </Text>
-            ) : null}
-          </View>
-
-          <View className="flex-row items-center justify-between gap-2 bg-black/20 px-4 py-2.5">
-            <View className="flex-row flex-wrap items-center gap-2">
-              <Button
-                label="Edit"
-                size="sm"
-                variant="secondary"
-                iconLeft="create-outline"
-                onPress={() => {
-                  blurActiveElement();
-                  router.push(`/agents/${agent.id}`);
-                }}
-              />
-            </View>
-
-            <Button
-              label="Chat"
-              size="sm"
-              variant="primary"
-              iconRight="chevron-forward"
-              onPress={() => handleChat(agent.id)}
-              accessibilityRole="button"
-              accessibilityLabel="Open chat"
-              accessibilityHint={`Open chat with ${agent.name}`}
-            />
-          </View>
-        </View>
+  const batchHealthMutation = useMutation({
+    mutationFn: async () => checkAgentsCatalogHealth(false),
+    onSuccess: async (response) => {
+      queryClient.setQueryData<AgentConfig[] | undefined>(
+        queryKeys.agents.catalog(),
+        (catalog) => patchCatalogHealth(catalog, response.items),
       );
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.agents.listRoot(),
+      });
     },
-    [handleChat, router],
-  );
+    onError: (mutationError) => {
+      const message =
+        mutationError instanceof Error
+          ? mutationError.message
+          : "Could not check agent availability.";
+      toast.error("Availability check failed", message);
+    },
+  });
 
-  const renderSharedAgentItem = useCallback(
-    ({ item: agent }: { item: HubA2AAgentUserResponse }) => (
-      <View className="mb-4 overflow-hidden rounded-2xl bg-surface shadow-sm">
-        <View className="px-4 py-4">
-          <View className="flex-row items-center justify-between">
-            <Text
-              className="flex-1 pr-4 text-[13px] font-semibold text-white"
-              numberOfLines={1}
-            >
-              {agent.name}
-            </Text>
-            <Text className="text-[10px] font-bold uppercase tracking-widest text-neo-green">
-              SHARED
-            </Text>
-          </View>
-          <Text className="mt-3 text-xs text-slate-400">
-            {agent.credential_mode === "user"
-              ? agent.credential_configured
-                ? `Uses your saved ${agent.auth_type} credential${
-                    agent.credential_display_hint
-                      ? ` (${agent.credential_display_hint})`
-                      : ""
-                  }.`
-                : `Requires your ${agent.auth_type} credential before chat.`
-              : agent.credential_mode === "shared"
-                ? "Uses an admin-managed shared credential."
-                : "No credential required."}
+  const renderAgentMeta = (agent: AgentConfig) => {
+    const healthStatus = resolveHealthStatus(agent);
+    const checkedAtLabel = agent.lastHealthCheckAt
+      ? `Checked ${formatLocalDateTime(agent.lastHealthCheckAt)}`
+      : "Not checked yet";
+    const sourceLabel = SOURCE_LABELS[agent.source];
+
+    return (
+      <>
+        <View className="flex-row items-center justify-between gap-3">
+          <Text
+            className="flex-1 pr-4 text-[13px] font-semibold text-white"
+            numberOfLines={1}
+          >
+            {agent.name}
+          </Text>
+          <Text className="text-[10px] font-bold uppercase tracking-widest text-neo-green">
+            {sourceLabel}
           </Text>
         </View>
 
-        <View className="flex-row items-center justify-between gap-2 bg-black/20 px-4 py-2.5">
-          <View className="flex-row gap-2">
+        <View className="mt-3 flex-row items-center justify-between gap-3">
+          <Text className="text-xs text-slate-400" numberOfLines={1}>
+            {HEALTH_BADGE_STYLES[healthStatus].label}
+          </Text>
+          <Text
+            className="flex-1 text-right text-xs text-slate-500"
+            numberOfLines={1}
+          >
+            {checkedAtLabel}
+          </Text>
+        </View>
+      </>
+    );
+  };
+
+  const renderPersonalAgentItem = (agent: AgentConfig) => (
+    <View className="mb-4 overflow-hidden rounded-2xl bg-surface shadow-sm">
+      <View className="px-4 py-4">
+        {renderAgentMeta(agent)}
+        {!agent.enabled ? (
+          <Text className="mt-2 text-xs text-slate-400" numberOfLines={1}>
+            Disabled
+          </Text>
+        ) : null}
+        {agent.lastHealthCheckError ? (
+          <Text className="mt-2 text-xs text-rose-200" numberOfLines={2}>
+            {agent.lastHealthCheckError}
+          </Text>
+        ) : null}
+      </View>
+
+      <View className="flex-row items-center justify-between gap-2 bg-black/20 px-4 py-2.5">
+        <Button
+          label="Edit"
+          size="sm"
+          variant="secondary"
+          iconLeft="create-outline"
+          onPress={() => {
+            blurActiveElement();
+            router.push(`/agents/${agent.id}`);
+          }}
+        />
+        <Button
+          label="Chat"
+          size="sm"
+          variant="primary"
+          iconRight="chevron-forward"
+          onPress={() => handleChat(agent.id)}
+          accessibilityRole="button"
+          accessibilityLabel="Open chat"
+          accessibilityHint={`Open chat with ${agent.name}`}
+        />
+      </View>
+    </View>
+  );
+
+  const renderSharedAgentItem = (agent: AgentConfig) => (
+    <View className="mb-4 overflow-hidden rounded-2xl bg-surface shadow-sm">
+      <View className="px-4 py-4">
+        {renderAgentMeta(agent)}
+        <Text className="mt-3 text-xs text-slate-400">
+          {agent.credentialMode === "user"
+            ? agent.credentialConfigured
+              ? `Uses your saved ${agent.authType} credential${
+                  agent.credentialDisplayHint
+                    ? ` (${agent.credentialDisplayHint})`
+                    : ""
+                }.`
+              : `Requires your ${agent.authType} credential before chat.`
+            : agent.credentialMode === "shared"
+              ? "Uses an admin-managed shared credential."
+              : "No credential required."}
+        </Text>
+        {agent.lastHealthCheckError ? (
+          <Text className="mt-2 text-xs text-rose-200" numberOfLines={2}>
+            {agent.lastHealthCheckError}
+          </Text>
+        ) : null}
+      </View>
+
+      <View className="flex-row items-center justify-between gap-2 bg-black/20 px-4 py-2.5">
+        <View className="flex-row gap-2">
+          <Button
+            label="Details"
+            size="sm"
+            variant="secondary"
+            iconLeft="information-outline"
+            onPress={() => {
+              blurActiveElement();
+              router.push(`/agents/${agent.id}`);
+            }}
+          />
+          {agent.credentialMode === "user" ? (
             <Button
-              label="Details"
+              label={
+                agent.credentialConfigured
+                  ? "Edit credential"
+                  : "Set credential"
+              }
               size="sm"
               variant="secondary"
-              iconLeft="information-outline"
+              iconLeft="key-outline"
               onPress={() => {
                 blurActiveElement();
                 router.push(`/agents/${agent.id}`);
               }}
             />
-            {agent.credential_mode === "user" ? (
-              <Button
-                label={
-                  agent.credential_configured
-                    ? "Edit credential"
-                    : "Set credential"
-                }
-                size="sm"
-                variant="secondary"
-                iconLeft="key-outline"
-                onPress={() => {
-                  blurActiveElement();
-                  router.push(`/agents/${agent.id}`);
-                }}
-              />
-            ) : null}
-          </View>
-
-          <Button
-            label="Chat"
-            size="sm"
-            variant="primary"
-            iconRight="chevron-forward"
-            onPress={() => handleChat(agent.id)}
-            disabled={
-              agent.credential_mode === "user" && !agent.credential_configured
-            }
-            accessibilityRole="button"
-            accessibilityLabel="Open chat"
-            accessibilityHint={`Open chat with ${agent.name}`}
-          />
+          ) : null}
         </View>
+
+        <Button
+          label="Chat"
+          size="sm"
+          variant="primary"
+          iconRight="chevron-forward"
+          onPress={() => handleChat(agent.id)}
+          disabled={
+            agent.credentialMode === "user" && !agent.credentialConfigured
+          }
+          accessibilityRole="button"
+          accessibilityLabel="Open chat"
+          accessibilityHint={`Open chat with ${agent.name}`}
+        />
       </View>
-    ),
+    </View>
+  );
+
+  const renderBuiltInAgentItem = (agent: AgentConfig) => (
+    <View className="mb-4 overflow-hidden rounded-2xl bg-surface shadow-sm">
+      <View className="px-4 py-4">
+        {renderAgentMeta(agent)}
+        <Text className="mt-3 text-xs text-slate-400">
+          {agent.description ??
+            "Manage your agents, sessions, and jobs through constrained built-in tools."}
+        </Text>
+        {agent.resources?.length ? (
+          <Text className="mt-2 text-xs text-slate-500">
+            Resources: {agent.resources.join(", ")}
+          </Text>
+        ) : null}
+      </View>
+
+      <View className="flex-row items-center justify-end gap-2 bg-black/20 px-4 py-2.5">
+        <Button
+          label="Chat"
+          size="sm"
+          variant="primary"
+          iconRight="chevron-forward"
+          onPress={() => handleChat(agent.id)}
+          accessibilityRole="button"
+          accessibilityLabel="Open built-in assistant"
+          accessibilityHint={`Open chat with ${agent.name}`}
+        />
+      </View>
+    </View>
+  );
+
+  const renderAgentItem = useCallback(
+    ({ item }: { item: AgentConfig }) => {
+      if (item.source === "builtin") {
+        return renderBuiltInAgentItem(item);
+      }
+      if (item.source === "shared") {
+        return renderSharedAgentItem(item);
+      }
+      return renderPersonalAgentItem(item);
+    },
     [handleChat, router],
   );
 
-  const renderBuiltInAgentCard = useCallback(
-    (profile: SelfManagementBuiltInAgentProfileResponse) => (
-      <View className="mb-4 overflow-hidden rounded-2xl bg-surface shadow-sm">
-        <View className="px-4 py-4">
-          <View className="flex-row items-center justify-between">
-            <Text
-              className="flex-1 pr-4 text-[13px] font-semibold text-white"
-              numberOfLines={1}
-            >
-              {profile.name}
-            </Text>
-            <Text className="text-[10px] font-bold uppercase tracking-widest text-neo-green">
-              BUILT-IN
-            </Text>
-          </View>
-          <Text className="mt-3 text-xs text-slate-400">
-            Manage your own {profile.resources.join(", ")} inside a2a-client-hub
-            through constrained built-in tools.
-          </Text>
-        </View>
-
-        <View className="flex-row items-center justify-end gap-2 bg-black/20 px-4 py-2.5">
-          <Button
-            label="Chat"
-            size="sm"
-            variant="primary"
-            iconRight="chevron-forward"
-            onPress={() => handleChat(profile.id)}
-            accessibilityRole="button"
-            accessibilityLabel="Open built-in assistant"
-            accessibilityHint={`Open chat with ${profile.name}`}
-          />
-        </View>
-      </View>
-    ),
-    [handleChat],
-  );
-
-  const sharedListData = useMemo(() => sharedQuery.items, [sharedQuery.items]);
-
   const renderHeader = useMemo(
     () => (
-      <View className="mb-5">
-        {isPersonalView ? (
-          <View className="rounded-2xl bg-surface p-4">
-            <View className="flex-row items-center gap-3">
-              <ScrollView
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                className="min-w-0 flex-1"
-                contentContainerStyle={{ gap: 12, paddingRight: 4 }}
-              >
-                {visiblePersonalHealthFilters.map((status) => (
-                  <Button
-                    key={status}
-                    className="rounded-full"
-                    label={`${counts?.[status] ?? 0} ${HEALTH_BADGE_STYLES[status].label}`}
-                    size="xs"
-                    variant={
-                      activePersonalHealthFilter === status
-                        ? "primary"
-                        : "secondary"
-                    }
-                    onPress={() => setActivePersonalHealthFilter(status)}
-                  />
-                ))}
-              </ScrollView>
-              <Button
-                label={batchHealthMutation.isPending ? "Checking..." : "Check"}
-                size="sm"
-                variant="secondary"
-                iconLeft="pulse-outline"
-                onPress={() => {
-                  if (batchHealthMutation.isPending) {
-                    return;
-                  }
-                  batchHealthMutation.mutate();
-                }}
-              />
-            </View>
+      <View className="mb-5 rounded-2xl bg-surface p-4">
+        <View className="flex-row items-center justify-between gap-4">
+          <View className="flex-1">
+            <Text className="text-sm font-semibold text-white">
+              {orderedAgents.length} agents
+            </Text>
+            <Text className="mt-1 text-xs text-slate-400">
+              Built-in {counts.builtin} / Personal {counts.personal} / Shared{" "}
+              {counts.shared}
+            </Text>
           </View>
-        ) : builtInAgentProfile ? (
-          renderBuiltInAgentCard(builtInAgentProfile)
-        ) : null}
-      </View>
-    ),
-    [
-      activePersonalHealthFilter,
-      batchHealthMutation,
-      builtInAgentProfile,
-      counts,
-      isPersonalView,
-      renderBuiltInAgentCard,
-      setActivePersonalHealthFilter,
-      visiblePersonalHealthFilters,
-    ],
-  );
-
-  const renderFooter = useMemo(() => {
-    const hasMore =
-      activeView === "personal" ? personalQuery.hasMore : sharedQuery.hasMore;
-    const loadingMore =
-      activeView === "personal"
-        ? personalQuery.loadingMore
-        : sharedQuery.loadingMore;
-
-    if (!hasMore) {
-      return null;
-    }
-
-    return (
-      <View className="py-4 items-center">
-        <Button
-          label={loadingMore ? "Loading..." : "Load more"}
-          size="sm"
-          variant="secondary"
-          loading={loadingMore}
-          onPress={handleLoadMore}
-        />
-      </View>
-    );
-  }, [
-    activeView,
-    handleLoadMore,
-    personalQuery.hasMore,
-    personalQuery.loadingMore,
-    sharedQuery.hasMore,
-    sharedQuery.loadingMore,
-  ]);
-
-  const renderPersonalEmptyState = useMemo(() => {
-    if (personalQuery.loading && personalQuery.items.length === 0) {
-      return (
-        <View className="mt-8 items-center">
-          <Text className="text-sm text-gray-400">Loading agents...</Text>
-        </View>
-      );
-    }
-
-    if (totalPersonalAgents === 0) {
-      return (
-        <View className="items-center rounded-2xl bg-surface p-8">
-          <View className="mb-4 h-16 w-16 items-center justify-center rounded-2xl bg-primary">
-            <Text className="text-[11px] font-bold text-black">A2A</Text>
-          </View>
-          <Text className="text-base font-bold text-white">No agents yet</Text>
-          <Text className="mt-2 text-center text-sm text-slate-400">
-            Add your first agent to start chatting with A2A services.
-          </Text>
           <Button
-            className="mt-6"
-            label="Add an agent"
+            label={batchHealthMutation.isPending ? "Checking..." : "Check all"}
+            size="sm"
+            variant="secondary"
+            iconLeft="pulse-outline"
             onPress={() => {
-              blurActiveElement();
-              router.push("/agents/new");
+              if (batchHealthMutation.isPending) {
+                return;
+              }
+              batchHealthMutation.mutate();
             }}
           />
         </View>
-      );
-    }
-
-    return (
-      <View className="items-center rounded-2xl bg-surface p-8">
-        <Text className="text-base font-bold text-white">
-          No {selectedFilterLabel} agents right now
-        </Text>
-        <Text className="mt-2 text-center text-sm text-slate-400">
-          Try another health status or run an availability check to refresh the
-          latest results.
-        </Text>
       </View>
-    );
-  }, [
-    personalQuery.items.length,
-    personalQuery.loading,
-    router,
-    selectedFilterLabel,
-    totalPersonalAgents,
-  ]);
-
-  const renderSharedEmptyState = useMemo(() => {
-    if (sharedQuery.loading && sharedQuery.items.length === 0) {
-      return (
-        <View className="mt-8 items-center">
-          <Text className="text-sm text-gray-400">Loading agents...</Text>
-        </View>
-      );
-    }
-
-    return (
-      <View className="items-center rounded-2xl bg-surface p-8">
-        <View className="mb-4 h-16 w-16 items-center justify-center rounded-2xl bg-primary">
-          <Text className="text-[11px] font-bold text-black">A2A</Text>
-        </View>
-        <Text className="text-base font-bold text-white">
-          No more shared agents available
-        </Text>
-        <Text className="mt-2 text-center text-sm text-slate-400">
-          Shared agents published by admins will appear here alongside the
-          built-in assistant.
-        </Text>
-      </View>
-    );
-  }, [sharedQuery.items.length, sharedQuery.loading]);
+    ),
+    [batchHealthMutation, counts, orderedAgents.length],
+  );
 
   return (
     <ScreenContainer className="flex-1 bg-background px-5 sm:px-6">
       <PageHeader
         title="Agents"
-        subtitle="Manage your connected A2A services."
+        subtitle="Browse and manage all available agents in one place."
         rightElement={
           <View className="flex-row gap-2">
             <AccountEntryButton />
@@ -581,17 +388,6 @@ export function AgentListScreen() {
                 }}
               />
             ) : null}
-            <Button
-              label={activeViewButtonLabel}
-              size="sm"
-              variant="secondary"
-              iconLeft={activeViewButtonIcon}
-              accessibilityLabel={`Switch to ${
-                isPersonalView ? "shared" : "my"
-              } agents`}
-              accessibilityHint={`Currently showing ${activeViewButtonLabel.toLowerCase()} agents`}
-              onPress={toggleActiveView}
-            />
             <IconButton
               accessibilityLabel="Add agent"
               icon="add"
@@ -605,47 +401,49 @@ export function AgentListScreen() {
         }
       />
 
-      {isPersonalView ? (
-        <FlatList
-          data={personalQuery.items}
-          renderItem={renderPersonalAgentItem}
-          keyExtractor={(item) => item.id}
-          style={{ marginTop: PAGE_HEADER_CONTENT_GAP }}
-          contentContainerStyle={{ paddingBottom: 18 }}
-          refreshControl={
-            <RefreshControl
-              refreshing={personalQuery.refreshing}
-              onRefresh={onRefresh}
-              tintColor="#FFFFFF"
-              colors={["#FFFFFF"]}
-            />
-          }
-          ListHeaderComponent={renderHeader}
-          ListEmptyComponent={renderPersonalEmptyState}
-          ListFooterComponent={renderFooter}
-          onEndReached={onEndReached}
-          onEndReachedThreshold={0.5}
-        />
+      {isLoading && orderedAgents.length === 0 ? (
+        <View className="mt-8 items-center">
+          <Text className="text-sm text-gray-400">Loading agents...</Text>
+        </View>
+      ) : error ? (
+        <View className="mt-8 rounded-2xl bg-surface p-6">
+          <Text className="text-base font-bold text-white">Load failed</Text>
+          <Text className="mt-2 text-sm text-gray-400">
+            {error instanceof Error ? error.message : "Could not load agents."}
+          </Text>
+        </View>
       ) : (
         <FlatList
-          data={sharedListData}
-          renderItem={renderSharedAgentItem}
-          keyExtractor={(item) => item.id}
+          data={orderedAgents}
+          renderItem={renderAgentItem}
+          keyExtractor={(item) => `${item.source}:${item.id}`}
           style={{ marginTop: PAGE_HEADER_CONTENT_GAP }}
           contentContainerStyle={{ paddingBottom: 18 }}
           refreshControl={
             <RefreshControl
-              refreshing={sharedQuery.refreshing}
-              onRefresh={onRefresh}
+              refreshing={isRefetching}
+              onRefresh={() => {
+                refetch().catch(() => undefined);
+              }}
               tintColor="#FFFFFF"
               colors={["#FFFFFF"]}
             />
           }
           ListHeaderComponent={renderHeader}
-          ListEmptyComponent={renderSharedEmptyState}
-          ListFooterComponent={renderFooter}
-          onEndReached={onEndReached}
-          onEndReachedThreshold={0.5}
+          ListEmptyComponent={
+            <View className="items-center rounded-2xl bg-surface p-8">
+              <View className="mb-4 h-16 w-16 items-center justify-center rounded-2xl bg-primary">
+                <Text className="text-[11px] font-bold text-black">A2A</Text>
+              </View>
+              <Text className="text-base font-bold text-white">
+                No agents available
+              </Text>
+              <Text className="mt-2 text-center text-sm text-slate-400">
+                Add your first personal agent or wait for shared agents to be
+                published.
+              </Text>
+            </View>
+          }
         />
       )}
     </ScreenContainer>

--- a/frontend/screens/ChatScreen.tsx
+++ b/frontend/screens/ChatScreen.tsx
@@ -147,7 +147,9 @@ export function ChatScreen({
             visible
             onClose={controller.closeModelPicker}
             agentId={controller.activeAgentId}
-            source={controller.agent.source}
+            source={
+              controller.agent.source === "shared" ? "shared" : "personal"
+            }
             providerDiscoveryStatus={controller.providerDiscoveryStatus}
             workingDirectory={controller.workingDirectory}
             selectedModel={controller.selectedModel}

--- a/frontend/screens/__tests__/AccountSecurityScreen.test.tsx
+++ b/frontend/screens/__tests__/AccountSecurityScreen.test.tsx
@@ -161,9 +161,9 @@ describe("AccountSecurityScreen", () => {
     await pressButtonByText("Change Password");
 
     expect(mockChangePasswordMutateAsync).toHaveBeenCalledWith({
-      current_password: "OldPass!23", // pragma: allowlist secret
-      new_password: "NewPass!23", // pragma: allowlist secret
-      new_password_confirm: "NewPass!23", // pragma: allowlist secret
+      current_password: "OldPass!23",
+      new_password: "NewPass!23",
+      new_password_confirm: "NewPass!23",
     });
     expect(mockToastSuccess).toHaveBeenCalledWith(
       "Password updated",

--- a/frontend/screens/__tests__/AgentFormScreen.allowlist.test.tsx
+++ b/frontend/screens/__tests__/AgentFormScreen.allowlist.test.tsx
@@ -2,6 +2,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 import type { ReactElement } from "react";
 
+import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { AgentFormScreen } from "@/screens/AgentFormScreen";
 import { useSessionStore } from "@/store/session";
 import { createTestQueryClient } from "@/test-utils/queryClient";
@@ -245,7 +246,7 @@ describe("AgentFormScreen auto allowlist create flow", () => {
       cardUrl: "https://existing.example.com/agent.json",
       authType: "none",
       bearerToken: "",
-      apiKeyHeader: "X-API-Key", // pragma: allowlist secret
+      apiKeyHeader: DEFAULT_API_KEY_HEADER,
       apiKeyValue: "",
       basicUsername: "",
       basicPassword: "",

--- a/frontend/screens/__tests__/AgentFormScreen.allowlist.test.tsx
+++ b/frontend/screens/__tests__/AgentFormScreen.allowlist.test.tsx
@@ -28,14 +28,9 @@ jest.mock("expo-router", () => ({
   useRouter: () => mockRouter,
 }));
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 jest.mock("@/hooks/useAgentsCatalogQuery", () => ({
   useAgentsCatalogQuery: () => ({

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -1,93 +1,84 @@
+import type { ReactNode } from "react";
 import { Text } from "react-native";
-import { act, create } from "react-test-renderer";
+import { act, create, type ReactTestInstance } from "react-test-renderer";
 
 import { AgentListScreen } from "@/screens/AgentListScreen";
 
 const mockPush = jest.fn();
 const mockSetActiveAgent = jest.fn();
-const mockInvalidateQueries = jest.fn(() => Promise.resolve());
-const mockBatchMutate = jest.fn();
 const mockBlurActiveElement = jest.fn();
-const mockPersonalLoadMore = jest.fn(async () => {});
-const mockSharedLoadMore = jest.fn(async () => {});
-const mockPersonalRefresh = jest.fn(async () => {});
-const mockSharedRefresh = jest.fn(async () => {});
-const mockPersonalQueryCalls: {
-  healthBucket: string;
-  enabled?: boolean;
-}[] = [];
-const mockSharedQueryCalls: { enabled?: boolean }[] = [];
+const mockBatchMutate = jest.fn();
+const mockSetQueryData = jest.fn();
+const mockInvalidateQueries = jest.fn(() => Promise.resolve());
 
 let mockButtons: Record<string, unknown>[] = [];
 let mockFlatLists: Record<string, unknown>[] = [];
-let mockPersonalHasMore = true;
-let mockPersonalLoadingMore = false;
-let mockSharedHasMore = true;
-let mockSharedLoadingMore = false;
-let mockBuiltInAgentProfile: {
-  id: string;
-  name: string;
-  description: string;
-  runtime: string;
-  configured: boolean;
-  resources: string[];
-  tools: {
-    operation_id: string;
-    tool_name: string;
-    description: string;
-    confirmation_policy: string;
-  }[];
-} | null = {
-  id: "self-management-assistant",
-  name: "A2A Client Hub Assistant",
-  description: "Built-in self-management assistant",
-  runtime: "swival",
-  configured: true,
-  resources: ["agents", "jobs", "sessions"],
-  tools: [],
-};
-
-let mockPersonalCounts = {
-  healthy: 1,
-  degraded: 1,
-  unavailable: 1,
-  unknown: 1,
-};
-
-const buildPersonalAgent = (
-  healthStatus: "healthy" | "degraded" | "unavailable" | "unknown",
-) => ({
-  id: `personal-${healthStatus}-1`,
-  name: `${healthStatus[0].toUpperCase()}${healthStatus.slice(1)} Agent`,
-  card_url: `https://example.com/${healthStatus}.json`,
-  auth_type: "none",
-  enabled: true,
-  health_status: healthStatus,
-  consecutive_health_check_failures: healthStatus === "healthy" ? 0 : 1,
-  last_health_check_at: "2026-03-25T10:00:00.000Z",
-  last_successful_health_check_at:
-    healthStatus === "healthy" ? "2026-03-25T10:00:00.000Z" : null,
-  last_health_check_error:
-    healthStatus === "healthy" ? null : "Connection failed",
-  tags: [],
-  extra_headers: {},
-  invoke_metadata_defaults: {},
-  created_at: "2026-03-25T09:00:00.000Z",
-  updated_at: "2026-03-25T09:00:00.000Z",
-});
+let mockAgents = [
+  {
+    id: "personal-1",
+    source: "personal" as const,
+    name: "Personal Agent",
+    cardUrl: "https://example.com/personal.json",
+    authType: "none" as const,
+    bearerToken: "",
+    apiKeyHeader: "X-API-Key",
+    apiKeyValue: "",
+    basicUsername: "",
+    basicPassword: "",
+    extraHeaders: [],
+    invokeMetadataDefaults: [],
+    status: "idle" as const,
+    enabled: true,
+    healthStatus: "healthy" as const,
+    lastHealthCheckAt: "2026-04-13T12:00:00.000Z",
+  },
+  {
+    id: "self-management-assistant",
+    source: "builtin" as const,
+    name: "A2A Client Hub Assistant",
+    cardUrl: "builtin://self-management-assistant",
+    authType: "none" as const,
+    bearerToken: "",
+    apiKeyHeader: "X-API-Key",
+    apiKeyValue: "",
+    basicUsername: "",
+    basicPassword: "",
+    extraHeaders: [],
+    invokeMetadataDefaults: [],
+    status: "idle" as const,
+    enabled: true,
+    healthStatus: "healthy" as const,
+    description: "Built-in self-management assistant",
+    resources: ["agents", "sessions"],
+  },
+  {
+    id: "shared-1",
+    source: "shared" as const,
+    name: "Shared Agent",
+    cardUrl: "https://example.com/shared.json",
+    authType: "bearer" as const,
+    bearerToken: "",
+    apiKeyHeader: "X-API-Key",
+    apiKeyValue: "",
+    basicUsername: "",
+    basicPassword: "",
+    extraHeaders: [],
+    invokeMetadataDefaults: [],
+    status: "idle" as const,
+    enabled: true,
+    healthStatus: "unknown" as const,
+    credentialMode: "user" as const,
+    credentialConfigured: false,
+  },
+];
 
 jest.mock("@tanstack/react-query", () => ({
-  useQuery: ({ enabled }: { enabled?: boolean }) => ({
-    data: enabled === false ? undefined : mockBuiltInAgentProfile,
-    isLoading: false,
-    isFetched: true,
-    error: null,
-  }),
   useMutation: () => ({
     isPending: false,
     mutate: mockBatchMutate,
   }),
   useQueryClient: () => ({
+    setQueryData: mockSetQueryData,
     invalidateQueries: mockInvalidateQueries,
   }),
 }));
@@ -107,24 +98,13 @@ jest.mock("react-native", () => {
     renderItem,
     ListHeaderComponent,
     ListEmptyComponent,
-    ListFooterComponent,
     ...props
   }: any) => {
-    mockFlatLists.push({
-      data,
-      renderItem,
-      ListHeaderComponent,
-      ListEmptyComponent,
-      ListFooterComponent,
-      ...props,
-    });
-
+    mockFlatLists.push({ data, renderItem, ListHeaderComponent, ...props });
     const children: any[] = [];
-
     if (ListHeaderComponent) {
       children.push(ListHeaderComponent);
     }
-
     if (data?.length) {
       data.forEach((item: any, index: number) => {
         const element = renderItem?.({ item, index });
@@ -135,11 +115,6 @@ jest.mock("react-native", () => {
     } else if (ListEmptyComponent) {
       children.push(ListEmptyComponent);
     }
-
-    if (ListFooterComponent) {
-      children.push(ListFooterComponent);
-    }
-
     return React.createElement(React.Fragment, null, ...children);
   };
 
@@ -158,79 +133,38 @@ jest.mock("react-native", () => {
   });
 });
 
-jest.mock("@/hooks/useAgentListQueries", () => ({
-  usePersonalAgentsListQuery: ({
-    healthBucket,
-    enabled,
-  }: {
-    healthBucket: string;
-    enabled?: boolean;
-  }) => {
-    mockPersonalQueryCalls.push({ healthBucket, enabled });
-
-    return {
-      items:
-        healthBucket === "healthy" ||
-        healthBucket === "degraded" ||
-        healthBucket === "unavailable" ||
-        healthBucket === "unknown"
-          ? [buildPersonalAgent(healthBucket)]
-          : [],
-      counts: mockPersonalCounts,
-      pages: [],
-      error: null,
-      isError: false,
-      nextPage: 2,
-      hasMore: mockPersonalHasMore,
-      loading: false,
-      refreshing: false,
-      loadingMore: mockPersonalLoadingMore,
-      setItems: jest.fn(),
-      reset: jest.fn(),
-      loadFirstPage: jest.fn(async () => true),
-      refresh: mockPersonalRefresh,
-      loadMore: mockPersonalLoadMore,
-    };
-  },
-  useSharedAgentsListQuery: ({ enabled }: { enabled?: boolean }) => {
-    mockSharedQueryCalls.push({ enabled });
-
-    return {
-      items: [
-        {
-          id: "shared-1",
-          name: "Shared Agent 1",
-          card_url: "https://example.com/shared-1.json",
-          auth_type: "none",
-          credential_mode: "shared",
-          credential_configured: true,
-          credential_display_hint: null,
-          tags: [],
-        },
-      ],
-      pages: [],
-      error: null,
-      isError: false,
-      nextPage: 2,
-      hasMore: mockSharedHasMore,
-      loading: false,
-      refreshing: false,
-      loadingMore: mockSharedLoadingMore,
-      setItems: jest.fn(),
-      reset: jest.fn(),
-      loadFirstPage: jest.fn(async () => true),
-      refresh: mockSharedRefresh,
-      loadMore: mockSharedLoadMore,
-    };
-  },
+jest.mock("@/hooks/useAgentsCatalogQuery", () => ({
+  useAgentsCatalogQuery: () => ({
+    data: mockAgents,
+    isLoading: false,
+    isRefetching: false,
+    refetch: jest.fn(async () => undefined),
+    error: null,
+  }),
 }));
 
-jest.mock("@/lib/api/a2aAgents", () => ({
-  checkAgentsHealth: jest.fn(),
+jest.mock("@/lib/api/agentsCatalog", () => ({
+  checkAgentsCatalogHealth: jest.fn(),
 }));
 
 jest.mock("@/lib/focus", () => ({
   blurActiveElement: () => mockBlurActiveElement(),
+}));
+
+jest.mock("@/components/ui/Button", () => ({
+  Button: (props: Record<string, unknown>) => {
+    const { Text: MockText } = jest.requireActual("react-native");
+    mockButtons.push(props);
+    return <MockText>{String(props.label ?? "")}</MockText>;
+  },
+}));
+
+jest.mock("@/components/ui/IconButton", () => ({
+  IconButton: () => null,
+}));
+
+jest.mock("@/components/layout/ScreenContainer", () => ({
+  ScreenContainer: ({ children }: { children: ReactNode }) => children,
 }));
 
 jest.mock("@/store/agents", () => ({
@@ -240,419 +174,84 @@ jest.mock("@/store/agents", () => ({
 }));
 
 jest.mock("@/store/chat", () => ({
-  useChatStore: Object.assign(() => null, {
+  useChatStore: {
     getState: () => ({
-      getLatestConversationIdByAgentId: () => null,
-      generateConversationId: () => "conv-generated-1",
+      getLatestConversationIdByAgentId: () => undefined,
+      generateConversationId: () => "conv-1",
     }),
-  }),
+  },
 }));
 
 jest.mock("@/store/session", () => ({
   useSessionStore: (
     selector: (state: { user: { is_superuser: boolean } }) => unknown,
-  ) => selector({ user: { is_superuser: true } }),
-}));
-
-jest.mock("@/components/layout/ScreenContainer", () => ({
-  ScreenContainer: ({ children }: { children: React.ReactNode }) => children,
-}));
-
-jest.mock("@/components/ui/PageHeader", () => ({
-  PageHeader: ({ rightElement }: { rightElement?: React.ReactNode }) =>
-    rightElement ?? null,
-}));
-
-jest.mock("@/components/ui/IconButton", () => ({
-  IconButton: () => null,
-}));
-
-jest.mock("@/components/ui/Button", () => ({
-  Button: (props: Record<string, unknown>) => {
-    mockButtons.push(props);
-    return null;
-  },
+  ) => selector({ user: { is_superuser: false } }),
 }));
 
 describe("AgentListScreen", () => {
   beforeEach(() => {
     mockButtons = [];
     mockFlatLists = [];
-    mockPersonalQueryCalls.length = 0;
-    mockSharedQueryCalls.length = 0;
-    mockPersonalHasMore = true;
-    mockPersonalLoadingMore = false;
-    mockSharedHasMore = true;
-    mockSharedLoadingMore = false;
-    mockBuiltInAgentProfile = {
-      id: "self-management-assistant",
-      name: "A2A Client Hub Assistant",
-      description: "Built-in self-management assistant",
-      runtime: "swival",
-      configured: true,
-      resources: ["agents", "jobs", "sessions"],
-      tools: [],
-    };
-    mockPersonalCounts = {
-      healthy: 1,
-      degraded: 1,
-      unavailable: 1,
-      unknown: 1,
-    };
+    mockAgents = [...mockAgents];
     jest.clearAllMocks();
   });
 
-  it("renders personal agents with continuous loading actions", async () => {
-    let tree: ReturnType<typeof create>;
-
+  it("renders personal, shared, and built-in agents in one list", async () => {
+    let tree;
     await act(async () => {
       tree = create(<AgentListScreen />);
     });
 
-    expect(mockButtons.some((button) => button.label === "My")).toBe(true);
-    expect(
-      mockButtons.some(
-        (button) => button.accessibilityLabel === "Switch to shared agents",
-      ),
-    ).toBe(true);
-    expect(mockButtons.some((button) => button.label === "1 Healthy")).toBe(
-      true,
-    );
-    expect(mockButtons.some((button) => button.label === "1 Degraded")).toBe(
-      true,
-    );
-    expect(mockButtons.some((button) => button.label === "Check")).toBe(true);
-    expect(mockButtons.some((button) => button.label === "Load more")).toBe(
-      true,
-    );
-    expect(mockButtons.some((button) => button.label === "Previous")).toBe(
-      false,
-    );
-    expect(mockButtons.some((button) => button.label === "Next")).toBe(false);
-
-    const chatButton = mockButtons.find(
-      (button) => button.label === "Chat",
-    ) as { onPress: () => void };
-    await act(async () => {
-      chatButton.onPress();
-    });
-
-    expect(mockSetActiveAgent).toHaveBeenCalledWith("personal-healthy-1");
-    expect(mockPush).toHaveBeenCalled();
-    expect(mockBlurActiveElement).toHaveBeenCalled();
-
-    const batchButton = mockButtons.find(
-      (button) => button.label === "Check",
-    ) as { onPress: () => void };
-    await act(async () => {
-      batchButton.onPress();
-    });
-
-    expect(mockBatchMutate).toHaveBeenCalled();
-
-    const loadMoreButton = mockButtons.find(
-      (button) => button.label === "Load more",
-    ) as { onPress: () => void };
-    await act(async () => {
-      await loadMoreButton.onPress();
-    });
-
-    expect(mockPersonalLoadMore).toHaveBeenCalled();
-
-    const degradedFilterButton = mockButtons.find(
-      (button) => button.label === "1 Degraded",
-    ) as { onPress: () => void };
-    mockButtons = [];
-    await act(async () => {
-      degradedFilterButton.onPress();
-      tree!.update(<AgentListScreen />);
-    });
-
-    expect(mockPersonalQueryCalls[mockPersonalQueryCalls.length - 1]).toEqual({
-      healthBucket: "degraded",
-      enabled: true,
-    });
-  });
-
-  it("shows shared cards and uses shared load more after switching tabs", async () => {
-    let tree: ReturnType<typeof create>;
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    const sourceToggleButton = mockButtons.find(
-      (button) => button.accessibilityLabel === "Switch to shared agents",
-    ) as { onPress: () => void };
-
-    mockButtons = [];
-    await act(async () => {
-      sourceToggleButton.onPress();
-      tree!.update(<AgentListScreen />);
-    });
-
-    expect(mockButtons.some((button) => button.label === "Shared")).toBe(true);
-    expect(mockButtons.some((button) => button.label === "Chat")).toBe(true);
+    expect(mockFlatLists).toHaveLength(1);
+    const labels = mockButtons.map((button) => button.label);
+    expect(labels).toContain("Check all");
+    expect(labels).toContain("Edit");
+    expect(labels).toContain("Details");
+    expect(labels.filter((label) => label === "Chat")).toHaveLength(3);
+    expect(labels).not.toContain("My");
+    expect(labels).not.toContain("Shared");
     expect(
       tree!.root
         .findAllByType(Text)
-        .flatMap((node) => node.props.children)
-        .join(" "),
-    ).toContain("BUILT-IN");
-    expect(mockButtons.some((button) => button.label === "Details")).toBe(true);
-    expect(mockButtons.some((button) => button.label === "Check")).toBe(false);
-    expect(mockButtons.some((button) => button.label === "Load more")).toBe(
-      true,
-    );
-    expect(mockSharedQueryCalls[mockSharedQueryCalls.length - 1]).toEqual({
-      enabled: true,
-    });
-
-    const loadMoreButton = mockButtons.find(
-      (button) => button.label === "Load more",
-    ) as { onPress: () => void };
-    await act(async () => {
-      await loadMoreButton.onPress();
-    });
-
-    expect(mockSharedLoadMore).toHaveBeenCalled();
+        .some((node: ReactTestInstance) => node.props.children === "BUILT-IN"),
+    ).toBe(true);
   });
 
-  it("opens chat for the built-in assistant from the shared tab", async () => {
-    let tree: ReturnType<typeof create>;
-
+  it("triggers a unified health check from the header action", async () => {
     await act(async () => {
-      tree = create(<AgentListScreen />);
+      create(<AgentListScreen />);
     });
 
-    const sourceToggleButton = mockButtons.find(
-      (button) => button.accessibilityLabel === "Switch to shared agents",
-    ) as { onPress: () => void };
+    const checkButton = mockButtons.find(
+      (button) => button.label === "Check all",
+    );
+    expect(checkButton).toBeDefined();
 
-    mockButtons = [];
     await act(async () => {
-      sourceToggleButton.onPress();
-      tree!.update(<AgentListScreen />);
+      (checkButton?.onPress as (() => void) | undefined)?.();
     });
 
-    const builtInChatButton = mockButtons.find(
-      (button) => button.accessibilityLabel === "Open built-in assistant",
-    ) as { onPress: () => void };
+    expect(mockBatchMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens chat for the built-in agent from the unified list", async () => {
+    await act(async () => {
+      create(<AgentListScreen />);
+    });
+
+    const chatButtons = mockButtons.filter(
+      (button) =>
+        button.label === "Chat" &&
+        button.accessibilityHint === "Open chat with A2A Client Hub Assistant",
+    );
 
     await act(async () => {
-      builtInChatButton.onPress();
+      (chatButtons[0]?.onPress as (() => void) | undefined)?.();
     });
 
     expect(mockSetActiveAgent).toHaveBeenCalledWith(
       "self-management-assistant",
     );
     expect(mockPush).toHaveBeenCalled();
-  });
-
-  it("loads more from onEndReached only when the active list can paginate", async () => {
-    let tree: ReturnType<typeof create>;
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    const personalList = mockFlatLists.at(-1) as {
-      onEndReached: () => void;
-    };
-    await act(async () => {
-      personalList.onEndReached();
-    });
-
-    expect(mockPersonalLoadMore).toHaveBeenCalledTimes(1);
-
-    const sourceToggleButton = mockButtons.find(
-      (button) => button.accessibilityLabel === "Switch to shared agents",
-    ) as { onPress: () => void };
-
-    mockButtons = [];
-    mockFlatLists = [];
-    await act(async () => {
-      sourceToggleButton.onPress();
-      tree!.update(<AgentListScreen />);
-    });
-
-    const sharedList = mockFlatLists.at(-1) as {
-      onEndReached: () => void;
-    };
-    await act(async () => {
-      sharedList.onEndReached();
-    });
-
-    expect(mockSharedLoadMore).toHaveBeenCalledTimes(1);
-
-    mockSharedHasMore = false;
-    mockFlatLists = [];
-    await act(async () => {
-      tree!.update(<AgentListScreen />);
-    });
-
-    const nonPaginatedSharedList = mockFlatLists.at(-1) as {
-      onEndReached: () => void;
-    };
-    await act(async () => {
-      nonPaginatedSharedList.onEndReached();
-    });
-
-    expect(mockSharedLoadMore).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not load more when the active list is already fetching the next page", async () => {
-    mockPersonalLoadingMore = true;
-
-    let tree: ReturnType<typeof create>;
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    const personalList = mockFlatLists.at(-1) as {
-      onEndReached: () => void;
-    };
-    await act(async () => {
-      personalList.onEndReached();
-    });
-
-    expect(mockPersonalLoadMore).not.toHaveBeenCalled();
-
-    mockPersonalLoadingMore = false;
-    mockButtons = [];
-    mockFlatLists = [];
-    await act(async () => {
-      tree!.update(<AgentListScreen />);
-    });
-
-    const refreshedPersonalList = mockFlatLists.at(-1) as {
-      onEndReached: () => void;
-    };
-    await act(async () => {
-      refreshedPersonalList.onEndReached();
-    });
-
-    expect(mockPersonalLoadMore).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps personal cards visually minimal by hiding personal markers", async () => {
-    let tree: ReturnType<typeof create>;
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    const textContent = tree!.root
-      .findAllByType(Text)
-      .flatMap((node) => node.props.children)
-      .join(" ");
-
-    expect(textContent).not.toContain("PERSONAL");
-    expect(textContent).not.toContain("Enabled");
-    expect(textContent).not.toContain("Checked");
-    expect(textContent).not.toContain("SHARED");
-  });
-
-  it("shows shared cards only after switching to the shared tab", async () => {
-    let tree: ReturnType<typeof create>;
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    let textContent = tree!.root
-      .findAllByType(Text)
-      .flatMap((node) => node.props.children)
-      .join(" ");
-
-    expect(textContent).not.toContain("SHARED");
-
-    const sourceToggleButton = mockButtons.find(
-      (button) => button.accessibilityLabel === "Switch to shared agents",
-    ) as { onPress: () => void };
-
-    mockButtons = [];
-    await act(async () => {
-      sourceToggleButton.onPress();
-      tree!.update(<AgentListScreen />);
-    });
-
-    textContent = tree!.root
-      .findAllByType(Text)
-      .flatMap((node) => node.props.children)
-      .join(" ");
-
-    expect(textContent).toContain("SHARED");
-  });
-
-  it("formats personal checked timestamps as YYYY-MM-DD HH:mm", async () => {
-    let tree: ReturnType<typeof create>;
-
-    jest
-      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
-      .mockReturnValue({
-        timeZone: "UTC",
-      } as Intl.ResolvedDateTimeFormatOptions);
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    const degradedFilterButton = mockButtons.find(
-      (button) => button.label === "1 Degraded",
-    ) as { onPress: () => void };
-
-    mockButtons = [];
-    await act(async () => {
-      degradedFilterButton.onPress();
-      tree!.update(<AgentListScreen />);
-    });
-
-    const textContent = tree!.root
-      .findAllByType(Text)
-      .flatMap((node) => node.props.children)
-      .join(" ");
-
-    expect(textContent).toContain("Checked 2026-03-25 10:00");
-    expect(textContent).not.toContain("AM");
-    expect(textContent).not.toContain("PM");
-  });
-
-  it("hides zero-count health filters and falls back to the first visible status", async () => {
-    let tree: ReturnType<typeof create>;
-
-    mockPersonalCounts = {
-      healthy: 0,
-      degraded: 2,
-      unavailable: 1,
-      unknown: 0,
-    };
-
-    await act(async () => {
-      tree = create(<AgentListScreen />);
-    });
-
-    expect(mockButtons.some((button) => button.label === "0 Healthy")).toBe(
-      false,
-    );
-    expect(mockButtons.some((button) => button.label === "0 Unknown")).toBe(
-      false,
-    );
-    expect(mockButtons.some((button) => button.label === "2 Degraded")).toBe(
-      true,
-    );
-    expect(mockButtons.some((button) => button.label === "1 Unavailable")).toBe(
-      true,
-    );
-
-    await act(async () => {
-      tree!.update(<AgentListScreen />);
-    });
-
-    expect(mockPersonalQueryCalls[mockPersonalQueryCalls.length - 1]).toEqual({
-      healthBucket: "degraded",
-      enabled: true,
-    });
   });
 });

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Text } from "react-native";
 import { act, create, type ReactTestInstance } from "react-test-renderer";
 
+import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { AgentListScreen } from "@/screens/AgentListScreen";
 
 const mockPush = jest.fn();
@@ -21,7 +22,7 @@ let mockAgents = [
     cardUrl: "https://example.com/personal.json",
     authType: "none" as const,
     bearerToken: "",
-    apiKeyHeader: "X-API-Key", // pragma: allowlist secret
+    apiKeyHeader: DEFAULT_API_KEY_HEADER,
     apiKeyValue: "",
     basicUsername: "",
     basicPassword: "",
@@ -39,7 +40,7 @@ let mockAgents = [
     cardUrl: "builtin://self-management-assistant",
     authType: "none" as const,
     bearerToken: "",
-    apiKeyHeader: "X-API-Key", // pragma: allowlist secret
+    apiKeyHeader: DEFAULT_API_KEY_HEADER,
     apiKeyValue: "",
     basicUsername: "",
     basicPassword: "",
@@ -58,7 +59,7 @@ let mockAgents = [
     cardUrl: "https://example.com/shared.json",
     authType: "bearer" as const,
     bearerToken: "",
-    apiKeyHeader: "X-API-Key", // pragma: allowlist secret
+    apiKeyHeader: DEFAULT_API_KEY_HEADER,
     apiKeyValue: "",
     basicUsername: "",
     basicPassword: "",

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -3,7 +3,7 @@ import { Text } from "react-native";
 import { act, create, type ReactTestInstance } from "react-test-renderer";
 
 import { AgentListScreen } from "@/screens/AgentListScreen";
-import { createMockAgentConfig } from "@/test-utils/agentFixtures";
+import { createMockAgentCatalog } from "@/test-utils/agentFixtures";
 
 const mockPush = jest.fn();
 const mockSetActiveAgent = jest.fn();
@@ -14,41 +14,43 @@ const mockInvalidateQueries = jest.fn(() => Promise.resolve());
 
 let mockButtons: Record<string, unknown>[] = [];
 let mockFlatLists: Record<string, unknown>[] = [];
-let mockAgents = [
-  createMockAgentConfig({
-    id: "personal-1",
-    source: "personal" as const,
-    name: "Personal Agent",
-    cardUrl: "https://example.com/personal.json",
-    status: "idle" as const,
-    enabled: true,
-    healthStatus: "healthy" as const,
-    lastHealthCheckAt: "2026-04-13T12:00:00.000Z",
-  }),
-  createMockAgentConfig({
-    id: "self-management-assistant",
-    source: "builtin" as const,
-    name: "A2A Client Hub Assistant",
-    cardUrl: "builtin://self-management-assistant",
-    status: "idle" as const,
-    enabled: true,
-    healthStatus: "healthy" as const,
-    description: "Built-in self-management assistant",
-    resources: ["agents", "sessions"],
-  }),
-  createMockAgentConfig({
-    id: "shared-1",
-    source: "shared" as const,
-    name: "Shared Agent",
-    cardUrl: "https://example.com/shared.json",
-    authType: "bearer" as const,
-    status: "idle" as const,
-    enabled: true,
-    healthStatus: "unknown" as const,
-    credentialMode: "user" as const,
-    credentialConfigured: false,
-  }),
-];
+const buildMockAgents = () =>
+  createMockAgentCatalog(
+    {
+      id: "personal-1",
+      source: "personal" as const,
+      name: "Personal Agent",
+      cardUrl: "https://example.com/personal.json",
+      status: "idle" as const,
+      enabled: true,
+      healthStatus: "healthy" as const,
+      lastHealthCheckAt: "2026-04-13T12:00:00.000Z",
+    },
+    {
+      id: "self-management-assistant",
+      source: "builtin" as const,
+      name: "A2A Client Hub Assistant",
+      cardUrl: "builtin://self-management-assistant",
+      status: "idle" as const,
+      enabled: true,
+      healthStatus: "healthy" as const,
+      description: "Built-in self-management assistant",
+      resources: ["agents", "sessions"],
+    },
+    {
+      id: "shared-1",
+      source: "shared" as const,
+      name: "Shared Agent",
+      cardUrl: "https://example.com/shared.json",
+      authType: "bearer" as const,
+      status: "idle" as const,
+      enabled: true,
+      healthStatus: "unknown" as const,
+      credentialMode: "user" as const,
+      credentialConfigured: false,
+    },
+  );
+let mockAgents = buildMockAgents();
 
 jest.mock("@tanstack/react-query", () => ({
   useMutation: () => ({
@@ -170,7 +172,7 @@ describe("AgentListScreen", () => {
   beforeEach(() => {
     mockButtons = [];
     mockFlatLists = [];
-    mockAgents = [...mockAgents];
+    mockAgents = buildMockAgents();
     jest.clearAllMocks();
   });
 

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 import { Text } from "react-native";
 import { act, create, type ReactTestInstance } from "react-test-renderer";
 
-import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
 import { AgentListScreen } from "@/screens/AgentListScreen";
+import { createMockAgentConfig } from "@/test-utils/agentFixtures";
 
 const mockPush = jest.fn();
 const mockSetActiveAgent = jest.fn();
@@ -15,62 +15,39 @@ const mockInvalidateQueries = jest.fn(() => Promise.resolve());
 let mockButtons: Record<string, unknown>[] = [];
 let mockFlatLists: Record<string, unknown>[] = [];
 let mockAgents = [
-  {
+  createMockAgentConfig({
     id: "personal-1",
     source: "personal" as const,
     name: "Personal Agent",
     cardUrl: "https://example.com/personal.json",
-    authType: "none" as const,
-    bearerToken: "",
-    apiKeyHeader: DEFAULT_API_KEY_HEADER,
-    apiKeyValue: "",
-    basicUsername: "",
-    basicPassword: "",
-    extraHeaders: [],
-    invokeMetadataDefaults: [],
     status: "idle" as const,
     enabled: true,
     healthStatus: "healthy" as const,
     lastHealthCheckAt: "2026-04-13T12:00:00.000Z",
-  },
-  {
+  }),
+  createMockAgentConfig({
     id: "self-management-assistant",
     source: "builtin" as const,
     name: "A2A Client Hub Assistant",
     cardUrl: "builtin://self-management-assistant",
-    authType: "none" as const,
-    bearerToken: "",
-    apiKeyHeader: DEFAULT_API_KEY_HEADER,
-    apiKeyValue: "",
-    basicUsername: "",
-    basicPassword: "",
-    extraHeaders: [],
-    invokeMetadataDefaults: [],
     status: "idle" as const,
     enabled: true,
     healthStatus: "healthy" as const,
     description: "Built-in self-management assistant",
     resources: ["agents", "sessions"],
-  },
-  {
+  }),
+  createMockAgentConfig({
     id: "shared-1",
     source: "shared" as const,
     name: "Shared Agent",
     cardUrl: "https://example.com/shared.json",
     authType: "bearer" as const,
-    bearerToken: "",
-    apiKeyHeader: DEFAULT_API_KEY_HEADER,
-    apiKeyValue: "",
-    basicUsername: "",
-    basicPassword: "",
-    extraHeaders: [],
-    invokeMetadataDefaults: [],
     status: "idle" as const,
     enabled: true,
     healthStatus: "unknown" as const,
     credentialMode: "user" as const,
     credentialConfigured: false,
-  },
+  }),
 ];
 
 jest.mock("@tanstack/react-query", () => ({

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -21,7 +21,7 @@ let mockAgents = [
     cardUrl: "https://example.com/personal.json",
     authType: "none" as const,
     bearerToken: "",
-    apiKeyHeader: "X-API-Key",
+    apiKeyHeader: "X-API-Key", // pragma: allowlist secret
     apiKeyValue: "",
     basicUsername: "",
     basicPassword: "",
@@ -39,7 +39,7 @@ let mockAgents = [
     cardUrl: "builtin://self-management-assistant",
     authType: "none" as const,
     bearerToken: "",
-    apiKeyHeader: "X-API-Key",
+    apiKeyHeader: "X-API-Key", // pragma: allowlist secret
     apiKeyValue: "",
     basicUsername: "",
     basicPassword: "",
@@ -58,7 +58,7 @@ let mockAgents = [
     cardUrl: "https://example.com/shared.json",
     authType: "bearer" as const,
     bearerToken: "",
-    apiKeyHeader: "X-API-Key",
+    apiKeyHeader: "X-API-Key", // pragma: allowlist secret
     apiKeyValue: "",
     basicUsername: "",
     basicPassword: "",

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -8,7 +8,7 @@ const mockPush = jest.fn();
 const mockSetActiveAgent = jest.fn();
 const mockBlurActiveElement = jest.fn();
 const mockBatchMutate = jest.fn();
-const mockSetQueryData = jest.fn();
+const mockRefetchQueries = jest.fn(() => Promise.resolve());
 const mockInvalidateQueries = jest.fn(() => Promise.resolve());
 
 let mockButtons: Record<string, unknown>[] = [];
@@ -78,7 +78,7 @@ jest.mock("@tanstack/react-query", () => ({
     mutate: mockBatchMutate,
   }),
   useQueryClient: () => ({
-    setQueryData: mockSetQueryData,
+    refetchQueries: mockRefetchQueries,
     invalidateQueries: mockInvalidateQueries,
   }),
 }));

--- a/frontend/screens/__tests__/ScheduledJobFormScreen.test.tsx
+++ b/frontend/screens/__tests__/ScheduledJobFormScreen.test.tsx
@@ -2,7 +2,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 
 import { ScheduledJobFormScreen } from "@/screens/ScheduledJobFormScreen";
 import { useSessionStore } from "@/store/session";
-import { createMockAgentConfig } from "@/test-utils/agentFixtures";
+import { createMockAgentCatalog } from "@/test-utils/agentFixtures";
 
 const mockCreateScheduledJob = jest.fn();
 const mockGetScheduledJob = jest.fn();
@@ -13,15 +13,15 @@ const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
 const mockBackOrHome = jest.fn();
 const mockBlurActiveElement = jest.fn();
-const mockAgents = [
-  createMockAgentConfig({
+const buildMockAgents = () =>
+  createMockAgentCatalog({
     id: "agent-1",
     source: "personal",
     name: "Agent One",
     cardUrl: "https://example.com/card",
     status: "success",
-  }),
-];
+  });
+const mockAgents = buildMockAgents();
 
 let capturedSubmit: (() => void) | null = null;
 let capturedChange: ((patch: unknown) => void) | null = null;
@@ -180,17 +180,7 @@ describe("ScheduledJobFormScreen", () => {
     capturedAgentOptions = [];
     capturedTimeZone = undefined;
     renderedScreen = null;
-    mockAgents.splice(
-      0,
-      mockAgents.length,
-      createMockAgentConfig({
-        id: "agent-1",
-        source: "personal",
-        name: "Agent One",
-        cardUrl: "https://example.com/card",
-        status: "success",
-      }),
-    );
+    mockAgents.splice(0, mockAgents.length, ...buildMockAgents());
     act(() => {
       useSessionStore.setState({ user: null });
     });
@@ -523,20 +513,22 @@ describe("ScheduledJobFormScreen", () => {
     mockAgents.splice(
       0,
       mockAgents.length,
-      createMockAgentConfig({
-        id: "agent-personal",
-        source: "personal",
-        name: "Personal Agent",
-        cardUrl: "https://example.com/card-personal",
-        status: "success",
-      }),
-      createMockAgentConfig({
-        id: "agent-shared",
-        source: "shared",
-        name: "Shared Agent",
-        cardUrl: "https://example.com/card-shared",
-        status: "success",
-      }),
+      ...createMockAgentCatalog(
+        {
+          id: "agent-personal",
+          source: "personal",
+          name: "Personal Agent",
+          cardUrl: "https://example.com/card-personal",
+          status: "success",
+        },
+        {
+          id: "agent-shared",
+          source: "shared",
+          name: "Shared Agent",
+          cardUrl: "https://example.com/card-shared",
+          status: "success",
+        },
+      ),
     );
 
     await act(async () => {

--- a/frontend/screens/__tests__/ScheduledJobFormScreen.test.tsx
+++ b/frontend/screens/__tests__/ScheduledJobFormScreen.test.tsx
@@ -2,6 +2,7 @@ import { act, create, type ReactTestRenderer } from "react-test-renderer";
 
 import { ScheduledJobFormScreen } from "@/screens/ScheduledJobFormScreen";
 import { useSessionStore } from "@/store/session";
+import { createMockAgentConfig } from "@/test-utils/agentFixtures";
 
 const mockCreateScheduledJob = jest.fn();
 const mockGetScheduledJob = jest.fn();
@@ -13,13 +14,13 @@ const mockToastError = jest.fn();
 const mockBackOrHome = jest.fn();
 const mockBlurActiveElement = jest.fn();
 const mockAgents = [
-  {
+  createMockAgentConfig({
     id: "agent-1",
     source: "personal",
     name: "Agent One",
     cardUrl: "https://example.com/card",
     status: "success",
-  },
+  }),
 ];
 
 let capturedSubmit: (() => void) | null = null;
@@ -179,13 +180,17 @@ describe("ScheduledJobFormScreen", () => {
     capturedAgentOptions = [];
     capturedTimeZone = undefined;
     renderedScreen = null;
-    mockAgents.splice(0, mockAgents.length, {
-      id: "agent-1",
-      source: "personal",
-      name: "Agent One",
-      cardUrl: "https://example.com/card",
-      status: "success",
-    });
+    mockAgents.splice(
+      0,
+      mockAgents.length,
+      createMockAgentConfig({
+        id: "agent-1",
+        source: "personal",
+        name: "Agent One",
+        cardUrl: "https://example.com/card",
+        status: "success",
+      }),
+    );
     act(() => {
       useSessionStore.setState({ user: null });
     });
@@ -518,20 +523,20 @@ describe("ScheduledJobFormScreen", () => {
     mockAgents.splice(
       0,
       mockAgents.length,
-      {
+      createMockAgentConfig({
         id: "agent-personal",
         source: "personal",
         name: "Personal Agent",
         cardUrl: "https://example.com/card-personal",
         status: "success",
-      },
-      {
+      }),
+      createMockAgentConfig({
         id: "agent-shared",
         source: "shared",
         name: "Shared Agent",
         cardUrl: "https://example.com/card-shared",
         status: "success",
-      },
+      }),
     );
 
     await act(async () => {

--- a/frontend/scripts/check-unused-exports.sh
+++ b/frontend/scripts/check-unused-exports.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+cd "${FRONTEND_DIR}"
+
+OUTPUT="$(
+  ./node_modules/.bin/ts-prune | rg -v \
+    'used in module| - default$| - ErrorBoundary$|lib/storage/mmkv.web.ts:10 - buildPersistStorageName|lib/storage/mmkv.web.ts:33 - createPersistStorage|test-utils/mockMmkv.ts:1 - createMockMmkvModule' \
+    || true
+)"
+
+if [[ -n "${OUTPUT}" ]]; then
+  printf '%s\n' "${OUTPUT}"
+  exit 1
+fi

--- a/frontend/scripts/check-unused-exports.sh
+++ b/frontend/scripts/check-unused-exports.sh
@@ -8,8 +8,9 @@ FRONTEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${FRONTEND_DIR}"
 
 OUTPUT="$(
-  ./node_modules/.bin/ts-prune | rg -v \
-    'used in module| - default$| - ErrorBoundary$|lib/storage/mmkv.web.ts:10 - buildPersistStorageName|lib/storage/mmkv.web.ts:33 - createPersistStorage|test-utils/mockMmkv.ts:1 - createMockMmkvModule' \
+  ./node_modules/.bin/ts-prune \
+    -i '^(app/|lib/storage/mmkv.web.ts|test-utils/mockMmkv.ts)' \
+    | rg -v 'used in module' \
     || true
 )"
 

--- a/frontend/store/__tests__/chatRuntime.test.ts
+++ b/frontend/store/__tests__/chatRuntime.test.ts
@@ -24,14 +24,9 @@ import {
   type ChatRuntimeState,
 } from "@/store/chatRuntime";
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 jest.mock("@/services/chatConnectionService", () => ({
   chatConnectionService: {

--- a/frontend/store/__tests__/chatStoreIdempotency.test.ts
+++ b/frontend/store/__tests__/chatStoreIdempotency.test.ts
@@ -5,14 +5,9 @@ import {
 import { useChatStore } from "@/store/chat";
 import { executeChatRuntime } from "@/store/chatRuntime";
 
-jest.mock("@/lib/storage/mmkv", () => ({
-  buildPersistStorageName: (key: string) => key,
-  createPersistStorage: () => ({
-    getItem: () => null,
-    setItem: () => {},
-    removeItem: () => {},
-  }),
-}));
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
 
 jest.mock("@/services/chatConnectionService", () => ({
   chatConnectionService: {

--- a/frontend/store/agents.ts
+++ b/frontend/store/agents.ts
@@ -12,7 +12,7 @@ type AgentStatus = "idle" | "checking" | "success" | "error";
 
 export type AgentHeader = HeaderEntryWithId;
 
-export type AgentSource = "personal" | "shared";
+export type AgentSource = "personal" | "shared" | "builtin";
 
 export type AgentConfig = {
   id: string;
@@ -30,6 +30,16 @@ export type AgentConfig = {
   status: AgentStatus;
   lastCheckedAt?: string;
   lastError?: string;
+  enabled?: boolean;
+  healthStatus?: "unknown" | "healthy" | "degraded" | "unavailable";
+  lastHealthCheckAt?: string;
+  lastHealthCheckError?: string;
+  credentialMode?: "none" | "shared" | "user";
+  credentialConfigured?: boolean;
+  credentialDisplayHint?: string;
+  description?: string;
+  runtime?: string;
+  resources?: string[];
 };
 
 type AgentState = {

--- a/frontend/store/agents.ts
+++ b/frontend/store/agents.ts
@@ -34,6 +34,13 @@ export type AgentConfig = {
   healthStatus?: "unknown" | "healthy" | "degraded" | "unavailable";
   lastHealthCheckAt?: string;
   lastHealthCheckError?: string;
+  lastHealthCheckReasonCode?:
+    | "card_validation_failed"
+    | "runtime_validation_failed"
+    | "agent_unavailable"
+    | "client_reset_required"
+    | "credential_required"
+    | "unexpected_error";
   credentialMode?: "none" | "shared" | "user";
   credentialConfigured?: boolean;
   credentialDisplayHint?: string;

--- a/frontend/test-utils/agentFixtures.ts
+++ b/frontend/test-utils/agentFixtures.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_API_KEY_HEADER } from "@/lib/agentHeaders";
+import { type AgentConfig } from "@/store/agents";
+
+export const createMockAgentConfig = (
+  overrides: Partial<AgentConfig> = {},
+): AgentConfig => ({
+  id: "agent-1",
+  source: "personal",
+  name: "Agent One",
+  cardUrl: "https://example.com/agent-1.json",
+  authType: "none",
+  bearerToken: "",
+  apiKeyHeader: DEFAULT_API_KEY_HEADER,
+  apiKeyValue: "",
+  basicUsername: "",
+  basicPassword: "",
+  extraHeaders: [],
+  invokeMetadataDefaults: [],
+  status: "idle",
+  ...overrides,
+});

--- a/frontend/test-utils/agentFixtures.ts
+++ b/frontend/test-utils/agentFixtures.ts
@@ -19,3 +19,7 @@ export const createMockAgentConfig = (
   status: "idle",
   ...overrides,
 });
+
+export const createMockAgentCatalog = (
+  ...entries: Partial<AgentConfig>[]
+): AgentConfig[] => entries.map((entry) => createMockAgentConfig(entry));

--- a/frontend/test-utils/mockMmkv.ts
+++ b/frontend/test-utils/mockMmkv.ts
@@ -1,0 +1,8 @@
+export const createMockMmkvModule = () => ({
+  buildPersistStorageName: (key: string) => key,
+  createPersistStorage: () => ({
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  }),
+});


### PR DESCRIPTION
## 背景
本 PR 以 `#782` 为主线，完成当前用户统一 agent catalog 与统一 health check 的实现，并补齐落地过程中暴露出的工程卫生问题，确保这批改动可以稳定通过 CI、稳定回归、稳定维护。

## 变更说明
### Backend
- 新增统一 catalog 路由：`/me/agents/catalog`
- 新增统一 health check 路由：`/me/agents/check-health`
- 新增 `agents_catalog` 的 `router / schemas / service`
- 聚合 current-user 可见的 `personal / shared / builtin` agents 目录读模型
- 新增 `user_agent_availability_snapshots` 持久化表，作为 `shared / builtin` 的用户视角状态快照
- `check-health` 会把 `shared / builtin` 的检查结果持久化到后端，并由 catalog 直接回读
- `shared` agent 缺少用户凭证时，统一按“当前不可用”处理，不再回落到纯前端 `unknown`
- `shared` agent catalog / health check 改为分页拉全量可见结果，避免 `size=1000` 静态上限
- 为 `personal` agents 与 `shared / builtin` snapshots 新增结构化 `reason_code` 持久化字段：
  - 持久化字段：`last_health_check_reason_code`
  - 单次检查结果字段：`reason_code`
- 当前已稳定化的 reason codes 包括：`card_validation_failed`、`runtime_validation_failed`、`agent_unavailable`、`client_reset_required`、`credential_required`、`unexpected_error`
- 保持既有 `health_status` 语义，不做大面积命名迁移

### Frontend
- 新增 `agentsCatalog` API client
- `useAgentsCatalogQuery` 改为消费统一 catalog 接口
- `AgentSource` 显式扩展为 `personal | shared | builtin`
- Agents 页面改为单列表展示，不再使用 `My / Shared` 切换
- Agents 页面新增统一 `Check all`，对 catalog 内 agents 执行统一检查
- Agents 页面不再依赖前端临时 patch health 结果，而是直接 refetch 后端持久化结果
- built-in agent 在详情页改为只读展示
- `chat / interrupt / model picker` 的 extension source 类型收窄为 `personal | shared`，避免 builtin 误入 extension 调用链路
- session agent presentation 补齐 builtin 展示语义

### Tooling / CI / Tests Hygiene
- 强化 `detect-secrets` 规则，减少测试样例与 migration revision 对 CI 的噪音影响
- 前端新增 `check-unused-exports` 门禁，并将其接入 pre-commit
- `check-unused-exports` 改为路径级 ignore，避免 Expo Router 入口、web-only storage、Jest mock 文件持续制造误报
- `vulture exploratory` 新增对 `FastMCP @mcp.tool` 的忽略，降低 exploratory 死代码扫描噪音
- `tests/auth/test_auth.py` 增加固定 trusted origin fixture，避免受本机环境变量干扰
- 抽共享 `mockMmkv` 与 agent fixture builders，减少测试装配重复

### Dead Code Cleanup
- 删除前端高置信未使用 API / type / 常量
- 删除后端高置信未使用 helper：
  - `verify_refresh_token`
  - `SelfManagementJobsService._timezone`
  - `SessionSupport.find_latest_message_by_sender`
- 当前 `bash scripts/run_vulture.sh` 与 `npm run check-unused-exports` 已通过，高置信死代码已收敛干净

### 已知约束
- built-in agent 的 health 当前仍是配置/运行时就绪度语义，不是完整 live probe
- `vulture exploratory` 仍会对 SQLAlchemy model 字段、Pydantic schema 字段、少量配置属性产生框架级误报；当前更适合作为人工排查候选集，而不是机械删除依据

## 验证
已按仓库要求执行串行低负载检查，并针对后续卫生收敛执行对应 scoped 验证。

### Backend
```bash
cd backend && uv run --locked pre-commit run --files app/db/models/a2a_agent.py app/db/models/user_agent_availability_snapshot.py app/features/agents_catalog/router.py app/features/agents_catalog/schemas.py app/features/agents_catalog/service.py app/features/personal_agents/router.py app/features/personal_agents/schemas.py app/features/personal_agents/service.py app/features/self_management_shared/self_management_toolkit.py app/core/security.py app/features/schedules/self_management_jobs_service.py app/features/sessions/support.py tests/agents_catalog/test_agents_catalog_routes.py tests/agents_catalog/test_agents_catalog_service.py tests/auth/test_auth.py tests/client/test_a2a_client.py tests/personal_agents/test_a2a_health_service.py tests/personal_agents/test_a2a_routes.py tests/personal_agents/test_self_management_agents_service.py tests/runtime/test_self_management_mcp.py tests/runtime/test_self_management_toolkit.py alembic/versions/20260413_1500_r202604131500_add_user_agent_availability_snapshots.py alembic/versions/20260413_1730_r202604131730_add_health_reason_codes.py --config ../.pre-commit-config.yaml
cd backend && uv run --locked pytest tests/agents_catalog/test_agents_catalog_routes.py tests/agents_catalog/test_agents_catalog_service.py tests/auth/test_auth.py tests/client/test_a2a_client.py tests/personal_agents/test_a2a_health_service.py tests/personal_agents/test_a2a_routes.py tests/personal_agents/test_self_management_agents_service.py tests/runtime/test_self_management_mcp.py tests/runtime/test_self_management_toolkit.py tests/schedules/test_self_management_jobs_service.py tests/schedules/test_a2a_schedule_routes.py
cd backend && SCHEMA_NAME=a2a_client_hub_schema uv run --locked alembic upgrade head
cd backend && bash scripts/run_vulture.sh
cd backend && bash scripts/run_vulture.sh exploratory
```
结果：通过

### Frontend
```bash
cd frontend && npm run lint
cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types
cd frontend && npm test -- --findRelatedTests hooks/useAgentsCatalogQuery.ts lib/api/a2aAgents.ts lib/api/agentsCatalog.ts store/agents.ts screens/__tests__/AgentListScreen.test.tsx screens/__tests__/ScheduledJobFormScreen.test.tsx lib/__tests__/agentCatalogCache.test.ts test-utils/agentFixtures.ts --maxWorkers=25%
cd frontend && npm run check-unused-exports
```
结果：通过

## 关联
- Closes #782
- Related #743
- Related #744

## 备注
本 PR 后半段包含若干工程卫生与死代码清理提交。这些提交没有单独拆 issue，目的是保证 `#782` 这一轮改动能以稳定、可维护、可验证的状态落地。
