### PR TITLE
fix(agents): restore health status filters on list banner (#804)

### DIFF
--- a/frontend/screens/AgentListScreen.tsx
+++ b/frontend/screens/AgentListScreen.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { FlatList, RefreshControl, Text, View } from "react-native";
 
 import { AccountEntryButton } from "@/components/auth/AccountEntryButton";
@@ -10,7 +10,10 @@ import { Button } from "@/components/ui/Button";
 import { IconButton } from "@/components/ui/IconButton";
 import { PageHeader } from "@/components/ui/PageHeader";
 import { useAgentsCatalogQuery } from "@/hooks/useAgentsCatalogQuery";
-import { checkAgentsCatalogHealth } from "@/lib/api/agentsCatalog";
+import {
+  checkAgentsCatalogHealth,
+  type UnifiedAgentHealthStatus,
+} from "@/lib/api/agentsCatalog";
 import { formatLocalDateTime } from "@/lib/datetime";
 import { blurActiveElement } from "@/lib/focus";
 import { queryKeys } from "@/lib/queryKeys";
@@ -20,15 +23,24 @@ import { type AgentConfig, useAgentStore } from "@/store/agents";
 import { useChatStore } from "@/store/chat";
 import { useSessionStore } from "@/store/session";
 
+type AgentHealthFilter = UnifiedAgentHealthStatus | "all";
+
 const HEALTH_BADGE_STYLES: Record<
   NonNullable<AgentConfig["healthStatus"]>,
   { label: string }
 > = {
-  healthy: { label: "Available" },
-  degraded: { label: "Needs attention" },
+  healthy: { label: "Healthy" },
+  degraded: { label: "Degraded" },
   unavailable: { label: "Unavailable" },
   unknown: { label: "Not checked" },
 };
+
+const HEALTH_FILTER_ORDER: UnifiedAgentHealthStatus[] = [
+  "healthy",
+  "degraded",
+  "unavailable",
+  "unknown",
+];
 
 const SOURCE_LABELS: Record<AgentConfig["source"], string> = {
   personal: "PERSONAL",
@@ -50,6 +62,8 @@ export function AgentListScreen() {
   const queryClient = useQueryClient();
   const user = useSessionStore((state) => state.user);
   const setActiveAgent = useAgentStore((state) => state.setActiveAgent);
+  const [activeHealthFilter, setActiveHealthFilter] =
+    useState<AgentHealthFilter>("healthy");
   const {
     data: agents = [],
     isLoading,
@@ -71,6 +85,34 @@ export function AgentListScreen() {
     [agents],
   );
 
+  const healthCounts = useMemo(
+    () =>
+      orderedAgents.reduce<Record<UnifiedAgentHealthStatus, number>>(
+        (result, agent) => {
+          const healthStatus = resolveHealthStatus(agent);
+          result[healthStatus] += 1;
+          return result;
+        },
+        {
+          healthy: 0,
+          degraded: 0,
+          unavailable: 0,
+          unknown: 0,
+        },
+      ),
+    [orderedAgents],
+  );
+
+  const filteredAgents = useMemo(() => {
+    if (activeHealthFilter === "all") {
+      return orderedAgents;
+    }
+
+    return orderedAgents.filter(
+      (agent) => resolveHealthStatus(agent) === activeHealthFilter,
+    );
+  }, [activeHealthFilter, orderedAgents]);
+
   const counts = useMemo(
     () => ({
       builtin: orderedAgents.filter((agent) => agent.source === "builtin")
@@ -81,6 +123,11 @@ export function AgentListScreen() {
     }),
     [orderedAgents],
   );
+
+  const selectedHealthFilterLabel =
+    activeHealthFilter === "all"
+      ? "all"
+      : HEALTH_BADGE_STYLES[activeHealthFilter].label.toLowerCase();
 
   const handleChat = useCallback(
     (agentId: string) => {
@@ -316,7 +363,7 @@ export function AgentListScreen() {
         <View className="flex-row items-center justify-between gap-4">
           <View className="flex-1">
             <Text className="text-sm font-semibold text-white">
-              {orderedAgents.length} agents
+              {filteredAgents.length} of {orderedAgents.length} agents
             </Text>
             <Text className="mt-1 text-xs text-slate-400">
               Built-in {counts.builtin} / Personal {counts.personal} / Shared{" "}
@@ -336,9 +383,36 @@ export function AgentListScreen() {
             }}
           />
         </View>
+
+        <View className="mt-4 flex-row flex-wrap items-center gap-3">
+          <Button
+            className="rounded-full"
+            label={`All ${orderedAgents.length}`}
+            size="xs"
+            variant={activeHealthFilter === "all" ? "primary" : "secondary"}
+            onPress={() => setActiveHealthFilter("all")}
+          />
+          {HEALTH_FILTER_ORDER.map((status) => (
+            <Button
+              key={status}
+              className="rounded-full"
+              label={`${HEALTH_BADGE_STYLES[status].label} ${healthCounts[status]}`}
+              size="xs"
+              variant={activeHealthFilter === status ? "primary" : "secondary"}
+              onPress={() => setActiveHealthFilter(status)}
+            />
+          ))}
+        </View>
       </View>
     ),
-    [batchHealthMutation, counts, orderedAgents.length],
+    [
+      activeHealthFilter,
+      batchHealthMutation,
+      counts,
+      filteredAgents.length,
+      healthCounts,
+      orderedAgents.length,
+    ],
   );
 
   return (
@@ -387,7 +461,7 @@ export function AgentListScreen() {
         </View>
       ) : (
         <FlatList
-          data={orderedAgents}
+          data={filteredAgents}
           renderItem={renderAgentItem}
           keyExtractor={(item) => `${item.source}:${item.id}`}
           style={{ marginTop: PAGE_HEADER_CONTENT_GAP }}
@@ -404,18 +478,30 @@ export function AgentListScreen() {
           }
           ListHeaderComponent={renderHeader}
           ListEmptyComponent={
-            <View className="items-center rounded-2xl bg-surface p-8">
-              <View className="mb-4 h-16 w-16 items-center justify-center rounded-2xl bg-primary">
-                <Text className="text-[11px] font-bold text-black">A2A</Text>
+            orderedAgents.length === 0 ? (
+              <View className="items-center rounded-2xl bg-surface p-8">
+                <View className="mb-4 h-16 w-16 items-center justify-center rounded-2xl bg-primary">
+                  <Text className="text-[11px] font-bold text-black">A2A</Text>
+                </View>
+                <Text className="text-base font-bold text-white">
+                  No agents available
+                </Text>
+                <Text className="mt-2 text-center text-sm text-slate-400">
+                  Add your first personal agent or wait for shared agents to be
+                  published.
+                </Text>
               </View>
-              <Text className="text-base font-bold text-white">
-                No agents available
-              </Text>
-              <Text className="mt-2 text-center text-sm text-slate-400">
-                Add your first personal agent or wait for shared agents to be
-                published.
-              </Text>
-            </View>
+            ) : (
+              <View className="items-center rounded-2xl bg-surface p-8">
+                <Text className="text-base font-bold text-white">
+                  No {selectedHealthFilterLabel} agents right now
+                </Text>
+                <Text className="mt-2 text-center text-sm text-slate-400">
+                  Switch to another health status or run Check all to refresh
+                  the latest results.
+                </Text>
+              </View>
+            )
           }
         />
       )}

--- a/frontend/screens/AgentListScreen.tsx
+++ b/frontend/screens/AgentListScreen.tsx
@@ -85,49 +85,44 @@ export function AgentListScreen() {
     [agents],
   );
 
-  const healthCounts = useMemo(
-    () =>
-      orderedAgents.reduce<Record<UnifiedAgentHealthStatus, number>>(
-        (result, agent) => {
-          const healthStatus = resolveHealthStatus(agent);
-          result[healthStatus] += 1;
-          return result;
-        },
-        {
-          healthy: 0,
-          degraded: 0,
-          unavailable: 0,
-          unknown: 0,
-        },
-      ),
-    [orderedAgents],
-  );
+  const { filteredAgents, healthCounts, sourceCounts, selectedFilterLabel } =
+    useMemo(() => {
+      const nextHealthCounts: Record<UnifiedAgentHealthStatus, number> = {
+        healthy: 0,
+        degraded: 0,
+        unavailable: 0,
+        unknown: 0,
+      };
+      const nextSourceCounts: Record<AgentConfig["source"], number> = {
+        builtin: 0,
+        personal: 0,
+        shared: 0,
+      };
+      const nextFilteredAgents: AgentConfig[] = [];
 
-  const filteredAgents = useMemo(() => {
-    if (activeHealthFilter === "all") {
-      return orderedAgents;
-    }
+      for (const agent of orderedAgents) {
+        const healthStatus = resolveHealthStatus(agent);
+        nextHealthCounts[healthStatus] += 1;
+        nextSourceCounts[agent.source] += 1;
 
-    return orderedAgents.filter(
-      (agent) => resolveHealthStatus(agent) === activeHealthFilter,
-    );
-  }, [activeHealthFilter, orderedAgents]);
+        if (
+          activeHealthFilter === "all" ||
+          healthStatus === activeHealthFilter
+        ) {
+          nextFilteredAgents.push(agent);
+        }
+      }
 
-  const counts = useMemo(
-    () => ({
-      builtin: orderedAgents.filter((agent) => agent.source === "builtin")
-        .length,
-      personal: orderedAgents.filter((agent) => agent.source === "personal")
-        .length,
-      shared: orderedAgents.filter((agent) => agent.source === "shared").length,
-    }),
-    [orderedAgents],
-  );
-
-  const selectedHealthFilterLabel =
-    activeHealthFilter === "all"
-      ? "all"
-      : HEALTH_BADGE_STYLES[activeHealthFilter].label.toLowerCase();
+      return {
+        filteredAgents: nextFilteredAgents,
+        healthCounts: nextHealthCounts,
+        sourceCounts: nextSourceCounts,
+        selectedFilterLabel:
+          activeHealthFilter === "all"
+            ? "all"
+            : HEALTH_BADGE_STYLES[activeHealthFilter].label.toLowerCase(),
+      };
+    }, [activeHealthFilter, orderedAgents]);
 
   const handleChat = useCallback(
     (agentId: string) => {
@@ -141,6 +136,14 @@ export function AgentListScreen() {
       router.push(buildChatRoute(agentId, conversationId));
     },
     [router, setActiveAgent],
+  );
+
+  const handleOpenAgentDetails = useCallback(
+    (agentId: string) => {
+      blurActiveElement();
+      router.push(`/agents/${agentId}`);
+    },
+    [router],
   );
 
   const batchHealthMutation = useMutation({
@@ -165,6 +168,13 @@ export function AgentListScreen() {
       toast.error("Availability check failed", message);
     },
   });
+
+  const handleCheckAll = useCallback(() => {
+    if (batchHealthMutation.isPending) {
+      return;
+    }
+    batchHealthMutation.mutate();
+  }, [batchHealthMutation]);
 
   const renderAgentMeta = (agent: AgentConfig) => {
     const healthStatus = resolveHealthStatus(agent);
@@ -224,10 +234,7 @@ export function AgentListScreen() {
           size="sm"
           variant="secondary"
           iconLeft="create-outline"
-          onPress={() => {
-            blurActiveElement();
-            router.push(`/agents/${agent.id}`);
-          }}
+          onPress={() => handleOpenAgentDetails(agent.id)}
         />
         <Button
           label="Chat"
@@ -274,10 +281,7 @@ export function AgentListScreen() {
             size="sm"
             variant="secondary"
             iconLeft="information-outline"
-            onPress={() => {
-              blurActiveElement();
-              router.push(`/agents/${agent.id}`);
-            }}
+            onPress={() => handleOpenAgentDetails(agent.id)}
           />
           {agent.credentialMode === "user" ? (
             <Button
@@ -289,10 +293,7 @@ export function AgentListScreen() {
               size="sm"
               variant="secondary"
               iconLeft="key-outline"
-              onPress={() => {
-                blurActiveElement();
-                router.push(`/agents/${agent.id}`);
-              }}
+              onPress={() => handleOpenAgentDetails(agent.id)}
             />
           ) : null}
         </View>
@@ -354,7 +355,7 @@ export function AgentListScreen() {
       }
       return renderPersonalAgentItem(item);
     },
-    [handleChat, router],
+    [handleChat, handleOpenAgentDetails],
   );
 
   const renderHeader = useMemo(
@@ -366,8 +367,8 @@ export function AgentListScreen() {
               {filteredAgents.length} of {orderedAgents.length} agents
             </Text>
             <Text className="mt-1 text-xs text-slate-400">
-              Built-in {counts.builtin} / Personal {counts.personal} / Shared{" "}
-              {counts.shared}
+              Built-in {sourceCounts.builtin} / Personal {sourceCounts.personal}{" "}
+              / Shared {sourceCounts.shared}
             </Text>
           </View>
           <Button
@@ -375,12 +376,7 @@ export function AgentListScreen() {
             size="sm"
             variant="secondary"
             iconLeft="pulse-outline"
-            onPress={() => {
-              if (batchHealthMutation.isPending) {
-                return;
-              }
-              batchHealthMutation.mutate();
-            }}
+            onPress={handleCheckAll}
           />
         </View>
 
@@ -408,10 +404,11 @@ export function AgentListScreen() {
     [
       activeHealthFilter,
       batchHealthMutation,
-      counts,
       filteredAgents.length,
+      handleCheckAll,
       healthCounts,
       orderedAgents.length,
+      sourceCounts,
     ],
   );
 
@@ -494,7 +491,7 @@ export function AgentListScreen() {
             ) : (
               <View className="items-center rounded-2xl bg-surface p-8">
                 <Text className="text-base font-bold text-white">
-                  No {selectedHealthFilterLabel} agents right now
+                  No {selectedFilterLabel} agents right now
                 </Text>
                 <Text className="mt-2 text-center text-sm text-slate-400">
                   Switch to another health status or run Check all to refresh

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -185,16 +185,56 @@ describe("AgentListScreen", () => {
     expect(mockFlatLists).toHaveLength(1);
     const labels = mockButtons.map((button) => button.label);
     expect(labels).toContain("Check all");
+    expect(labels).toContain("All 3");
+    expect(labels).toContain("Healthy 2");
+    expect(labels).toContain("Not checked 1");
     expect(labels).toContain("Edit");
-    expect(labels).toContain("Details");
-    expect(labels.filter((label) => label === "Chat")).toHaveLength(3);
+    expect(labels.filter((label) => label === "Chat")).toHaveLength(2);
     expect(labels).not.toContain("My");
     expect(labels).not.toContain("Shared");
     expect(
       tree!.root
         .findAllByType(Text)
+        .some(
+          (node: ReactTestInstance) => node.props.children === "Shared Agent",
+        ),
+    ).toBe(false);
+    expect(
+      tree!.root
+        .findAllByType(Text)
         .some((node: ReactTestInstance) => node.props.children === "BUILT-IN"),
     ).toBe(true);
+  });
+
+  it("switches the unified list when a health filter is selected", async () => {
+    let tree;
+    await act(async () => {
+      tree = create(<AgentListScreen />);
+    });
+
+    const notCheckedButton = mockButtons.find(
+      (button) => button.label === "Not checked 1",
+    );
+    expect(notCheckedButton).toBeDefined();
+
+    await act(async () => {
+      (notCheckedButton?.onPress as (() => void) | undefined)?.();
+    });
+
+    expect(
+      tree!.root
+        .findAllByType(Text)
+        .some(
+          (node: ReactTestInstance) => node.props.children === "Shared Agent",
+        ),
+    ).toBe(true);
+    expect(
+      tree!.root
+        .findAllByType(Text)
+        .some(
+          (node: ReactTestInstance) => node.props.children === "Personal Agent",
+        ),
+    ).toBe(false);
   });
 
   it("triggers a unified health check from the header action", async () => {


### PR DESCRIPTION
## 关联 Issues
- Closes #804

## 模块审查
### Frontend
- 在统一 Agents 列表页的 banner 中恢复了健康状态筛选入口，包含 `All / Healthy / Degraded / Unavailable / Not checked` 按钮与状态计数。
- 默认筛选恢复为 `Healthy`，与 issue 期望的“优先展示正常可用 agents”一致。
- 实现沿用统一 catalog 数据源，在前端完成计数与筛选，没有回退到旧的分裂式列表结构，改动范围小且可维护。
- 为无匹配筛选结果补充了空状态提示，避免筛选后页面表现不明确。

### Tests
- 补充了 `AgentListScreen` 的单元测试，覆盖默认仅展示 healthy agents，以及切换到 `Not checked` 后列表切换。
- 已执行前端 lint、typecheck 与关联测试。

## 审查结论
- 本 PR 的代码变更与 #804 的诉求一致，`Closes #804` 的关联关系准确。
- 当前未发现阻塞性问题，整体实现合理，且相对优雅地保留了统一列表架构。

## 剩余风险 / 观察项
- 目前测试主要覆盖默认筛选与单一状态切换，尚未覆盖 `Degraded` / `Unavailable` 的交互路径。
- 尚未做真实界面层面的人工验证，小屏幕下 banner 按钮换行与可读性仍建议在合并前人工确认。

## 验证记录
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests screens/AgentListScreen.tsx screens/__tests__/AgentListScreen.test.tsx --maxWorkers=25%`
