### PR TITLE
fix(frontend): streamline agents list and chat header info display

### DIFF
--- a/frontend/components/chat/ChatHeaderPanel.tsx
+++ b/frontend/components/chat/ChatHeaderPanel.tsx
@@ -25,44 +25,17 @@ const resolveModesValue = (session?: AgentSession) => {
   return `${inputValue} -> ${outputValue}`;
 };
 
-const resolveCapabilityBadge = (status: CapabilityStatus) => {
-  if (status === "supported") {
-    return {
-      label: "Available",
-      container: "border-emerald-500/30 bg-emerald-500/10",
-      text: "text-emerald-200",
-    };
-  }
-  if (status === "unsupported") {
-    return {
-      label: "Unavailable",
-      container: "border-slate-500/30 bg-slate-500/10",
-      text: "text-slate-300",
-    };
-  }
-  return {
-    label: "Unknown",
-    container: "border-amber-500/30 bg-amber-500/10",
-    text: "text-amber-200",
-  };
-};
-
-const InfoCard = ({
-  label,
-  value,
-  fullWidth = false,
-}: {
-  label: string;
-  value: string;
-  fullWidth?: boolean;
-}) => (
-  <View className={`${INFO_CARD_CLASS} ${fullWidth ? "basis-full" : ""}`}>
-    <Text className="text-[10px] font-medium uppercase tracking-wider text-slate-500">
+const InfoCard = ({ label, value }: { label: string; value: string }) => (
+  <View className={INFO_CARD_CLASS}>
+    <Text
+      className="text-[10px] font-medium uppercase tracking-wider text-slate-500"
+      numberOfLines={1}
+    >
       {label}
     </Text>
     <Text
       className="mt-1 text-[11px] font-normal leading-4 text-slate-300"
-      numberOfLines={fullWidth ? undefined : 2}
+      numberOfLines={1}
     >
       {value}
     </Text>
@@ -120,6 +93,9 @@ export function ChatHeaderPanel({
     { label: "Session Shell", status: sessionShellStatus },
     { label: "Invoke Metadata", status: invokeMetadataStatus },
   ];
+  const availableCapabilities = capabilityItems
+    .filter((item) => item.status === "supported")
+    .map((item) => item.label);
 
   return (
     <View
@@ -169,7 +145,8 @@ export function ChatHeaderPanel({
 
       {showDetails ? (
         <View className="mt-4 gap-3 overflow-hidden rounded-2xl bg-surface p-4 shadow-sm">
-          <View className="flex-row justify-end">
+          <View className="flex-row items-center gap-3">
+            <InfoCard label="Agent Card" value={agent.cardUrl} />
             <Button
               label="Check"
               size="xs"
@@ -181,7 +158,6 @@ export function ChatHeaderPanel({
           </View>
 
           <View className="flex-row flex-wrap gap-3">
-            <InfoCard label="Agent Endpoint" value={agent.cardUrl} fullWidth />
             <InfoCard label="Conversation ID" value={conversationId ?? "N/A"} />
             <InfoCard label="Source" value={sessionSource ?? "N/A"} />
             {session?.runtimeStatus ? (
@@ -190,41 +166,29 @@ export function ChatHeaderPanel({
             <InfoCard label="Transport" value={session?.transport ?? "N/A"} />
             {modesValue ? <InfoCard label="Modes" value={modesValue} /> : null}
             {workingDirectory ? (
-              <InfoCard
-                label="Working Directory"
-                value={workingDirectory}
-                fullWidth
-              />
+              <InfoCard label="Working Directory" value={workingDirectory} />
             ) : null}
           </View>
 
-          <View>
-            <Text className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
-              Capabilities
-            </Text>
-            <View className="mt-2 flex-row flex-wrap gap-2">
-              {capabilityItems.map((item) => {
-                const badge = resolveCapabilityBadge(item.status);
-                return (
+          {availableCapabilities.length > 0 ? (
+            <View>
+              <Text className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
+                Capabilities
+              </Text>
+              <View className="mt-2 flex-row flex-wrap gap-2">
+                {availableCapabilities.map((label) => (
                   <View
-                    key={item.label}
-                    className="min-w-[46%] flex-1 rounded-xl border border-white/5 bg-black/20 px-3 py-2.5"
+                    key={label}
+                    className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1.5"
                   >
-                    <Text className="text-[10px] font-medium text-slate-300">
-                      {item.label}
+                    <Text className="text-[10px] font-medium text-emerald-200">
+                      {label}
                     </Text>
-                    <View
-                      className={`mt-2 self-start rounded-full border px-2.5 py-1 ${badge.container}`}
-                    >
-                      <Text className={`text-[10px] font-medium ${badge.text}`}>
-                        {badge.label}
-                      </Text>
-                    </View>
                   </View>
-                );
-              })}
+                ))}
+              </View>
             </View>
-          </View>
+          ) : null}
 
           {session?.externalSessionRef?.externalSessionId ? (
             <>

--- a/frontend/components/chat/__tests__/ChatHeaderPanel.test.tsx
+++ b/frontend/components/chat/__tests__/ChatHeaderPanel.test.tsx
@@ -11,7 +11,7 @@ jest.mock("@/components/ui/BackButton", () => ({
 }));
 
 describe("ChatHeaderPanel", () => {
-  it("does not render Codex Discovery in the generic agent info panel", () => {
+  it("renders a compact generic agent info panel without discovery-specific details", () => {
     const agent = {
       id: "agent-1",
       name: "Planner",
@@ -59,9 +59,10 @@ describe("ChatHeaderPanel", () => {
       />,
     );
 
-    expect(screen.getByText("Agent Endpoint")).toBeTruthy();
+    expect(screen.getByText("Agent Card")).toBeTruthy();
     expect(screen.getByText("Check")).toBeTruthy();
     expect(screen.getByText("Modes")).toBeTruthy();
+    expect(screen.getByText("sse").props.numberOfLines).toBe(1);
     expect(screen.getByText("text -> text")).toBeTruthy();
     expect(screen.queryByText("Diagnostics")).toBeNull();
     expect(screen.queryByText("Test")).toBeNull();
@@ -72,12 +73,16 @@ describe("ChatHeaderPanel", () => {
     ).toBeNull();
     expect(screen.getByText("Capabilities")).toBeTruthy();
     expect(screen.getByText("Model Selection")).toBeTruthy();
-    expect(screen.getByText("Provider Discovery")).toBeTruthy();
-    expect(screen.getByText("Interrupt Recovery")).toBeTruthy();
     expect(screen.getByText("Streaming Append")).toBeTruthy();
-    expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Unavailable").length).toBeGreaterThan(0);
+    expect(screen.getByText("Prompt Async")).toBeTruthy();
+    expect(screen.getByText("Invoke Metadata")).toBeTruthy();
+    expect(screen.queryByText("Provider Discovery")).toBeNull();
+    expect(screen.queryByText("Interrupt Recovery")).toBeNull();
+    expect(screen.queryByText("Session Command")).toBeNull();
+    expect(screen.queryByText("Session Shell")).toBeNull();
+    expect(screen.queryByText("Available")).toBeNull();
+    expect(screen.queryByText("Unknown")).toBeNull();
+    expect(screen.queryByText("Unavailable")).toBeNull();
     expect(screen.queryByText("IN: text")).toBeNull();
     expect(screen.queryByText("OUT: text")).toBeNull();
   });

--- a/frontend/screens/AgentListScreen.tsx
+++ b/frontend/screens/AgentListScreen.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { FlatList, RefreshControl, Text, View } from "react-native";
 
 import { AccountEntryButton } from "@/components/auth/AccountEntryButton";
@@ -14,7 +14,6 @@ import {
   checkAgentsCatalogHealth,
   type UnifiedAgentHealthStatus,
 } from "@/lib/api/agentsCatalog";
-import { formatLocalDateTime } from "@/lib/datetime";
 import { blurActiveElement } from "@/lib/focus";
 import { queryKeys } from "@/lib/queryKeys";
 import { buildChatRoute } from "@/lib/routes";
@@ -23,8 +22,6 @@ import { type AgentConfig, useAgentStore } from "@/store/agents";
 import { useChatStore } from "@/store/chat";
 import { useSessionStore } from "@/store/session";
 
-type AgentHealthFilter = UnifiedAgentHealthStatus | "all";
-
 const HEALTH_BADGE_STYLES: Record<
   NonNullable<AgentConfig["healthStatus"]>,
   { label: string }
@@ -32,7 +29,7 @@ const HEALTH_BADGE_STYLES: Record<
   healthy: { label: "Healthy" },
   degraded: { label: "Degraded" },
   unavailable: { label: "Unavailable" },
-  unknown: { label: "Not checked" },
+  unknown: { label: "Unknown" },
 };
 
 const HEALTH_FILTER_ORDER: UnifiedAgentHealthStatus[] = [
@@ -63,7 +60,7 @@ export function AgentListScreen() {
   const user = useSessionStore((state) => state.user);
   const setActiveAgent = useAgentStore((state) => state.setActiveAgent);
   const [activeHealthFilter, setActiveHealthFilter] =
-    useState<AgentHealthFilter>("healthy");
+    useState<UnifiedAgentHealthStatus>("healthy");
   const {
     data: agents = [],
     isLoading,
@@ -105,10 +102,7 @@ export function AgentListScreen() {
         nextHealthCounts[healthStatus] += 1;
         nextSourceCounts[agent.source] += 1;
 
-        if (
-          activeHealthFilter === "all" ||
-          healthStatus === activeHealthFilter
-        ) {
+        if (healthStatus === activeHealthFilter) {
           nextFilteredAgents.push(agent);
         }
       }
@@ -118,11 +112,25 @@ export function AgentListScreen() {
         healthCounts: nextHealthCounts,
         sourceCounts: nextSourceCounts,
         selectedFilterLabel:
-          activeHealthFilter === "all"
-            ? "all"
-            : HEALTH_BADGE_STYLES[activeHealthFilter].label.toLowerCase(),
+          HEALTH_BADGE_STYLES[activeHealthFilter].label.toLowerCase(),
       };
     }, [activeHealthFilter, orderedAgents]);
+
+  const visibleHealthFilters = useMemo(
+    () => HEALTH_FILTER_ORDER.filter((status) => healthCounts[status] > 0),
+    [healthCounts],
+  );
+
+  useEffect(() => {
+    if (healthCounts[activeHealthFilter] > 0) {
+      return;
+    }
+
+    const fallbackFilter = visibleHealthFilters[0];
+    if (fallbackFilter) {
+      setActiveHealthFilter(fallbackFilter);
+    }
+  }, [activeHealthFilter, healthCounts, visibleHealthFilters]);
 
   const handleChat = useCallback(
     (agentId: string) => {
@@ -177,38 +185,20 @@ export function AgentListScreen() {
   }, [batchHealthMutation]);
 
   const renderAgentMeta = (agent: AgentConfig) => {
-    const healthStatus = resolveHealthStatus(agent);
-    const checkedAtLabel = agent.lastHealthCheckAt
-      ? `Checked ${formatLocalDateTime(agent.lastHealthCheckAt)}`
-      : "Not checked yet";
     const sourceLabel = SOURCE_LABELS[agent.source];
 
     return (
-      <>
-        <View className="flex-row items-center justify-between gap-3">
-          <Text
-            className="flex-1 pr-4 text-[13px] font-semibold text-white"
-            numberOfLines={1}
-          >
-            {agent.name}
-          </Text>
-          <Text className="text-[10px] font-bold uppercase tracking-widest text-neo-green">
-            {sourceLabel}
-          </Text>
-        </View>
-
-        <View className="mt-3 flex-row items-center justify-between gap-3">
-          <Text className="text-xs text-slate-400" numberOfLines={1}>
-            {HEALTH_BADGE_STYLES[healthStatus].label}
-          </Text>
-          <Text
-            className="flex-1 text-right text-xs text-slate-500"
-            numberOfLines={1}
-          >
-            {checkedAtLabel}
-          </Text>
-        </View>
-      </>
+      <View className="flex-row items-center justify-between gap-3">
+        <Text
+          className="flex-1 pr-4 text-[13px] font-semibold text-white"
+          numberOfLines={1}
+        >
+          {agent.name}
+        </Text>
+        <Text className="text-[10px] font-bold uppercase tracking-widest text-neo-green">
+          {sourceLabel}
+        </Text>
+      </View>
     );
   };
 
@@ -364,15 +354,12 @@ export function AgentListScreen() {
         <View className="flex-row items-center justify-between gap-4">
           <View className="flex-1">
             <Text className="text-sm font-semibold text-white">
-              {filteredAgents.length} of {orderedAgents.length} agents
-            </Text>
-            <Text className="mt-1 text-xs text-slate-400">
               Built-in {sourceCounts.builtin} / Personal {sourceCounts.personal}{" "}
               / Shared {sourceCounts.shared}
             </Text>
           </View>
           <Button
-            label={batchHealthMutation.isPending ? "Checking..." : "Check all"}
+            label={batchHealthMutation.isPending ? "Checking..." : "Check"}
             size="sm"
             variant="secondary"
             iconLeft="pulse-outline"
@@ -381,14 +368,7 @@ export function AgentListScreen() {
         </View>
 
         <View className="mt-4 flex-row flex-wrap items-center gap-3">
-          <Button
-            className="rounded-full"
-            label={`All ${orderedAgents.length}`}
-            size="xs"
-            variant={activeHealthFilter === "all" ? "primary" : "secondary"}
-            onPress={() => setActiveHealthFilter("all")}
-          />
-          {HEALTH_FILTER_ORDER.map((status) => (
+          {visibleHealthFilters.map((status) => (
             <Button
               key={status}
               className="rounded-full"
@@ -404,11 +384,10 @@ export function AgentListScreen() {
     [
       activeHealthFilter,
       batchHealthMutation,
-      filteredAgents.length,
       handleCheckAll,
-      healthCounts,
-      orderedAgents.length,
       sourceCounts,
+      visibleHealthFilters,
+      healthCounts,
     ],
   );
 
@@ -494,8 +473,8 @@ export function AgentListScreen() {
                   No {selectedFilterLabel} agents right now
                 </Text>
                 <Text className="mt-2 text-center text-sm text-slate-400">
-                  Switch to another health status or run Check all to refresh
-                  the latest results.
+                  Switch to another health status or run Check to refresh the
+                  latest results.
                 </Text>
               </View>
             )

--- a/frontend/screens/__tests__/AgentListScreen.test.tsx
+++ b/frontend/screens/__tests__/AgentListScreen.test.tsx
@@ -184,14 +184,32 @@ describe("AgentListScreen", () => {
 
     expect(mockFlatLists).toHaveLength(1);
     const labels = mockButtons.map((button) => button.label);
-    expect(labels).toContain("Check all");
-    expect(labels).toContain("All 3");
+    expect(labels).toContain("Check");
     expect(labels).toContain("Healthy 2");
-    expect(labels).toContain("Not checked 1");
+    expect(labels).toContain("Unknown 1");
+    expect(labels).not.toContain("All 3");
+    expect(labels).not.toContain("Degraded 0");
+    expect(labels).not.toContain("Unavailable 0");
     expect(labels).toContain("Edit");
     expect(labels.filter((label) => label === "Chat")).toHaveLength(2);
     expect(labels).not.toContain("My");
     expect(labels).not.toContain("Shared");
+    expect(
+      tree!.root
+        .findAllByType(Text)
+        .some(
+          (node: ReactTestInstance) =>
+            typeof node.props.children === "string" &&
+            node.props.children.startsWith("Checked "),
+        ),
+    ).toBe(false);
+    expect(
+      tree!.root
+        .findAllByType(Text)
+        .some(
+          (node: ReactTestInstance) => node.props.children === "Not checked",
+        ),
+    ).toBe(false);
     expect(
       tree!.root
         .findAllByType(Text)
@@ -212,13 +230,13 @@ describe("AgentListScreen", () => {
       tree = create(<AgentListScreen />);
     });
 
-    const notCheckedButton = mockButtons.find(
-      (button) => button.label === "Not checked 1",
+    const unknownButton = mockButtons.find(
+      (button) => button.label === "Unknown 1",
     );
-    expect(notCheckedButton).toBeDefined();
+    expect(unknownButton).toBeDefined();
 
     await act(async () => {
-      (notCheckedButton?.onPress as (() => void) | undefined)?.();
+      (unknownButton?.onPress as (() => void) | undefined)?.();
     });
 
     expect(
@@ -242,9 +260,7 @@ describe("AgentListScreen", () => {
       create(<AgentListScreen />);
     });
 
-    const checkButton = mockButtons.find(
-      (button) => button.label === "Check all",
-    );
+    const checkButton = mockButtons.find((button) => button.label === "Check");
     expect(checkButton).toBeDefined();
 
     await act(async () => {


### PR DESCRIPTION
## 关联 Issues
- Closes #806
- Closes #808

## Frontend / Agents List
- 基于 `fix(frontend): trim agent health filter display noise (#806)`，继续收敛 Agents 列表顶部状态筛选显示。
- 移除顶部 `19 of 29 agents` 统计文案。
- 将顶部按钮文案从 `Check all` 调整为 `Check`。
- 移除 `All` 标签，并仅渲染数量大于 0 的健康状态标签。
- 将 `Not checked` 统一改为 `Unknown`。
- 移除 agent card 内重复的健康状态与检查时间文本。
- 增加当前筛选状态数量为 0 时的回退逻辑，自动切到第一个仍有数据的状态标签。

## Frontend / Chat Header
- 基于 `fix(frontend): simplify chat header agent info layout (#808)`，简化聊天页 `agent info` 面板布局。
- 保留每行两个信息项，但单个 item 改为单行显示。
- 将 `Check` 按钮移动到 `Agent Card` 同行右侧。
- 将 `Agent Endpoint` 文案改为 `Agent Card`。
- `Capabilities` 仅显示可用能力名称，不再渲染 unsupported/unknown 能力，也不再显示状态标签。

## Tests
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests screens/AgentListScreen.tsx screens/__tests__/AgentListScreen.test.tsx --maxWorkers=25%`
- `cd frontend && npm test -- --findRelatedTests components/chat/ChatHeaderPanel.tsx components/chat/__tests__/ChatHeaderPanel.test.tsx --maxWorkers=25%`

## 备注
- 本次仅涉及前端，未运行后端回归。
