### PR TITLE
fix(frontend): clear metro cache before web export (#809)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -89,6 +89,29 @@ Use `npm run publish:web` to export and serve the web build locally.
 - Default port: `8787`
 - Override with env vars: `HOST`, `PORT`
 - Run in background: `DETACH=1 npm run publish:web`
+- The publish helper clears `dist/` before each export so stale hashed bundles are not carried into the next local build snapshot.
+
+## Web Runtime Troubleshooting
+
+### `Requiring unknown module "<id>"`
+
+If the web app fails at runtime with an error like `Requiring unknown module "1352"` and the stack points to `entry-*.js`, `__expo-metro-runtime-*.js`, or a route chunk such as `AgentListScreen-*.js`, treat it as a mixed-bundle symptom first.
+
+Typical cause:
+
+- The browser, CDN, reverse proxy, or static host is serving an older `entry-*.js` / route chunk together with a newer build, or vice versa.
+
+Practical recovery steps:
+
+1. Hard refresh the page and clear browser cache for the site.
+2. Redeploy the full exported `dist/` directory atomically instead of partially updating only some files.
+3. Invalidate CDN or proxy caches for `index.html`, route HTML files, and hashed JS bundles after deployment.
+4. Rebuild locally with `npm run publish:web` to confirm the latest source exports cleanly.
+
+Notes:
+
+- A successful local `expo export -p web` strongly suggests the problem is deployment/cache related rather than a missing source import.
+- If you are using a manual upload flow, make sure the target directory is replaced as one release unit instead of merging old and new bundle files over time.
 
 ## Unified Conversations
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -89,29 +89,6 @@ Use `npm run publish:web` to export and serve the web build locally.
 - Default port: `8787`
 - Override with env vars: `HOST`, `PORT`
 - Run in background: `DETACH=1 npm run publish:web`
-- The publish helper clears `dist/` before each export so stale hashed bundles are not carried into the next local build snapshot.
-
-## Web Runtime Troubleshooting
-
-### `Requiring unknown module "<id>"`
-
-If the web app fails at runtime with an error like `Requiring unknown module "1352"` and the stack points to `entry-*.js`, `__expo-metro-runtime-*.js`, or a route chunk such as `AgentListScreen-*.js`, treat it as a mixed-bundle symptom first.
-
-Typical cause:
-
-- The browser, CDN, reverse proxy, or static host is serving an older `entry-*.js` / route chunk together with a newer build, or vice versa.
-
-Practical recovery steps:
-
-1. Hard refresh the page and clear browser cache for the site.
-2. Redeploy the full exported `dist/` directory atomically instead of partially updating only some files.
-3. Invalidate CDN or proxy caches for `index.html`, route HTML files, and hashed JS bundles after deployment.
-4. Rebuild locally with `npm run publish:web` to confirm the latest source exports cleanly.
-
-Notes:
-
-- A successful local `expo export -p web` strongly suggests the problem is deployment/cache related rather than a missing source import.
-- If you are using a manual upload flow, make sure the target directory is replaced as one release unit instead of merging old and new bundle files over time.
 
 ## Unified Conversations
 

--- a/frontend/scripts/publish-web.sh
+++ b/frontend/scripts/publish-web.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 HOST=${HOST:-127.0.0.1}
 PORT=${PORT:-8787}
 
+rm -rf dist
 npx expo export -p web
 
 echo "Serving dist/ on http://${HOST}:${PORT}"

--- a/frontend/scripts/publish-web.sh
+++ b/frontend/scripts/publish-web.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 HOST=${HOST:-127.0.0.1}
 PORT=${PORT:-8787}
 
-rm -rf dist
 npx expo export -p web
 
 echo "Serving dist/ on http://${HOST}:${PORT}"

--- a/frontend/scripts/publish-web.sh
+++ b/frontend/scripts/publish-web.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 HOST=${HOST:-127.0.0.1}
 PORT=${PORT:-8787}
 
-npx expo export -p web
+rm -rf dist
+npx expo export -p web --clear
 
 echo "Serving dist/ on http://${HOST}:${PORT}"
 


### PR DESCRIPTION
## 变更说明
本 PR 修复前端 Web 导出流程中复用 Metro bundler cache 导致的产物不一致问题。

## 根因分析
### 发布脚本
- 仅删除 `dist`、`.expo`、`.cache`、`node_modules/.cache` 不能清掉 Metro 默认缓存
- 当前依赖版本下，Metro 默认缓存位于系统临时目录，例如 `/tmp/metro-cache` 与 `/tmp/metro-file-map-*`
- `expo export` 复用旧的 Metro cache 后，可能继续产出带旧模块编号关系的 Web bundle，并在运行时触发 `Requiring unknown module "1352"`

## 改动模块
### frontend/scripts
- 在 `frontend/scripts/publish-web.sh` 中先删除 `dist`
- 将 `npx expo export -p web` 改为 `npx expo export -p web --clear`
- 通过脚本层统一清理 Metro bundler cache，避免人工依赖本地缓存路径知识

## 验证
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && bash -n scripts/publish-web.sh`
- `cd frontend && rm -rf dist && npx expo export -p web --clear`

## 关联
- Closes #809
