### PR TITLE
fix(self-management): tighten built-in approvals and cleanup reply failures

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -366,12 +366,20 @@ def create_self_management_interrupt_token(
     conversation_id: str,
     message: str,
     tool_names: Sequence[str],
+    allowed_operations: Sequence[str] = (),
 ) -> str:
     normalized_conversation_id = str(conversation_id).strip()
     if not normalized_conversation_id:
         raise ValueError("conversation_id is required")
     normalized_tool_names = sorted(
         {str(tool_name).strip() for tool_name in tool_names if str(tool_name).strip()}
+    )
+    normalized_operations = sorted(
+        {
+            str(operation_id).strip()
+            for operation_id in allowed_operations
+            if str(operation_id).strip()
+        }
     )
     return create_jwt_token(
         subject=str(user_id),
@@ -381,6 +389,7 @@ def create_self_management_interrupt_token(
             SELF_MANAGEMENT_INTERRUPT_CONVERSATION_ID_CLAIM: normalized_conversation_id,
             SELF_MANAGEMENT_INTERRUPT_MESSAGE_CLAIM: message,
             SELF_MANAGEMENT_INTERRUPT_TOOL_NAMES_CLAIM: normalized_tool_names,
+            SELF_MANAGEMENT_ALLOWED_OPERATIONS_CLAIM: normalized_operations,
         },
     )
 

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -518,10 +518,50 @@ class SelfManagementBuiltInAgentService:
                 local_source=local_source,
             )
         if effective_write_tools and self._answer_requests_write_approval(answer):
-            await self._invalidate_runtime_session(runtime_state)
-            raise SelfManagementBuiltInAgentUnavailableError(
-                "swival built-in agent requested write approval after write "
-                "tools were enabled"
+            requested_write_operation_ids = self._extract_requested_write_operation_ids(
+                answer
+            )
+            if not requested_write_operation_ids:
+                await self._invalidate_runtime_session(runtime_state)
+                raise SelfManagementBuiltInAgentUnavailableError(
+                    "swival built-in agent requested write approval without "
+                    "declaring any write operations"
+                )
+            missing_write_operation_ids = tuple(
+                operation_id
+                for operation_id in requested_write_operation_ids
+                if operation_id not in effective_write_operation_ids
+            )
+            if not missing_write_operation_ids:
+                await self._invalidate_runtime_session(runtime_state)
+                raise SelfManagementBuiltInAgentUnavailableError(
+                    "swival built-in agent requested write approval after write "
+                    "tools were enabled"
+                )
+            interrupt = self._build_permission_interrupt(
+                current_user=current_user,
+                conversation_id=local_session_id,
+                message=message,
+                answer=answer,
+                allowed_write_operation_ids=missing_write_operation_ids,
+            )
+            return _ExecutedBuiltInRun(
+                result=SelfManagementBuiltInAgentRunResult(
+                    status=SelfManagementBuiltInAgentRunStatus.INTERRUPTED,
+                    answer=self._strip_write_approval_metadata(answer),
+                    exhausted=exhausted,
+                    runtime="swival",
+                    resources=profile.resources,
+                    tool_names=tuple(
+                        definition.tool_name for definition in tool_definitions
+                    ),
+                    write_tools_enabled=True,
+                    interrupt=interrupt,
+                ),
+                profile=profile,
+                local_session=local_session,
+                local_session_id=local_session_id,
+                local_source=local_source,
             )
         return _ExecutedBuiltInRun(
             result=SelfManagementBuiltInAgentRunResult(
@@ -621,7 +661,24 @@ class SelfManagementBuiltInAgentService:
                 conversation_id=conversation_id,
             )
             async with runtime_state.get_lock():
+                approved_operation_ids = (
+                    runtime_state.auto_approve_write_operation_ids
+                    | runtime_state.delegated_write_operation_ids
+                    | approved_operation_ids
+                )
                 runtime_state.auto_approve_write_operation_ids = approved_operation_ids
+                runtime_state.last_accessed_monotonic = time.monotonic()
+        else:
+            runtime_state = await self._get_conversation_runtime_state(
+                current_user_id=str(current_user.id),
+                conversation_id=conversation_id,
+            )
+            async with runtime_state.get_lock():
+                approved_operation_ids = (
+                    runtime_state.auto_approve_write_operation_ids
+                    | runtime_state.delegated_write_operation_ids
+                    | approved_operation_ids
+                )
                 runtime_state.last_accessed_monotonic = time.monotonic()
 
         executed = await self._execute_run(

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -23,6 +23,7 @@ from app.core.security import (
     SELF_MANAGEMENT_INTERRUPT_TOKEN_TYPE,
     create_self_management_access_token,
     create_self_management_interrupt_token,
+    get_self_management_allowed_operations,
     get_self_management_interrupt_conversation_id,
     get_self_management_interrupt_message,
     get_self_management_interrupt_tool_names,
@@ -71,15 +72,27 @@ _DEFAULT_SYSTEM_PROMPT = (
     "required identifiers, ask one concise follow-up question."
 )
 _WRITE_APPROVAL_SENTINEL = "[[SELF_MANAGEMENT_WRITE_APPROVAL_REQUIRED]]"
+_WRITE_APPROVAL_OPERATIONS_PREFIX = "[[SELF_MANAGEMENT_WRITE_OPERATIONS:"
+_WRITE_APPROVAL_OPERATIONS_SUFFIX = "]]"
 _READ_ONLY_APPENDIX = (
     " This run is read-only. Do not attempt write operations. If the user's latest "
     "request would require a write tool, explain the intended change briefly, do not "
-    "claim that any change was applied, and append a final line containing exactly "
-    f"{_WRITE_APPROVAL_SENTINEL}."
+    "claim that any change was applied, append a final line containing exactly "
+    f"{_WRITE_APPROVAL_SENTINEL}, then append one more final line containing exactly "
+    "`[[SELF_MANAGEMENT_WRITE_OPERATIONS:<comma-separated operation ids>]]` using "
+    "only the required write operation ids from this catalog: "
+    "self.agents.check_health, self.agents.check_health_all, self.agents.create, "
+    "self.agents.delete, self.agents.update_config, self.jobs.create, "
+    "self.jobs.delete, self.jobs.pause, self.jobs.resume, self.jobs.update, "
+    "self.jobs.update_prompt, self.jobs.update_schedule, self.sessions.archive, "
+    "self.sessions.unarchive, self.sessions.update."
 )
 _WRITE_ENABLED_APPENDIX = (
     " This run includes explicitly approved write tools. Only perform a write when "
-    "the user's latest request clearly asks for that change."
+    "the user's latest request clearly asks for that change. When additional write "
+    "operations outside the approved tool set are needed, do not claim that any "
+    "change was applied, append the approval sentinel, and append the exact "
+    "operation ids that still require approval."
 )
 
 
@@ -165,8 +178,8 @@ class _ConversationRuntimeState:
     """One in-memory swival conversation runtime owned by one user conversation."""
 
     session: Any | None = None
-    write_tools_enabled: bool = False
-    auto_approve_writes: bool = False
+    delegated_write_operation_ids: frozenset[str] = frozenset()
+    auto_approve_write_operation_ids: frozenset[str] = frozenset()
     delegated_token_expires_at_monotonic: float = 0.0
     last_accessed_monotonic: float = 0.0
     lock: asyncio.Lock | None = None
@@ -201,11 +214,11 @@ class SelfManagementBuiltInAgentService:
         self,
         *,
         runtime_state: _ConversationRuntimeState,
-        write_tools_enabled: bool,
+        delegated_write_operation_ids: frozenset[str],
     ) -> bool:
         if runtime_state.session is None:
             return True
-        if runtime_state.write_tools_enabled != write_tools_enabled:
+        if runtime_state.delegated_write_operation_ids != delegated_write_operation_ids:
             return True
         expires_at = runtime_state.delegated_token_expires_at_monotonic
         if expires_at <= 0:
@@ -220,7 +233,7 @@ class SelfManagementBuiltInAgentService:
         session = runtime_state.session
         runtime_state.session = None
         runtime_state.delegated_token_expires_at_monotonic = 0.0
-        runtime_state.write_tools_enabled = False
+        runtime_state.delegated_write_operation_ids = frozenset()
         runtime_state.last_accessed_monotonic = time.monotonic()
         if session is not None:
             await asyncio.to_thread(self._close_swival_session, session)
@@ -400,6 +413,7 @@ class SelfManagementBuiltInAgentService:
         conversation_id: str,
         message: str,
         allow_write_tools: bool,
+        allowed_write_operation_ids: frozenset[str] = frozenset(),
     ) -> _ExecutedBuiltInRun:
         if not self.is_configured():
             raise SelfManagementBuiltInAgentConfigError(
@@ -426,18 +440,31 @@ class SelfManagementBuiltInAgentService:
         )
         tool_definitions: tuple[SelfManagementToolDefinition, ...]
         async with runtime_state.get_lock():
-            effective_write_tools = (
-                allow_write_tools or runtime_state.auto_approve_writes
+            effective_write_operation_ids = (
+                allowed_write_operation_ids
+                if allowed_write_operation_ids
+                else (
+                    frozenset(
+                        definition.operation_id
+                        for definition in self._list_write_tool_definitions()
+                    )
+                    if allow_write_tools
+                    else runtime_state.auto_approve_write_operation_ids
+                )
+            )
+            effective_write_tools = allow_write_tools or bool(
+                effective_write_operation_ids
             )
             tool_definitions = self._select_run_tool_definitions(
-                allow_write_tools=effective_write_tools
+                allow_write_tools=effective_write_tools,
+                delegated_write_operation_ids=effective_write_operation_ids,
             )
             session = await self._ensure_conversation_session(
                 db=db,
                 runtime_state=runtime_state,
                 current_user=current_user,
                 conversation_id=local_session_id,
-                write_tools_enabled=effective_write_tools,
+                delegated_write_operation_ids=effective_write_operation_ids,
             )
             try:
                 result = await asyncio.to_thread(session.ask, message)
@@ -456,16 +483,26 @@ class SelfManagementBuiltInAgentService:
         answer = cast(str | None, getattr(result, "answer", None))
         exhausted = bool(getattr(result, "exhausted", False))
         if not effective_write_tools and self._answer_requests_write_approval(answer):
+            requested_write_operation_ids = self._extract_requested_write_operation_ids(
+                answer
+            )
+            if not requested_write_operation_ids:
+                await self._invalidate_runtime_session(runtime_state)
+                raise SelfManagementBuiltInAgentUnavailableError(
+                    "swival built-in agent requested write approval without "
+                    "declaring any write operations"
+                )
             interrupt = self._build_permission_interrupt(
                 current_user=current_user,
                 conversation_id=local_session_id,
                 message=message,
                 answer=answer,
+                allowed_write_operation_ids=requested_write_operation_ids,
             )
             return _ExecutedBuiltInRun(
                 result=SelfManagementBuiltInAgentRunResult(
                     status=SelfManagementBuiltInAgentRunStatus.INTERRUPTED,
-                    answer=self._strip_write_approval_sentinel(answer),
+                    answer=self._strip_write_approval_metadata(answer),
                     exhausted=exhausted,
                     runtime="swival",
                     resources=profile.resources,
@@ -536,6 +573,11 @@ class SelfManagementBuiltInAgentService:
             raise SelfManagementBuiltInAgentUnavailableError(
                 "The write approval request is missing the original prompt."
             )
+        approved_operation_ids = get_self_management_allowed_operations(claims)
+        if not approved_operation_ids:
+            raise SelfManagementBuiltInAgentUnavailableError(
+                "The write approval request is missing the approved operations."
+            )
 
         if reply == "reject":
             result = SelfManagementBuiltInAgentRunResult(
@@ -579,7 +621,7 @@ class SelfManagementBuiltInAgentService:
                 conversation_id=conversation_id,
             )
             async with runtime_state.get_lock():
-                runtime_state.auto_approve_writes = True
+                runtime_state.auto_approve_write_operation_ids = approved_operation_ids
                 runtime_state.last_accessed_monotonic = time.monotonic()
 
         executed = await self._execute_run(
@@ -588,6 +630,7 @@ class SelfManagementBuiltInAgentService:
             conversation_id=conversation_id,
             message=interrupt_message,
             allow_write_tools=True,
+            allowed_write_operation_ids=approved_operation_ids,
         )
         await self._persist_interrupt_resolution(
             db=db,
@@ -641,8 +684,20 @@ class SelfManagementBuiltInAgentService:
         )
         return f"{base}{mount_path}/"
 
-    def _build_system_prompt(self, *, allow_write_tools: bool) -> str:
+    def _build_system_prompt(
+        self,
+        *,
+        allow_write_tools: bool,
+        delegated_write_operation_ids: frozenset[str] = frozenset(),
+    ) -> str:
         if allow_write_tools:
+            if delegated_write_operation_ids:
+                approved_operations = ", ".join(sorted(delegated_write_operation_ids))
+                return (
+                    _DEFAULT_SYSTEM_PROMPT
+                    + _WRITE_ENABLED_APPENDIX
+                    + f" The currently approved write operations are: {approved_operations}."
+                )
             return _DEFAULT_SYSTEM_PROMPT + _WRITE_ENABLED_APPENDIX
         return _DEFAULT_SYSTEM_PROMPT + _READ_ONLY_APPENDIX
 
@@ -651,11 +706,59 @@ class SelfManagementBuiltInAgentService:
             return False
         return _WRITE_APPROVAL_SENTINEL in answer
 
-    def _strip_write_approval_sentinel(self, answer: str | None) -> str | None:
+    def _strip_write_approval_metadata(self, answer: str | None) -> str | None:
         if not isinstance(answer, str):
             return answer
-        stripped = answer.replace(_WRITE_APPROVAL_SENTINEL, "").strip()
+        stripped_lines = [
+            line.strip()
+            for line in answer.splitlines()
+            if line.strip()
+            and line.strip() != _WRITE_APPROVAL_SENTINEL
+            and not (
+                line.strip().startswith(_WRITE_APPROVAL_OPERATIONS_PREFIX)
+                and line.strip().endswith(_WRITE_APPROVAL_OPERATIONS_SUFFIX)
+            )
+        ]
+        stripped = "\n".join(stripped_lines).strip()
         return stripped or None
+
+    def _list_write_tool_definitions(self) -> tuple[SelfManagementToolDefinition, ...]:
+        return tuple(
+            definition
+            for definition in list_self_management_mcp_tool_definitions()
+            if definition.confirmation_policy != SelfManagementConfirmationPolicy.NONE
+        )
+
+    def _extract_requested_write_operation_ids(
+        self,
+        answer: str | None,
+    ) -> tuple[str, ...]:
+        if not isinstance(answer, str):
+            return ()
+        allowed_operation_ids = {
+            definition.operation_id
+            for definition in self._list_write_tool_definitions()
+        }
+        requested_operation_ids: list[str] = []
+        for raw_line in answer.splitlines():
+            line = raw_line.strip()
+            if not (
+                line.startswith(_WRITE_APPROVAL_OPERATIONS_PREFIX)
+                and line.endswith(_WRITE_APPROVAL_OPERATIONS_SUFFIX)
+            ):
+                continue
+            raw_payload = line.removeprefix(
+                _WRITE_APPROVAL_OPERATIONS_PREFIX
+            ).removesuffix(_WRITE_APPROVAL_OPERATIONS_SUFFIX)
+            for raw_operation_id in raw_payload.split(","):
+                operation_id = raw_operation_id.strip()
+                if (
+                    operation_id
+                    and operation_id in allowed_operation_ids
+                    and operation_id not in requested_operation_ids
+                ):
+                    requested_operation_ids.append(operation_id)
+        return tuple(requested_operation_ids)
 
     def _build_permission_interrupt(
         self,
@@ -664,39 +767,52 @@ class SelfManagementBuiltInAgentService:
         conversation_id: str,
         message: str,
         answer: str | None,
+        allowed_write_operation_ids: tuple[str, ...],
     ) -> SelfManagementBuiltInAgentInterrupt:
-        write_tool_names = tuple(
-            definition.tool_name
-            for definition in self._select_run_tool_definitions(allow_write_tools=True)
-            if definition.confirmation_policy != SelfManagementConfirmationPolicy.NONE
+        write_tool_definitions = tuple(
+            definition
+            for definition in self._list_write_tool_definitions()
+            if definition.operation_id in allowed_write_operation_ids
         )
         request_id = create_self_management_interrupt_token(
             cast(Any, current_user.id),
             conversation_id=conversation_id,
             message=message,
-            tool_names=write_tool_names,
+            tool_names=tuple(
+                definition.tool_name for definition in write_tool_definitions
+            ),
+            allowed_operations=allowed_write_operation_ids,
         )
-        display_message = self._strip_write_approval_sentinel(answer) or (
+        display_message = self._strip_write_approval_metadata(answer) or (
             "This change requires explicit write approval before the built-in agent "
             "can continue."
         )
         return SelfManagementBuiltInAgentInterrupt(
             request_id=request_id,
             permission="self-management-write",
-            patterns=write_tool_names,
+            patterns=tuple(
+                definition.tool_name for definition in write_tool_definitions
+            ),
             display_message=display_message,
         )
 
     def _select_run_tool_definitions(
-        self, *, allow_write_tools: bool
+        self,
+        *,
+        allow_write_tools: bool,
+        delegated_write_operation_ids: frozenset[str] = frozenset(),
     ) -> tuple[SelfManagementToolDefinition, ...]:
         tool_definitions = list_self_management_mcp_tool_definitions()
-        if allow_write_tools:
+        if allow_write_tools and not delegated_write_operation_ids:
             return tool_definitions
+        allowed_write_operation_ids = (
+            delegated_write_operation_ids if allow_write_tools else frozenset()
+        )
         return tuple(
             definition
             for definition in tool_definitions
             if definition.confirmation_policy == SelfManagementConfirmationPolicy.NONE
+            or definition.operation_id in allowed_write_operation_ids
         )
 
     async def _ensure_local_builtin_session(
@@ -904,11 +1020,11 @@ class SelfManagementBuiltInAgentService:
         runtime_state: _ConversationRuntimeState,
         current_user: User,
         conversation_id: str,
-        write_tools_enabled: bool,
+        delegated_write_operation_ids: frozenset[str],
     ) -> Any:
         if not self._runtime_session_needs_refresh(
             runtime_state=runtime_state,
-            write_tools_enabled=write_tools_enabled,
+            delegated_write_operation_ids=delegated_write_operation_ids,
         ):
             runtime_state.last_accessed_monotonic = time.monotonic()
             return runtime_state.session
@@ -917,7 +1033,7 @@ class SelfManagementBuiltInAgentService:
         new_session = await asyncio.to_thread(
             self._create_swival_session,
             current_user=current_user,
-            write_tools_enabled=write_tools_enabled,
+            delegated_write_operation_ids=delegated_write_operation_ids,
         )
         if previous_session is not None:
             self._transfer_conversation_state(previous_session, new_session)
@@ -931,7 +1047,7 @@ class SelfManagementBuiltInAgentService:
             )
 
         runtime_state.session = new_session
-        runtime_state.write_tools_enabled = write_tools_enabled
+        runtime_state.delegated_write_operation_ids = delegated_write_operation_ids
         runtime_state.delegated_token_expires_at_monotonic = float(
             getattr(
                 new_session,
@@ -1070,11 +1186,13 @@ class SelfManagementBuiltInAgentService:
         self,
         *,
         current_user: User,
-        write_tools_enabled: bool,
+        delegated_write_operation_ids: frozenset[str],
     ) -> Any:
+        write_tools_enabled = bool(delegated_write_operation_ids)
         session_cls = self._load_swival_session_cls()
         tool_definitions = self._select_run_tool_definitions(
-            allow_write_tools=write_tools_enabled
+            allow_write_tools=write_tools_enabled,
+            delegated_write_operation_ids=delegated_write_operation_ids,
         )
         delegated_token_ttl_seconds = self._delegated_token_ttl_seconds()
         token = create_self_management_access_token(
@@ -1094,7 +1212,8 @@ class SelfManagementBuiltInAgentService:
             max_output_tokens=settings.self_management_swival_max_output_tokens,
             reasoning_effort=settings.self_management_swival_reasoning_effort,
             system_prompt=self._build_system_prompt(
-                allow_write_tools=write_tools_enabled
+                allow_write_tools=write_tools_enabled,
+                delegated_write_operation_ids=delegated_write_operation_ids,
             ),
             files="none",
             commands="none",

--- a/backend/app/features/self_management_agent/service.py
+++ b/backend/app/features/self_management_agent/service.py
@@ -1093,7 +1093,9 @@ class SelfManagementBuiltInAgentService:
             delegated_write_operation_ids=delegated_write_operation_ids,
         )
         if previous_session is not None:
-            self._transfer_conversation_state(previous_session, new_session)
+            await asyncio.to_thread(
+                self._transfer_conversation_state, previous_session, new_session
+            )
             await asyncio.to_thread(self._close_swival_session, previous_session)
         else:
             await self._best_effort_rehydrate_swival_session(
@@ -1141,8 +1143,13 @@ class SelfManagementBuiltInAgentService:
         existing_state = cast(
             dict[str, Any] | None, getattr(session, "_conv_state", None)
         )
-        if isinstance(existing_state, dict) and existing_state.get("messages"):
-            return
+        if isinstance(existing_state, dict):
+            existing_messages = existing_state.get("messages")
+            if isinstance(existing_messages, list) and any(
+                not (isinstance(message, dict) and message.get("role") == "system")
+                for message in existing_messages
+            ):
+                return
 
         make_state = getattr(session, "_make_per_run_state", None)
         if callable(make_state):
@@ -1309,14 +1316,82 @@ class SelfManagementBuiltInAgentService:
                 continue
         return str(user_runtime_dir.resolve())
 
+    def _build_session_conversation_state(
+        self,
+        session: Any,
+    ) -> dict[str, Any] | None:
+        conv_state = getattr(session, "_conv_state", None)
+        if isinstance(conv_state, dict):
+            return copy.deepcopy(conv_state)
+
+        setup = getattr(session, "_setup", None)
+        if callable(setup):
+            try:
+                setup()
+            except Exception:
+                return None
+            conv_state = getattr(session, "_conv_state", None)
+            if isinstance(conv_state, dict):
+                return copy.deepcopy(conv_state)
+
+        make_state = getattr(session, "_make_per_run_state", None)
+        if not callable(make_state):
+            return None
+
+        system_content = None
+        system_with_memory = getattr(session, "_system_with_memory", None)
+        if callable(system_with_memory):
+            try:
+                system_content = system_with_memory("", policy="interactive")
+            except TypeError:
+                system_content = system_with_memory("")
+            except Exception:
+                system_content = None
+        try:
+            return cast(
+                dict[str, Any],
+                make_state(system_content=cast(str | None, system_content)),
+            )
+        except TypeError:
+            return cast(dict[str, Any], make_state())
+        except Exception:
+            return None
+
     def _transfer_conversation_state(
         self,
         previous_session: Any,
         next_session: Any,
     ) -> None:
-        conv_state = getattr(previous_session, "_conv_state", None)
-        if conv_state is not None:
-            setattr(next_session, "_conv_state", copy.deepcopy(conv_state))
+        previous_state = self._build_session_conversation_state(previous_session)
+        if previous_state is not None:
+            next_state = self._build_session_conversation_state(next_session)
+            previous_messages = previous_state.get("messages")
+            next_messages = next_state.get("messages") if next_state else None
+            previous_non_system_messages = (
+                [
+                    copy.deepcopy(message)
+                    for message in previous_messages
+                    if not (
+                        isinstance(message, dict) and message.get("role") == "system"
+                    )
+                ]
+                if isinstance(previous_messages, list)
+                else []
+            )
+            next_system_messages = (
+                [
+                    copy.deepcopy(message)
+                    for message in next_messages
+                    if isinstance(message, dict) and message.get("role") == "system"
+                ]
+                if isinstance(next_messages, list)
+                else []
+            )
+            transferred_state = copy.deepcopy(next_state) if next_state else {}
+            transferred_state["messages"] = (
+                next_system_messages + previous_non_system_messages
+            )
+            setattr(next_session, "_conv_state", transferred_state)
         trace_session_id = getattr(previous_session, "_trace_session_id", None)
         if isinstance(trace_session_id, str) and trace_session_id.strip():
             setattr(next_session, "_trace_session_id", trace_session_id)

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -151,6 +151,16 @@ def _new_conversation_id() -> str:
     return str(uuid4())
 
 
+def _approval_answer(message: str, *operation_ids: str) -> str:
+    return (
+        f"{message}\n"
+        f"{_WRITE_APPROVAL_SENTINEL}\n"
+        "[[SELF_MANAGEMENT_WRITE_OPERATIONS:"
+        f"{','.join(operation_ids)}"
+        "]]"
+    )
+
+
 async def test_built_in_agent_profile_exposes_full_available_tool_surface(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -752,9 +762,9 @@ async def test_built_in_agent_interrupt_and_resolution_are_persisted(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -820,9 +830,9 @@ async def test_built_in_agent_permission_reply_persists_supplied_agent_message_i
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -869,9 +879,9 @@ async def test_built_in_agent_can_recover_unresolved_permission_interrupts(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -894,23 +904,7 @@ async def test_built_in_agent_can_recover_unresolved_permission_interrupts(
     assert recovered[0].session_id == conversation_id
     assert recovered[0].type == "permission"
     assert recovered[0].details["permission"] == "self-management-write"
-    assert recovered[0].details["patterns"] == [
-        "self.agents.check_health",
-        "self.agents.check_health_all",
-        "self.agents.create",
-        "self.agents.delete",
-        "self.agents.update_config",
-        "self.jobs.create",
-        "self.jobs.delete",
-        "self.jobs.pause",
-        "self.jobs.resume",
-        "self.jobs.update",
-        "self.jobs.update_prompt",
-        "self.jobs.update_schedule",
-        "self.sessions.archive",
-        "self.sessions.unarchive",
-        "self.sessions.update",
-    ]
+    assert recovered[0].details["patterns"] == ["self.jobs.pause"]
 
 
 async def test_built_in_agent_recovery_ignores_resolved_interrupts(
@@ -922,9 +916,9 @@ async def test_built_in_agent_recovery_ignores_resolved_interrupts(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -991,9 +985,9 @@ async def test_built_in_agent_read_only_run_can_raise_permission_interrupt(
     _reset_built_in_agent_runtime()
     _configure_swival_settings(monkeypatch)
     _install_fake_swival(monkeypatch)
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
@@ -1013,23 +1007,7 @@ async def test_built_in_agent_read_only_run_can_raise_permission_interrupt(
     assert result.write_tools_enabled is False
     assert result.interrupt is not None
     assert result.interrupt.permission == "self-management-write"
-    assert result.interrupt.patterns == (
-        "self.agents.check_health",
-        "self.agents.check_health_all",
-        "self.agents.create",
-        "self.agents.delete",
-        "self.agents.update_config",
-        "self.jobs.create",
-        "self.jobs.delete",
-        "self.jobs.pause",
-        "self.jobs.resume",
-        "self.jobs.update",
-        "self.jobs.update_prompt",
-        "self.jobs.update_schedule",
-        "self.sessions.archive",
-        "self.sessions.unarchive",
-        "self.sessions.update",
-    )
+    assert result.interrupt.patterns == ("self.jobs.pause",)
     claims = verify_jwt_token_claims(
         result.interrupt.request_id,
         expected_type="self_management_interrupt",
@@ -1037,22 +1015,9 @@ async def test_built_in_agent_read_only_run_can_raise_permission_interrupt(
     assert claims is not None
     assert claims.subject == str(user.id)
     assert get_self_management_interrupt_message(claims) == "Pause my job"
-    assert get_self_management_interrupt_tool_names(claims) == (
-        "self.agents.check_health",
-        "self.agents.check_health_all",
-        "self.agents.create",
-        "self.agents.delete",
-        "self.agents.update_config",
-        "self.jobs.create",
-        "self.jobs.delete",
-        "self.jobs.pause",
-        "self.jobs.resume",
-        "self.jobs.update",
-        "self.jobs.update_prompt",
-        "self.jobs.update_schedule",
-        "self.sessions.archive",
-        "self.sessions.unarchive",
-        "self.sessions.update",
+    assert get_self_management_interrupt_tool_names(claims) == ("self.jobs.pause",)
+    assert get_self_management_allowed_operations(claims) == frozenset(
+        {"self.jobs.pause"}
     )
 
 
@@ -1070,6 +1035,7 @@ async def test_built_in_agent_permission_reply_once_resumes_with_write_tools(
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
+        allowed_write_operation_ids=("self.jobs.pause",),
     )
 
     result = await self_management_built_in_agent_service.reply_permission_interrupt(
@@ -1082,6 +1048,7 @@ async def test_built_in_agent_permission_reply_once_resumes_with_write_tools(
     assert result.status == "completed"
     assert result.write_tools_enabled is True
     assert "self.jobs.pause" in result.tool_names
+    assert "self.sessions.update" not in result.tool_names
     assert _FakeSwivalSession.ask_call_count == 1
     assert _FakeSwivalSession.last_message == "Pause my job"
     assert _FakeSwivalSession.last_init_kwargs is not None
@@ -1100,9 +1067,9 @@ async def test_built_in_agent_permission_reply_rejects_repeated_write_approval(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -1114,9 +1081,9 @@ async def test_built_in_agent_permission_reply_rejects_repeated_write_approval(
     )
     assert interrupt_result.interrupt is not None
 
-    _FakeSwivalSession.next_answer = (
-        "I still need write approval before I can pause that job.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I still need write approval before I can pause that job.",
+        "self.jobs.pause",
     )
 
     with pytest.raises(SelfManagementBuiltInAgentUnavailableError) as excinfo:
@@ -1165,6 +1132,7 @@ async def test_built_in_agent_permission_reply_reject_returns_no_change_result(
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
+        allowed_write_operation_ids=("self.jobs.pause",),
     )
 
     result = await self_management_built_in_agent_service.reply_permission_interrupt(
@@ -1191,9 +1159,9 @@ async def test_built_in_agent_permission_reply_route_resumes_or_rejects(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     async with create_test_client(
@@ -1233,9 +1201,9 @@ async def test_built_in_agent_interrupt_recovery_route_returns_unresolved_interr
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     await self_management_built_in_agent_service.run(
@@ -1267,23 +1235,7 @@ async def test_built_in_agent_interrupt_recovery_route_returns_unresolved_interr
             "phase": "asked",
             "details": {
                 "permission": "self-management-write",
-                "patterns": [
-                    "self.agents.check_health",
-                    "self.agents.check_health_all",
-                    "self.agents.create",
-                    "self.agents.delete",
-                    "self.agents.update_config",
-                    "self.jobs.create",
-                    "self.jobs.delete",
-                    "self.jobs.pause",
-                    "self.jobs.resume",
-                    "self.jobs.update",
-                    "self.jobs.update_prompt",
-                    "self.jobs.update_schedule",
-                    "self.sessions.archive",
-                    "self.sessions.unarchive",
-                    "self.sessions.update",
-                ],
+                "patterns": ["self.jobs.pause"],
                 "displayMessage": "I can pause the requested job after you approve write access.",
             },
         }
@@ -1301,9 +1253,9 @@ async def test_built_in_agent_interrupt_recovery_route_persists_expired_interrup
     user = await create_user(async_db_session)
     persisted_user_id = cast(Any, user.id)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -1373,9 +1325,9 @@ async def test_built_in_agent_recovery_skips_invalid_interrupt_requests(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -1437,9 +1389,9 @@ async def test_built_in_agent_recovery_skips_interrupts_for_other_conversations(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    _FakeSwivalSession.next_answer = (
-        "I can pause the requested job after you approve write access.\n"
-        f"{_WRITE_APPROVAL_SENTINEL}"
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "I can pause the requested job after you approve write access.",
+        "self.jobs.pause",
     )
 
     interrupt_result = await self_management_built_in_agent_service.run(
@@ -1556,6 +1508,7 @@ async def test_built_in_agent_permission_reply_route_rejects_other_user_interrup
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
+        allowed_write_operation_ids=("self.jobs.pause",),
     )
 
     async with create_test_client(
@@ -1659,6 +1612,7 @@ async def test_built_in_agent_permission_reply_always_enables_session_scoped_wri
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
+        allowed_write_operation_ids=("self.jobs.pause",),
     )
 
     always_result = (
@@ -1680,6 +1634,7 @@ async def test_built_in_agent_permission_reply_always_enables_session_scoped_wri
     assert always_result.write_tools_enabled is True
     assert follow_up_result.write_tools_enabled is True
     assert "self.jobs.pause" in follow_up_result.tool_names
+    assert "self.sessions.update" not in follow_up_result.tool_names
     assert _FakeSwivalSession.instance_count == 1
     assert _FakeSwivalSession.ask_call_count == 2
     assert _FakeSwivalSession.last_init_kwargs is not None

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -48,8 +48,33 @@ class _FakeSwivalSession:
         type(self).last_init_kwargs = dict(kwargs)
         type(self).instance_count += 1
         type(self).instances.append(self)
+        self._system_prompt = cast(str, kwargs.get("system_prompt", ""))
         self._conv_state: dict[str, object] | None = None
         self.closed = False
+
+    def _setup(self) -> None:
+        if self._conv_state is None:
+            self._conv_state = self._make_per_run_state(
+                system_content=self._system_with_memory("", policy="interactive")
+            )
+
+    def _system_with_memory(
+        self,
+        _question: str,
+        report: object | None = None,
+        policy: str = "autonomous",
+    ) -> str:
+        del report, policy
+        return self._system_prompt
+
+    def _make_per_run_state(
+        self,
+        system_content: str | None = None,
+    ) -> dict[str, object]:
+        messages: list[dict[str, str]] = []
+        if isinstance(system_content, str) and system_content.strip():
+            messages.append({"role": "system", "content": system_content})
+        return {"messages": messages}
 
     def ask(self, message: str) -> object:
         if type(self).next_error is not None:
@@ -59,7 +84,7 @@ class _FakeSwivalSession:
         type(self).last_message = message
         type(self).ask_call_count += 1
         if self._conv_state is None:
-            self._conv_state = {"messages": []}
+            self._setup()
         messages = cast(list[dict[str, str]], self._conv_state["messages"])
         messages.append({"role": "user", "content": message})
         messages.append({"role": "assistant", "content": type(self).next_answer})
@@ -375,9 +400,13 @@ async def test_built_in_agent_rebuilds_session_when_delegated_token_expires(
     assert _FakeSwivalSession.instance_count == 2
     assert _FakeSwivalSession.instances[0].closed is True
     assert _FakeSwivalSession.instances[1]._conv_state is not None
+    transferred_messages = cast(
+        list[dict[str, str]], _FakeSwivalSession.instances[1]._conv_state["messages"]
+    )
+    assert transferred_messages[0]["role"] == "system"
     assert cast(
         list[dict[str, str]], _FakeSwivalSession.instances[1]._conv_state["messages"]
-    )[:2] == [
+    )[1:3] == [
         {"role": "user", "content": "List my jobs"},
         {"role": "assistant", "content": "Built-in agent reply"},
     ]
@@ -1058,7 +1087,7 @@ async def test_built_in_agent_permission_reply_once_resumes_with_write_tools(
     assert _FakeSwivalSession.instance_count == 1
 
 
-async def test_built_in_agent_permission_reply_rejects_repeated_write_approval(
+async def test_built_in_agent_session_refresh_preserves_new_system_prompt(
     async_db_session,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1081,40 +1110,37 @@ async def test_built_in_agent_permission_reply_rejects_repeated_write_approval(
     )
     assert interrupt_result.interrupt is not None
 
-    _FakeSwivalSession.next_answer = _approval_answer(
-        "I still need write approval before I can pause that job.",
-        "self.jobs.pause",
-    )
+    _FakeSwivalSession.next_answer = "Paused the requested job."
 
-    with pytest.raises(SelfManagementBuiltInAgentUnavailableError) as excinfo:
-        await self_management_built_in_agent_service.reply_permission_interrupt(
-            db=async_db_session,
-            current_user=user,
-            request_id=interrupt_result.interrupt.request_id,
-            reply="once",
-        )
-
-    assert "requested write approval after write tools were enabled" in str(
-        excinfo.value
-    )
-
-    messages, _extra, _db_mutated = await session_hub_service.list_messages(
-        async_db_session,
-        user_id=cast(Any, user.id),
-        conversation_id=conversation_id,
-        before=None,
-        limit=20,
-    )
-    assert [item["role"] for item in messages] == ["user", "agent"]
-    assert messages[1]["status"] == "interrupted"
-
-    recovered = await self_management_built_in_agent_service.recover_pending_interrupts(
+    result = await self_management_built_in_agent_service.reply_permission_interrupt(
         db=async_db_session,
         current_user=user,
-        conversation_id=conversation_id,
+        request_id=interrupt_result.interrupt.request_id,
+        reply="once",
     )
-    assert [item.request_id for item in recovered] == [
-        interrupt_result.interrupt.request_id
+
+    assert result.status == "completed"
+    assert _FakeSwivalSession.instance_count == 2
+    assert _FakeSwivalSession.instances[1]._conv_state is not None
+    next_messages = cast(
+        list[dict[str, str]], _FakeSwivalSession.instances[1]._conv_state["messages"]
+    )
+    assert next_messages[0]["role"] == "system"
+    assert (
+        "This run includes explicitly approved write tools."
+        in next_messages[0]["content"]
+    )
+    assert "The currently approved write operations are: self.jobs.pause." in (
+        next_messages[0]["content"]
+    )
+    assert next_messages[1:3] == [
+        {"role": "user", "content": "Pause my job"},
+        {
+            "role": "assistant",
+            "content": "I can pause the requested job after you approve write access.\n"
+            "[[SELF_MANAGEMENT_WRITE_APPROVAL_REQUIRED]]\n"
+            "[[SELF_MANAGEMENT_WRITE_OPERATIONS:self.jobs.pause]]",
+        },
     ]
 
 
@@ -1554,7 +1580,7 @@ async def test_built_in_agent_reuses_conversation_session_for_follow_up_turns(
     assert _FakeSwivalSession.instance_count == 1
     assert _FakeSwivalSession.ask_call_count == 2
     assert _FakeSwivalSession.instances[0]._conv_state is not None
-    assert len(_FakeSwivalSession.instances[0]._conv_state["messages"]) == 4
+    assert len(_FakeSwivalSession.instances[0]._conv_state["messages"]) == 5
 
 
 async def test_built_in_agent_rehydrates_runtime_from_durable_history_after_registry_loss(
@@ -1587,12 +1613,16 @@ async def test_built_in_agent_rehydrates_runtime_from_durable_history_after_regi
     assert _FakeSwivalSession.instance_count == 2
     assert _FakeSwivalSession.ask_call_count == 2
     assert _FakeSwivalSession.instances[1]._conv_state is not None
-    assert len(_FakeSwivalSession.instances[1]._conv_state["messages"]) == 4
+    assert len(_FakeSwivalSession.instances[1]._conv_state["messages"]) == 5
     assert _FakeSwivalSession.instances[1]._conv_state["messages"][0] == {
+        "role": "system",
+        "content": cast(str, _FakeSwivalSession.instances[1]._system_prompt),
+    }
+    assert _FakeSwivalSession.instances[1]._conv_state["messages"][1] == {
         "role": "user",
         "content": "List my jobs",
     }
-    assert _FakeSwivalSession.instances[1]._conv_state["messages"][1] == {
+    assert _FakeSwivalSession.instances[1]._conv_state["messages"][2] == {
         "role": "assistant",
         "content": "Built-in agent reply",
     }

--- a/backend/tests/runtime/test_self_management_built_in_agent.py
+++ b/backend/tests/runtime/test_self_management_built_in_agent.py
@@ -1643,6 +1643,64 @@ async def test_built_in_agent_permission_reply_always_enables_session_scoped_wri
     ] == ("http://internal-mcp/mcp-write/")
 
 
+async def test_built_in_agent_requests_additional_approval_for_new_write_operations(
+    async_db_session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reset_built_in_agent_runtime()
+    _configure_swival_settings(monkeypatch)
+    _install_fake_swival(monkeypatch)
+    user = await create_user(async_db_session)
+    conversation_id = _new_conversation_id()
+    interrupt = self_management_built_in_agent_service._build_permission_interrupt(
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Pause my job",
+        answer="Need approval",
+        allowed_write_operation_ids=("self.jobs.pause",),
+    )
+
+    await self_management_built_in_agent_service.reply_permission_interrupt(
+        db=async_db_session,
+        current_user=user,
+        request_id=interrupt.request_id,
+        reply="always",
+    )
+
+    _FakeSwivalSession.next_answer = _approval_answer(
+        "Deleting that agent requires additional approval.",
+        "self.agents.delete",
+    )
+    follow_up_result = await self_management_built_in_agent_service.run(
+        db=async_db_session,
+        current_user=user,
+        conversation_id=conversation_id,
+        message="Delete my agent",
+        allow_write_tools=False,
+    )
+
+    assert follow_up_result.status == "interrupted"
+    assert follow_up_result.write_tools_enabled is True
+    assert follow_up_result.interrupt is not None
+    assert follow_up_result.interrupt.patterns == ("self.agents.delete",)
+
+    _FakeSwivalSession.next_answer = "Deleted the requested agent."
+    resumed_result = (
+        await self_management_built_in_agent_service.reply_permission_interrupt(
+            db=async_db_session,
+            current_user=user,
+            request_id=follow_up_result.interrupt.request_id,
+            reply="once",
+        )
+    )
+
+    assert resumed_result.status == "completed"
+    assert resumed_result.write_tools_enabled is True
+    assert "self.jobs.pause" in resumed_result.tool_names
+    assert "self.agents.delete" in resumed_result.tool_names
+    assert "self.sessions.update" not in resumed_result.tool_names
+
+
 async def test_built_in_agent_runtime_patches_private_swival_mcp_tool_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -346,22 +346,25 @@ export function useChatInterruptController({
     (reply: "once" | "always" | "reject") => {
       if (
         !activeAgentId ||
-        !agentSource ||
         !conversationId ||
         !pendingInterrupt ||
         pendingInterrupt.type !== "permission"
       ) {
         return;
       }
+      if (!onPermissionReplyOverride && !agentSource) {
+        return;
+      }
+      const replyAgentSource = agentSource;
       const requestId = pendingInterrupt.requestId;
       runInterruptAction(
         `permission:${reply}`,
         async () => {
           if (onPermissionReplyOverride) {
             await onPermissionReplyOverride({ requestId, reply });
-          } else {
+          } else if (replyAgentSource) {
             await replyPermissionInterrupt({
-              source: agentSource,
+              source: replyAgentSource,
               agentId: activeAgentId,
               requestId,
               reply,
@@ -369,6 +372,8 @@ export function useChatInterruptController({
                 ? { workingDirectory: normalizedWorkingDirectory }
                 : {}),
             });
+          } else {
+            return;
           }
           acknowledgeLocalInterruptResolution(
             requestId,

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -57,6 +57,7 @@ import {
 } from "@/lib/chat-utils";
 import {
   addConversationMessage,
+  removeConversationMessage,
   updateConversationMessage,
 } from "@/lib/chatHistoryCache";
 import {
@@ -539,13 +540,7 @@ export function useChatScreenController({
           }),
         );
       } catch (error) {
-        updateConversationMessage(conversationId, nextAgentMessageId, {
-          content:
-            error instanceof Error
-              ? error.message
-              : "Built-in assistant request failed.",
-          status: "error",
-        });
+        removeConversationMessage(conversationId, nextAgentMessageId);
         applyBuiltInAgentSessionUpdate(
           conversationId,
           activeAgentId,
@@ -553,11 +548,8 @@ export function useChatScreenController({
             ...current,
             agentId: activeAgentId,
             lastActiveAt: new Date().toISOString(),
-            streamState: "error",
-            lastStreamError:
-              error instanceof Error
-                ? error.message
-                : "Built-in assistant request failed.",
+            streamState: "idle",
+            lastStreamError: null,
           }),
         );
         throw error;

--- a/frontend/lib/chatHistoryCache.ts
+++ b/frontend/lib/chatHistoryCache.ts
@@ -98,6 +98,17 @@ export const updateConversationMessage = (
   writeMessages(conversationId, next);
 };
 
+export const removeConversationMessage = (
+  conversationId: string,
+  messageId: string,
+) => {
+  const targetId = normalizeMessageId(messageId);
+  if (!targetId) return;
+  const current = getConversationMessages(conversationId);
+  const next = current.filter((item) => item.id !== targetId);
+  writeMessages(conversationId, next);
+};
+
 export const updateConversationMessageWithUpdater = (
   conversationId: string,
   messageId: string,

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -162,12 +162,26 @@ jest.mock("@/components/chat/ChatTimelinePanel", () => ({
               first.
             </Text>
             {props.pendingInterrupt.type === "permission" ? (
-              <Pressable
-                testID="interrupt-permission-once"
-                onPress={() => props.onPermissionReply?.("once")}
-              >
-                <Text>Allow once</Text>
-              </Pressable>
+              <>
+                <Pressable
+                  testID="interrupt-permission-once"
+                  onPress={() => props.onPermissionReply?.("once")}
+                >
+                  <Text>Allow once</Text>
+                </Pressable>
+                <Pressable
+                  testID="interrupt-permission-always"
+                  onPress={() => props.onPermissionReply?.("always")}
+                >
+                  <Text>Always allow</Text>
+                </Pressable>
+                <Pressable
+                  testID="interrupt-permission-reject"
+                  onPress={() => props.onPermissionReply?.("reject")}
+                >
+                  <Text>Reject</Text>
+                </Pressable>
+              </>
             ) : null}
             {props.pendingInterrupt.type === "question" ? (
               <>
@@ -350,7 +364,7 @@ jest.mock("@/hooks/useAgentsCatalogQuery", () => ({
       },
       {
         id: SELF_MANAGEMENT_AGENT_ID,
-        source: "shared",
+        source: "builtin",
         name: "A2A Client Hub Assistant",
         cardUrl: "builtin://self-management-assistant",
         status: "success",
@@ -1626,22 +1640,29 @@ describe("ChatScreen interrupt handling", () => {
     });
   });
 
-  it("submits built-in permission replies through the existing interrupt action card", async () => {
-    mockChatState.sessions[conversationId] = {
-      ...baseSession(),
-      agentId: SELF_MANAGEMENT_AGENT_ID,
-      pendingInterrupt: {
-        requestId: "builtin-perm-2",
-        type: "permission",
-        phase: "asked",
-        details: {
-          permission: "self-management-write",
-          patterns: ["self.jobs.pause"],
-          displayMessage: "Approve write access to continue.",
-        },
-      },
-      pendingInterrupts: [
-        {
+  it.each([
+    {
+      buttonTestId: "interrupt-permission-once",
+      reply: "once" as const,
+      expectedResolution: "replied",
+    },
+    {
+      buttonTestId: "interrupt-permission-always",
+      reply: "always" as const,
+      expectedResolution: "replied",
+    },
+    {
+      buttonTestId: "interrupt-permission-reject",
+      reply: "reject" as const,
+      expectedResolution: "rejected",
+    },
+  ])(
+    "submits built-in permission reply %s through the existing interrupt action card",
+    async ({ buttonTestId, reply, expectedResolution }) => {
+      mockChatState.sessions[conversationId] = {
+        ...baseSession(),
+        agentId: SELF_MANAGEMENT_AGENT_ID,
+        pendingInterrupt: {
           requestId: "builtin-perm-2",
           type: "permission",
           phase: "asked",
@@ -1651,61 +1672,75 @@ describe("ChatScreen interrupt handling", () => {
             displayMessage: "Approve write access to continue.",
           },
         },
-      ],
-    };
+        pendingInterrupts: [
+          {
+            requestId: "builtin-perm-2",
+            type: "permission",
+            phase: "asked",
+            details: {
+              permission: "self-management-write",
+              patterns: ["self.jobs.pause"],
+              displayMessage: "Approve write access to continue.",
+            },
+          },
+        ],
+      };
 
-    const tree = renderChatScreen(conversationId, SELF_MANAGEMENT_AGENT_ID);
-    const root = tree.root;
-    const permissionButton = root.findByProps({
-      testID: "interrupt-permission-once",
-    });
+      const tree = renderChatScreen(conversationId, SELF_MANAGEMENT_AGENT_ID);
+      const root = tree.root;
+      const permissionButton = root.findByProps({
+        testID: buttonTestId,
+      });
 
-    await act(async () => {
-      await permissionButton.props.onPress();
-      await Promise.resolve();
-    });
+      await act(async () => {
+        await permissionButton.props.onPress();
+        await Promise.resolve();
+      });
 
-    expect(
-      mockReplySelfManagementBuiltInAgentPermissionInterrupt,
-    ).toHaveBeenCalledWith({
-      requestId: "builtin-perm-2",
-      reply: "once",
-      agentMessageId: expect.any(String),
-    });
-    expect(mockAddConversationMessage).toHaveBeenCalledWith(
-      conversationId,
-      expect.objectContaining({
-        role: "agent",
-        content: "",
-        status: "streaming",
-      }),
-    );
-    expect(mockUpdateConversationMessage).toHaveBeenCalledWith(
-      conversationId,
-      expect.any(String),
-      expect.objectContaining({
-        content: "Write approval was handled.",
-        status: "done",
-      }),
-    );
-    expect(mockChatState.sessions[conversationId]?.pendingInterrupt).toBeNull();
-    expect(
-      mockChatState.sessions[conversationId]?.lastResolvedInterrupt,
-    ).toMatchObject({
-      requestId: "builtin-perm-2",
-      type: "permission",
-      phase: "resolved",
-      resolution: "replied",
-    });
-    expect(mockToastSuccess).toHaveBeenCalledWith(
-      "Action submitted",
-      "Authorization request handled.",
-    );
+      expect(
+        mockReplySelfManagementBuiltInAgentPermissionInterrupt,
+      ).toHaveBeenCalledWith({
+        requestId: "builtin-perm-2",
+        reply,
+        agentMessageId: expect.any(String),
+      });
+      expect(mockAddConversationMessage).toHaveBeenCalledWith(
+        conversationId,
+        expect.objectContaining({
+          role: "agent",
+          content: "",
+          status: "streaming",
+        }),
+      );
+      expect(mockUpdateConversationMessage).toHaveBeenCalledWith(
+        conversationId,
+        expect.any(String),
+        expect.objectContaining({
+          content: "Write approval was handled.",
+          status: "done",
+        }),
+      );
+      expect(
+        mockChatState.sessions[conversationId]?.pendingInterrupt,
+      ).toBeNull();
+      expect(
+        mockChatState.sessions[conversationId]?.lastResolvedInterrupt,
+      ).toMatchObject({
+        requestId: "builtin-perm-2",
+        type: "permission",
+        phase: "resolved",
+        resolution: expectedResolution,
+      });
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Action submitted",
+        "Authorization request handled.",
+      );
 
-    act(() => {
-      tree.unmount();
-    });
-  });
+      act(() => {
+        tree.unmount();
+      });
+    },
+  );
 
   it("clears stale built-in permission interrupts when the reply request expired", async () => {
     mockReplySelfManagementBuiltInAgentPermissionInterrupt.mockRejectedValueOnce(

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.tsx
@@ -20,6 +20,7 @@ const mockRunSelfManagementBuiltInAgent = jest.fn();
 const mockRecoverSelfManagementBuiltInAgentInterrupts = jest.fn();
 const mockReplySelfManagementBuiltInAgentPermissionInterrupt = jest.fn();
 const mockAddConversationMessage = jest.fn();
+const mockRemoveConversationMessage = jest.fn();
 const mockUpdateConversationMessage = jest.fn();
 const mockToastInfo = jest.fn();
 const mockToastSuccess = jest.fn();
@@ -456,6 +457,8 @@ jest.mock("@/lib/api/hubA2aAgentsUser", () => ({
 jest.mock("@/lib/chatHistoryCache", () => ({
   addConversationMessage: (...args: unknown[]) =>
     mockAddConversationMessage(...args),
+  removeConversationMessage: (...args: unknown[]) =>
+    mockRemoveConversationMessage(...args),
   updateConversationMessage: (...args: unknown[]) =>
     mockUpdateConversationMessage(...args),
 }));
@@ -527,6 +530,9 @@ describe("ChatScreen interrupt handling", () => {
     mockReplyQuestion.mockReset();
     mockRejectQuestion.mockReset();
     mockReplyElicitation.mockReset();
+    mockAddConversationMessage.mockReset();
+    mockRemoveConversationMessage.mockReset();
+    mockUpdateConversationMessage.mockReset();
     mockToastInfo.mockReset();
     mockToastSuccess.mockReset();
     mockToastError.mockReset();
@@ -1759,11 +1765,83 @@ describe("ChatScreen interrupt handling", () => {
       conversationId,
       "builtin-perm-stale-1",
     );
+    expect(mockRemoveConversationMessage).toHaveBeenCalledWith(
+      conversationId,
+      expect.any(String),
+    );
+    expect(mockUpdateConversationMessage).not.toHaveBeenCalled();
+    expect(mockChatState.sessions[conversationId]?.streamState).toBe("idle");
+    expect(mockChatState.sessions[conversationId]?.lastStreamError).toBeNull();
     expect(mockToastInfo).toHaveBeenCalledWith(
       "Interrupt closed",
       "The interrupt request expired and was removed.",
     );
     expect(mockToastError).not.toHaveBeenCalled();
+
+    act(() => {
+      tree.unmount();
+    });
+  });
+
+  it("restores built-in permission reply state after non-terminal errors", async () => {
+    mockReplySelfManagementBuiltInAgentPermissionInterrupt.mockRejectedValueOnce(
+      new ApiRequestError("Server Error", 500, {
+        errorCode: "internal_error",
+        upstreamError: {
+          message: "Permission reply failed upstream.",
+        },
+      }),
+    );
+    mockChatState.sessions[conversationId] = {
+      ...baseSession(),
+      agentId: SELF_MANAGEMENT_AGENT_ID,
+      pendingInterrupt: {
+        requestId: "builtin-perm-failed-1",
+        type: "permission",
+        phase: "asked",
+        details: {
+          permission: "self-management-write",
+          patterns: ["self.jobs.pause"],
+          displayMessage: "Approve write access to continue.",
+        },
+      },
+      pendingInterrupts: [
+        {
+          requestId: "builtin-perm-failed-1",
+          type: "permission",
+          phase: "asked",
+          details: {
+            permission: "self-management-write",
+            patterns: ["self.jobs.pause"],
+            displayMessage: "Approve write access to continue.",
+          },
+        },
+      ],
+    };
+
+    const tree = renderChatScreen(conversationId, SELF_MANAGEMENT_AGENT_ID);
+    const root = tree.root;
+    const permissionButton = root.findByProps({
+      testID: "interrupt-permission-once",
+    });
+
+    await act(async () => {
+      await permissionButton.props.onPress();
+      await Promise.resolve();
+    });
+
+    expect(mockRemoveConversationMessage).toHaveBeenCalledWith(
+      conversationId,
+      expect.any(String),
+    );
+    expect(mockUpdateConversationMessage).not.toHaveBeenCalled();
+    expect(mockChatState.clearPendingInterrupt).not.toHaveBeenCalled();
+    expect(mockChatState.sessions[conversationId]?.streamState).toBe("idle");
+    expect(mockChatState.sessions[conversationId]?.lastStreamError).toBeNull();
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Interrupt callback failed",
+      "Server Error [internal_error]：Permission reply failed upstream.",
+    );
 
     act(() => {
       tree.unmount();

--- a/frontend/scripts/publish-web.sh
+++ b/frontend/scripts/publish-web.sh
@@ -1,20 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+
 HOST=${HOST:-127.0.0.1}
 PORT=${PORT:-8787}
+CONFIG_PATH=${CONFIG_PATH:-"${ROOT_DIR}/serve.json"}
+SERVE_CONFIG_PATH=${SERVE_CONFIG_PATH:-"${ROOT_DIR}/dist/serve.json"}
+BUILD_VERSION=${BUILD_VERSION:-$(date +%s)}
 
+append_asset_version_suffix() {
+  local target_file="$1"
+
+  BUILD_VERSION="${BUILD_VERSION}" perl -0pi -e \
+    's{(/_expo/static/(?:css/[^"'"'"'"'"'"'"'"'"'\''?]+\.css|js/web/[^"'"'"'"'"'"'"'"'"'\''?]+\.js))(?!\?v=)}{$1 . "?v=" . $ENV{BUILD_VERSION}}ge' \
+    "${target_file}"
+}
+
+cd "${ROOT_DIR}"
 rm -rf dist
 npx expo export -p web --clear
+cp "${CONFIG_PATH}" "${SERVE_CONFIG_PATH}"
+
+while IFS= read -r -d '' html_file; do
+  append_asset_version_suffix "${html_file}"
+done < <(find dist -type f -name '*.html' -print0)
+
+while IFS= read -r -d '' entry_file; do
+  append_asset_version_suffix "${entry_file}"
+done < <(find dist/_expo/static/js/web -type f -name 'entry-*.js' -print0)
 
 echo "Serving dist/ on http://${HOST}:${PORT}"
 
 LISTEN_ENDPOINT="tcp://${HOST}:${PORT}"
 
 if [ "${DETACH:-0}" = "1" ]; then
-  nohup npx serve dist -s --listen "${LISTEN_ENDPOINT}" > /tmp/a2a-web-serve.log 2>&1 &
+  nohup npx serve -c "${SERVE_CONFIG_PATH}" dist -s --listen "${LISTEN_ENDPOINT}" > /tmp/a2a-web-serve.log 2>&1 &
   echo "Server started in background. Logs: /tmp/a2a-web-serve.log"
   exit 0
 fi
 
-npx serve dist -s --listen "${LISTEN_ENDPOINT}"
+npx serve -c "${SERVE_CONFIG_PATH}" dist -s --listen "${LISTEN_ENDPOINT}"

--- a/frontend/serve.json
+++ b/frontend/serve.json
@@ -1,0 +1,55 @@
+{
+  "headers": [
+    {
+      "source": "index.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "source": "manifest.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "source": "_expo/static/**/*",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 关联 Issues
- Closes #813
- Closes #812

## 变更概览
### Backend
- 为 built-in self-management agent 的 write approval 增加显式 operation 元数据约束。
- interrupt token 现在同时写入最小化的 `sm_ops` claims，避免批准后恢复执行时获得全量写权限。
- swival 恢复执行阶段改为只暴露已批准的 write operations，并同步收窄可见工具集合。
- 当会话已拥有部分 write approvals、但后续请求需要新的 write operation 时，改为再次发出最小化 approval interrupt，而不是把运行时视为异常。
- 补充并更新 runtime 回归测试，验证 interrupt `patterns`、token claims、delegated tool surface，以及二次最小权限申请路径都符合预期。

### Frontend
- built-in permission reply 失败时，不再把会话置为 `error` 并残留失败 agent 占位消息。
- 对终态 interrupt 错误保留现有清卡逻辑，同时把 session 状态恢复为 `idle`，避免无意义错误污染。
- 新增和更新 ChatScreen 中断测试，覆盖过期请求与非终态失败两条收尾路径。

## Issue 评估结论
### #813
- 需求仍然有效。
- 本次实现没有停留在前端展示层，而是同时收紧了 interrupt 展示、token claims 和实际 delegated 授权边界。
- 对于“已批准部分 write ops 后再申请新 write op”的路径，本次也补齐了再次最小化申请逻辑，避免把新的授权请求误判为异常。

### #812
- 原始“点击后卡死、卡片不消失”的主诉求已被主干后续修复部分覆盖。
- 本次按小范围最佳实践修复处理，聚焦 built-in permission reply 失败时的状态收尾问题。

## 验证
### Scoped 验证
- `cd backend && uv run --locked pre-commit run --files app/core/security.py app/features/self_management_agent/service.py tests/runtime/test_self_management_built_in_agent.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_self_management_built_in_agent.py`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests hooks/useChatScreenController.ts lib/chatHistoryCache.ts screens/__tests__/ChatScreen.interrupt.test.tsx --maxWorkers=25% --coverage=false`

### 全量回归
- `cd backend && uv sync --extra dev --locked`
- `cd backend && uv run pre-commit run --all-files --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest`
  结果：`1044 passed`
- `cd frontend && npm install`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --maxWorkers=25%`
  结果：`456 passed`

## 风险与关注
- `#813` 现在依赖 built-in agent 在请求写权限时返回显式 operation 元数据；当前实现采用 fail-closed 策略，若元数据缺失会拒绝放大授权范围。
