### PR TITLE
refactor(chat): unify interrupt continuation and permission naming

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -27,7 +27,7 @@ DUMMY_PASSWORD_HASH = PASSWORD_HASHER.hash("dummy-password-not-used")
 ACCESS_TOKEN_TYPE = "access"
 REFRESH_TOKEN_TYPE = "refresh"
 HUB_ASSISTANT_INTERRUPT_TOKEN_TYPE = "hub_assistant_interrupt"
-HUB_ASSISTANT_ALLOWED_OPERATIONS_CLAIM = "ha_ops"
+HUB_ASSISTANT_OPERATION_IDS_CLAIM = "ha_ops"
 HUB_ASSISTANT_DELEGATED_BY_CLAIM = "ha_delegate"
 HUB_ASSISTANT_CONVERSATION_ID_CLAIM = "ha_conversation_id"
 HUB_ASSISTANT_INTERRUPT_MESSAGE_CLAIM = "ha_interrupt_message"
@@ -352,7 +352,7 @@ def create_hub_assistant_access_token(
         str(conversation_id).strip() if conversation_id is not None else ""
     )
     extra_claims: dict[str, Any] = {
-        HUB_ASSISTANT_ALLOWED_OPERATIONS_CLAIM: normalized_operations,
+        HUB_ASSISTANT_OPERATION_IDS_CLAIM: normalized_operations,
         HUB_ASSISTANT_DELEGATED_BY_CLAIM: delegated_by,
     }
     if normalized_conversation_id:
@@ -374,7 +374,7 @@ def create_hub_assistant_interrupt_token(
     conversation_id: str,
     message: str,
     tool_names: Sequence[str],
-    allowed_operations: Sequence[str] = (),
+    requested_operations: Sequence[str] = (),
 ) -> str:
     normalized_conversation_id = str(conversation_id).strip()
     if not normalized_conversation_id:
@@ -385,7 +385,7 @@ def create_hub_assistant_interrupt_token(
     normalized_operations = sorted(
         {
             str(operation_id).strip()
-            for operation_id in allowed_operations
+            for operation_id in requested_operations
             if str(operation_id).strip()
         }
     )
@@ -397,7 +397,7 @@ def create_hub_assistant_interrupt_token(
             HUB_ASSISTANT_INTERRUPT_CONVERSATION_ID_CLAIM: normalized_conversation_id,
             HUB_ASSISTANT_INTERRUPT_MESSAGE_CLAIM: message,
             HUB_ASSISTANT_INTERRUPT_TOOL_NAMES_CLAIM: normalized_tool_names,
-            HUB_ASSISTANT_ALLOWED_OPERATIONS_CLAIM: normalized_operations,
+            HUB_ASSISTANT_OPERATION_IDS_CLAIM: normalized_operations,
         },
     )
 
@@ -417,13 +417,27 @@ def create_user_refresh_token(
     )
 
 
-def get_hub_assistant_allowed_operations(
-    claims: VerifiedJwtClaims,
-) -> frozenset[str]:
-    raw_operations = claims.raw_payload.get(HUB_ASSISTANT_ALLOWED_OPERATIONS_CLAIM)
+def _get_hub_assistant_operation_ids(claims: VerifiedJwtClaims) -> frozenset[str]:
+    raw_operations = claims.raw_payload.get(HUB_ASSISTANT_OPERATION_IDS_CLAIM)
     if not isinstance(raw_operations, list):
         return frozenset()
     return frozenset(str(item).strip() for item in raw_operations if str(item).strip())
+
+
+def get_hub_assistant_allowed_operations(
+    claims: VerifiedJwtClaims,
+) -> frozenset[str]:
+    """Return operation ids already allowed by a delegated access token."""
+
+    return _get_hub_assistant_operation_ids(claims)
+
+
+def get_hub_assistant_interrupt_requested_operations(
+    claims: VerifiedJwtClaims,
+) -> frozenset[str]:
+    """Return operation ids requested by a pending write-approval interrupt."""
+
+    return _get_hub_assistant_operation_ids(claims)
 
 
 def get_hub_assistant_conversation_id(claims: VerifiedJwtClaims) -> str | None:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -417,27 +417,13 @@ def create_user_refresh_token(
     )
 
 
-def _get_hub_assistant_operation_ids(claims: VerifiedJwtClaims) -> frozenset[str]:
+def get_hub_assistant_operation_ids(claims: VerifiedJwtClaims) -> frozenset[str]:
+    """Return Hub Assistant operation ids carried by the JWT."""
+
     raw_operations = claims.raw_payload.get(HUB_ASSISTANT_OPERATION_IDS_CLAIM)
     if not isinstance(raw_operations, list):
         return frozenset()
     return frozenset(str(item).strip() for item in raw_operations if str(item).strip())
-
-
-def get_hub_assistant_allowed_operations(
-    claims: VerifiedJwtClaims,
-) -> frozenset[str]:
-    """Return operation ids already allowed by a delegated access token."""
-
-    return _get_hub_assistant_operation_ids(claims)
-
-
-def get_hub_assistant_interrupt_requested_operations(
-    claims: VerifiedJwtClaims,
-) -> frozenset[str]:
-    """Return operation ids requested by a pending write-approval interrupt."""
-
-    return _get_hub_assistant_operation_ids(claims)
 
 
 def get_hub_assistant_conversation_id(claims: VerifiedJwtClaims) -> str | None:

--- a/backend/app/features/hub_assistant/models.py
+++ b/backend/app/features/hub_assistant/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from app.features.hub_assistant.shared.constants import HUB_ASSISTANT_PUBLIC_ID
@@ -62,7 +62,7 @@ class HubAssistantRunStatus(str, Enum):
 
 
 @dataclass(frozen=True)
-class HubAssistantInterrupt:
+class HubAssistantPermissionInterrupt:
     """Permission interrupt emitted by a read-only Hub Assistant run."""
 
     request_id: str
@@ -103,17 +103,17 @@ class HubAssistantRunResult:
     resources: tuple[str, ...]
     tool_names: tuple[str, ...]
     write_tools_enabled: bool
-    interrupt: HubAssistantInterrupt | None = None
+    interrupt: HubAssistantPermissionInterrupt | None = None
     continuation: HubAssistantContinuation | None = None
 
 
 @dataclass(frozen=True)
-class HubAssistantRecoveredInterrupt:
-    """One unresolved persisted interrupt recovered from durable session history."""
+class HubAssistantRecoveredPermissionInterrupt:
+    """One unresolved permission interrupt recovered from durable session history."""
 
     request_id: str
     session_id: str
-    type: str
+    type: Literal["permission"]
     details: dict[str, Any]
 
 

--- a/backend/app/features/hub_assistant/persistence.py
+++ b/backend/app/features/hub_assistant/persistence.py
@@ -17,8 +17,8 @@ from app.core.security import (
 from app.db.models.agent_message import AgentMessage
 from app.db.models.conversation_thread import ConversationThread
 from app.features.hub_assistant.models import (
-    HubAssistantInterrupt,
-    HubAssistantRecoveredInterrupt,
+    HubAssistantPermissionInterrupt,
+    HubAssistantRecoveredPermissionInterrupt,
     HubAssistantRunResult,
     HubAssistantRunStatus,
 )
@@ -45,13 +45,13 @@ class HubAssistantPersistenceService:
     def __init__(self, *, session_support: SessionHubSupport) -> None:
         self._session_support = session_support
 
-    async def recover_pending_interrupts(
+    async def recover_pending_permission_interrupts(
         self,
         *,
         db: AsyncSession,
         current_user: Any,
         conversation_id: str,
-    ) -> list[HubAssistantRecoveredInterrupt]:
+    ) -> list[HubAssistantRecoveredPermissionInterrupt]:
         resolved_conversation_id = parse_conversation_id(conversation_id)
         recoverable_conversation = cast(
             ConversationThread | None,
@@ -113,10 +113,12 @@ class HubAssistantPersistenceService:
             if phase == "resolved":
                 asked_interrupts.pop(request_id, None)
 
-        recovered: list[HubAssistantRecoveredInterrupt] = []
+        recovered: list[HubAssistantRecoveredPermissionInterrupt] = []
         for request_id in ordered_request_ids:
             interrupt = asked_interrupts.get(request_id)
             if interrupt is None:
+                continue
+            if interrupt.get("type") != "permission":
                 continue
             claims = verify_jwt_token_claims(
                 request_id,
@@ -137,10 +139,10 @@ class HubAssistantPersistenceService:
                 expired_request_ids.append(request_id)
                 continue
             recovered.append(
-                HubAssistantRecoveredInterrupt(
+                HubAssistantRecoveredPermissionInterrupt(
                     request_id=request_id,
                     session_id=str(resolved_conversation_id),
-                    type=cast(str, interrupt["type"]),
+                    type="permission",
                     details=cast(dict[str, Any], interrupt.get("details") or {}),
                 )
             )
@@ -240,7 +242,7 @@ class HubAssistantPersistenceService:
         db: AsyncSession,
         current_user: Any,
         local_session_id: str,
-        interrupt: HubAssistantInterrupt,
+        interrupt: HubAssistantPermissionInterrupt,
     ) -> None:
         await session_hub_service.record_interrupt_lifecycle_event_by_local_session_id(
             db,

--- a/backend/app/features/hub_assistant/router.py
+++ b/backend/app/features/hub_assistant/router.py
@@ -13,13 +13,13 @@ from app.db.models.user import User
 from app.db.transaction import commit_safely
 from app.features.hub_assistant.schemas import (
     HubAssistantContinuation,
-    HubAssistantInterrupt,
-    HubAssistantInterruptDetails,
-    HubAssistantInterruptRecoveryRequest,
-    HubAssistantInterruptRecoveryResponse,
-    HubAssistantInterruptReplyRequest,
+    HubAssistantPermissionInterruptDetails,
+    HubAssistantPermissionInterruptRecoveryRequest,
+    HubAssistantPermissionInterruptRecoveryResponse,
+    HubAssistantPermissionInterruptReplyRequest,
+    HubAssistantPermissionInterruptResponse,
     HubAssistantProfileResponse,
-    HubAssistantRecoveredInterrupt,
+    HubAssistantRecoveredPermissionInterrupt,
     HubAssistantRunRequest,
     HubAssistantRunResponse,
     HubAssistantToolResponse,
@@ -59,11 +59,11 @@ def _to_run_response(
 ) -> HubAssistantRunResponse:
     interrupt = None
     if result.interrupt is not None:
-        interrupt = HubAssistantInterrupt(
+        interrupt = HubAssistantPermissionInterruptResponse(
             requestId=result.interrupt.request_id,
             type="permission",
             phase="asked",
-            details=HubAssistantInterruptDetails(
+            details=HubAssistantPermissionInterruptDetails(
                 permission=result.interrupt.permission,
                 patterns=list(result.interrupt.patterns),
                 displayMessage=result.interrupt.display_message,
@@ -175,15 +175,15 @@ async def run_hub_assistant(
 
 @router.post(
     "/interrupts:recover",
-    response_model=HubAssistantInterruptRecoveryResponse,
+    response_model=HubAssistantPermissionInterruptRecoveryResponse,
 )
-async def recover_hub_assistant_interrupts(
-    payload: HubAssistantInterruptRecoveryRequest,
+async def recover_hub_assistant_permission_interrupts(
+    payload: HubAssistantPermissionInterruptRecoveryRequest,
     db: AsyncSession = Depends(get_async_db),
     current_user: User = Depends(get_current_user),
-) -> HubAssistantInterruptRecoveryResponse:
+) -> HubAssistantPermissionInterruptRecoveryResponse:
     try:
-        items = await hub_assistant_service.recover_pending_interrupts(
+        items = await hub_assistant_service.recover_pending_permission_interrupts(
             db=db,
             current_user=current_user,
             conversation_id=payload.conversation_id,
@@ -195,14 +195,14 @@ async def recover_hub_assistant_interrupts(
         ) from exc
     await commit_safely(db)
 
-    return HubAssistantInterruptRecoveryResponse(
+    return HubAssistantPermissionInterruptRecoveryResponse(
         items=[
-            HubAssistantRecoveredInterrupt(
+            HubAssistantRecoveredPermissionInterrupt(
                 requestId=item.request_id,
                 sessionId=item.session_id,
                 type="permission",
                 phase="asked",
-                details=HubAssistantInterruptDetails(
+                details=HubAssistantPermissionInterruptDetails(
                     permission=item.details.get("permission"),
                     patterns=list(item.details.get("patterns") or []),
                     displayMessage=item.details.get("displayMessage")
@@ -219,7 +219,7 @@ async def recover_hub_assistant_interrupts(
     response_model=HubAssistantRunResponse,
 )
 async def reply_hub_assistant_permission_interrupt(
-    payload: HubAssistantInterruptReplyRequest,
+    payload: HubAssistantPermissionInterruptReplyRequest,
     db: AsyncSession = Depends(get_async_db),
     current_user: User = Depends(get_current_user),
 ) -> HubAssistantRunResponse:

--- a/backend/app/features/hub_assistant/schemas.py
+++ b/backend/app/features/hub_assistant/schemas.py
@@ -41,7 +41,7 @@ class HubAssistantRunRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
-class HubAssistantInterruptDetails(BaseModel):
+class HubAssistantPermissionInterruptDetails(BaseModel):
     """Display-safe details for a Hub Assistant permission interrupt."""
 
     permission: str | None = None
@@ -51,13 +51,13 @@ class HubAssistantInterruptDetails(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
-class HubAssistantInterrupt(BaseModel):
-    """One interrupt emitted by the Hub Assistant."""
+class HubAssistantPermissionInterruptResponse(BaseModel):
+    """One permission interrupt emitted by the Hub Assistant."""
 
     request_id: str = Field(alias="requestId")
     type: Literal["permission"]
     phase: Literal["asked"]
-    details: HubAssistantInterruptDetails
+    details: HubAssistantPermissionInterruptDetails
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
@@ -81,13 +81,13 @@ class HubAssistantRunResponse(BaseModel):
     resources: list[str]
     tools: list[str]
     write_tools_enabled: bool
-    interrupt: HubAssistantInterrupt | None = None
+    interrupt: HubAssistantPermissionInterruptResponse | None = None
     continuation: HubAssistantContinuation | None = None
 
     model_config = ConfigDict(extra="forbid")
 
 
-class HubAssistantInterruptReplyRequest(BaseModel):
+class HubAssistantPermissionInterruptReplyRequest(BaseModel):
     """Permission interrupt reply payload for the Hub Assistant."""
 
     request_id: str = Field(alias="requestId", min_length=1)
@@ -97,7 +97,7 @@ class HubAssistantInterruptReplyRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
-class HubAssistantInterruptRecoveryRequest(BaseModel):
+class HubAssistantPermissionInterruptRecoveryRequest(BaseModel):
     """Conversation-scoped recovery request for persisted Hub Assistant interrupts."""
 
     conversation_id: str = Field(alias="conversationId", min_length=1)
@@ -105,21 +105,21 @@ class HubAssistantInterruptRecoveryRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
-class HubAssistantRecoveredInterrupt(BaseModel):
+class HubAssistantRecoveredPermissionInterrupt(BaseModel):
     """One unresolved Hub Assistant permission interrupt restored from durable history."""
 
     request_id: str = Field(alias="requestId")
     session_id: str = Field(alias="sessionId")
     type: Literal["permission"]
     phase: Literal["asked"]
-    details: HubAssistantInterruptDetails
+    details: HubAssistantPermissionInterruptDetails
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
 
-class HubAssistantInterruptRecoveryResponse(BaseModel):
+class HubAssistantPermissionInterruptRecoveryResponse(BaseModel):
     """Recovered unresolved Hub Assistant permission interrupts for one conversation."""
 
-    items: list[HubAssistantRecoveredInterrupt]
+    items: list[HubAssistantRecoveredPermissionInterrupt]
 
     model_config = ConfigDict(extra="forbid")

--- a/backend/app/features/hub_assistant/service.py
+++ b/backend/app/features/hub_assistant/service.py
@@ -13,9 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.logging import get_logger
 from app.core.security import (
     HUB_ASSISTANT_INTERRUPT_TOKEN_TYPE,
-    get_hub_assistant_allowed_operations,
     get_hub_assistant_interrupt_conversation_id,
     get_hub_assistant_interrupt_message,
+    get_hub_assistant_interrupt_requested_operations,
     get_hub_assistant_interrupt_tool_names,
     verify_jwt_token_claims,
 )
@@ -30,9 +30,9 @@ from app.features.hub_assistant.models import (
     ExecutedHubAssistantRun,
     HubAssistantConfigError,
     HubAssistantContinuation,
-    HubAssistantInterrupt,
+    HubAssistantPermissionInterrupt,
     HubAssistantProfile,
-    HubAssistantRecoveredInterrupt,
+    HubAssistantRecoveredPermissionInterrupt,
     HubAssistantRunResult,
     HubAssistantRunStatus,
     HubAssistantUnavailableError,
@@ -134,13 +134,13 @@ class HubAssistantService:
         )
         return executed.result
 
-    async def recover_pending_interrupts(
+    async def recover_pending_permission_interrupts(
         self,
         *,
         db: AsyncSession,
         current_user: Any,
         conversation_id: str,
-    ) -> list[HubAssistantRecoveredInterrupt]:
+    ) -> list[HubAssistantRecoveredPermissionInterrupt]:
         resolved_conversation_id = parse_conversation_id(conversation_id)
         recoverable_conversation = cast(
             ConversationThread | None,
@@ -202,10 +202,12 @@ class HubAssistantService:
             if phase == "resolved":
                 asked_interrupts.pop(request_id, None)
 
-        recovered: list[HubAssistantRecoveredInterrupt] = []
+        recovered: list[HubAssistantRecoveredPermissionInterrupt] = []
         for request_id in ordered_request_ids:
             interrupt = asked_interrupts.get(request_id)
             if interrupt is None:
+                continue
+            if interrupt.get("type") != "permission":
                 continue
             claims = verify_jwt_token_claims(
                 request_id,
@@ -226,10 +228,10 @@ class HubAssistantService:
                 expired_request_ids.append(request_id)
                 continue
             recovered.append(
-                HubAssistantRecoveredInterrupt(
+                HubAssistantRecoveredPermissionInterrupt(
                     request_id=request_id,
                     session_id=str(resolved_conversation_id),
-                    type=cast(str, interrupt["type"]),
+                    type="permission",
                     details=cast(dict[str, Any], interrupt.get("details") or {}),
                 )
             )
@@ -252,7 +254,7 @@ class HubAssistantService:
         conversation_id: str,
         message: str,
         allow_write_tools: bool,
-        allowed_write_operation_ids: frozenset[str] = frozenset(),
+        approved_write_operation_ids: frozenset[str] = frozenset(),
     ) -> ExecutedHubAssistantRun:
         if not self.is_configured():
             raise HubAssistantConfigError(
@@ -286,9 +288,9 @@ class HubAssistantService:
 
         tool_definitions = cast(tuple[HubAssistantToolDefinition, ...], ())
         async with runtime_state.get_lock():
-            effective_write_operation_ids = (
-                allowed_write_operation_ids
-                if allowed_write_operation_ids
+            runtime_allowed_write_operation_ids = (
+                approved_write_operation_ids
+                if approved_write_operation_ids
                 else (
                     frozenset(
                         definition.operation_id
@@ -298,19 +300,19 @@ class HubAssistantService:
                     else runtime_state.auto_approve_write_operation_ids
                 )
             )
-            effective_write_tools = allow_write_tools or bool(
-                effective_write_operation_ids
+            runtime_write_tools_enabled = allow_write_tools or bool(
+                runtime_allowed_write_operation_ids
             )
             tool_definitions = self._select_run_tool_definitions(
-                allow_write_tools=effective_write_tools,
-                delegated_write_operation_ids=effective_write_operation_ids,
+                allow_write_tools=runtime_write_tools_enabled,
+                delegated_write_operation_ids=runtime_allowed_write_operation_ids,
             )
             session = await self._runtime.ensure_conversation_session(
                 db=db,
                 runtime_state=runtime_state,
                 current_user=current_user,
                 conversation_id=local_session_id,
-                delegated_write_operation_ids=effective_write_operation_ids,
+                delegated_write_operation_ids=runtime_allowed_write_operation_ids,
             )
             try:
                 result = await asyncio.to_thread(session.ask, message)
@@ -329,7 +331,9 @@ class HubAssistantService:
 
         answer = cast(str | None, getattr(result, "answer", None))
         exhausted = bool(getattr(result, "exhausted", False))
-        if not effective_write_tools and self._answer_requests_write_approval(answer):
+        if not runtime_write_tools_enabled and self._answer_requests_write_approval(
+            answer
+        ):
             requested_write_operation_ids = self._extract_requested_write_operation_ids(
                 answer
             )
@@ -344,7 +348,7 @@ class HubAssistantService:
                 conversation_id=local_session_id,
                 message=message,
                 answer=answer,
-                allowed_write_operation_ids=requested_write_operation_ids,
+                requested_write_operation_ids=requested_write_operation_ids,
             )
             return ExecutedHubAssistantRun(
                 result=HubAssistantRunResult(
@@ -364,7 +368,7 @@ class HubAssistantService:
                 local_session_id=local_session_id,
                 local_source=local_source,
             )
-        if effective_write_tools and self._answer_requests_write_approval(answer):
+        if runtime_write_tools_enabled and self._answer_requests_write_approval(answer):
             requested_write_operation_ids = self._extract_requested_write_operation_ids(
                 answer
             )
@@ -374,12 +378,12 @@ class HubAssistantService:
                     "swival Hub Assistant requested write approval without "
                     "declaring any write operations"
                 )
-            missing_write_operation_ids = tuple(
+            additional_requested_write_operation_ids = tuple(
                 operation_id
                 for operation_id in requested_write_operation_ids
-                if operation_id not in effective_write_operation_ids
+                if operation_id not in runtime_allowed_write_operation_ids
             )
-            if not missing_write_operation_ids:
+            if not additional_requested_write_operation_ids:
                 await self._runtime.invalidate_runtime_session(runtime_state)
                 raise HubAssistantUnavailableError(
                     "swival Hub Assistant requested write approval after write "
@@ -390,7 +394,7 @@ class HubAssistantService:
                 conversation_id=local_session_id,
                 message=message,
                 answer=answer,
-                allowed_write_operation_ids=missing_write_operation_ids,
+                requested_write_operation_ids=additional_requested_write_operation_ids,
             )
             return ExecutedHubAssistantRun(
                 result=HubAssistantRunResult(
@@ -420,7 +424,7 @@ class HubAssistantService:
                 tool_names=tuple(
                     definition.tool_name for definition in tool_definitions
                 ),
-                write_tools_enabled=effective_write_tools,
+                write_tools_enabled=runtime_write_tools_enabled,
             ),
             profile=profile,
             local_session=local_session,
@@ -460,10 +464,12 @@ class HubAssistantService:
             raise HubAssistantUnavailableError(
                 "The write approval request is missing the original prompt."
             )
-        approved_operation_ids = get_hub_assistant_allowed_operations(claims)
-        if not approved_operation_ids:
+        requested_operation_ids = get_hub_assistant_interrupt_requested_operations(
+            claims
+        )
+        if not requested_operation_ids:
             raise HubAssistantUnavailableError(
-                "The write approval request is missing the approved operations."
+                "The write approval request is missing the requested operations."
             )
 
         if reply == "reject":
@@ -510,7 +516,7 @@ class HubAssistantService:
             approved_operation_ids = (
                 runtime_state.auto_approve_write_operation_ids
                 | runtime_state.delegated_write_operation_ids
-                | approved_operation_ids
+                | requested_operation_ids
             )
             if reply == "always":
                 runtime_state.auto_approve_write_operation_ids = approved_operation_ids
@@ -694,7 +700,7 @@ class HubAssistantService:
                 conversation_id=request.hub_assistant_conversation_id,
                 message=request.message,
                 allow_write_tools=True,
-                allowed_write_operation_ids=request.approved_operation_ids,
+                approved_write_operation_ids=request.approved_operation_ids,
             )
             await self._persistence.persist_follow_up_agent_message(
                 db=db,
@@ -804,14 +810,14 @@ class HubAssistantService:
         conversation_id: str,
         message: str,
         answer: str | None,
-        allowed_write_operation_ids: tuple[str, ...],
-    ) -> HubAssistantInterrupt:
+        requested_write_operation_ids: tuple[str, ...],
+    ) -> HubAssistantPermissionInterrupt:
         return self._runtime.build_permission_interrupt(
             current_user=current_user,
             conversation_id=conversation_id,
             message=message,
             answer=answer,
-            allowed_write_operation_ids=allowed_write_operation_ids,
+            requested_write_operation_ids=requested_write_operation_ids,
         )
 
     def _select_run_tool_definitions(

--- a/backend/app/features/hub_assistant/service.py
+++ b/backend/app/features/hub_assistant/service.py
@@ -15,8 +15,8 @@ from app.core.security import (
     HUB_ASSISTANT_INTERRUPT_TOKEN_TYPE,
     get_hub_assistant_interrupt_conversation_id,
     get_hub_assistant_interrupt_message,
-    get_hub_assistant_interrupt_requested_operations,
     get_hub_assistant_interrupt_tool_names,
+    get_hub_assistant_operation_ids,
     verify_jwt_token_claims,
 )
 from app.db.models.agent_message import AgentMessage
@@ -30,7 +30,6 @@ from app.features.hub_assistant.models import (
     ExecutedHubAssistantRun,
     HubAssistantConfigError,
     HubAssistantContinuation,
-    HubAssistantPermissionInterrupt,
     HubAssistantProfile,
     HubAssistantRecoveredPermissionInterrupt,
     HubAssistantRunResult,
@@ -100,7 +99,7 @@ class HubAssistantService:
     def is_configured(self) -> bool:
         return (
             self._runtime.has_required_runtime_configuration()
-            and self._is_swival_importable()
+            and self._runtime.is_swival_importable()
         )
 
     async def run(
@@ -294,7 +293,7 @@ class HubAssistantService:
                 else (
                     frozenset(
                         definition.operation_id
-                        for definition in self._list_write_tool_definitions()
+                        for definition in self._runtime.list_write_tool_definitions()
                     )
                     if allow_write_tools
                     else runtime_state.auto_approve_write_operation_ids
@@ -303,7 +302,7 @@ class HubAssistantService:
             runtime_write_tools_enabled = allow_write_tools or bool(
                 runtime_allowed_write_operation_ids
             )
-            tool_definitions = self._select_run_tool_definitions(
+            tool_definitions = self._runtime.select_run_tool_definitions(
                 allow_write_tools=runtime_write_tools_enabled,
                 delegated_write_operation_ids=runtime_allowed_write_operation_ids,
             )
@@ -331,11 +330,12 @@ class HubAssistantService:
 
         answer = cast(str | None, getattr(result, "answer", None))
         exhausted = bool(getattr(result, "exhausted", False))
-        if not runtime_write_tools_enabled and self._answer_requests_write_approval(
-            answer
+        if (
+            not runtime_write_tools_enabled
+            and self._runtime.answer_requests_write_approval(answer)
         ):
-            requested_write_operation_ids = self._extract_requested_write_operation_ids(
-                answer
+            requested_write_operation_ids = (
+                self._runtime.extract_requested_write_operation_ids(answer)
             )
             if not requested_write_operation_ids:
                 await self._runtime.invalidate_runtime_session(runtime_state)
@@ -343,7 +343,7 @@ class HubAssistantService:
                     "swival Hub Assistant requested write approval without "
                     "declaring any write operations"
                 )
-            interrupt = self._build_permission_interrupt(
+            interrupt = self._runtime.build_permission_interrupt(
                 current_user=current_user,
                 conversation_id=local_session_id,
                 message=message,
@@ -353,7 +353,7 @@ class HubAssistantService:
             return ExecutedHubAssistantRun(
                 result=HubAssistantRunResult(
                     status=HubAssistantRunStatus.INTERRUPTED,
-                    answer=self._strip_write_approval_metadata(answer),
+                    answer=self._runtime.strip_write_approval_metadata(answer),
                     exhausted=exhausted,
                     runtime="swival",
                     resources=profile.resources,
@@ -368,9 +368,12 @@ class HubAssistantService:
                 local_session_id=local_session_id,
                 local_source=local_source,
             )
-        if runtime_write_tools_enabled and self._answer_requests_write_approval(answer):
-            requested_write_operation_ids = self._extract_requested_write_operation_ids(
-                answer
+        if (
+            runtime_write_tools_enabled
+            and self._runtime.answer_requests_write_approval(answer)
+        ):
+            requested_write_operation_ids = (
+                self._runtime.extract_requested_write_operation_ids(answer)
             )
             if not requested_write_operation_ids:
                 await self._runtime.invalidate_runtime_session(runtime_state)
@@ -389,7 +392,7 @@ class HubAssistantService:
                     "swival Hub Assistant requested write approval after write "
                     "tools were enabled"
                 )
-            interrupt = self._build_permission_interrupt(
+            interrupt = self._runtime.build_permission_interrupt(
                 current_user=current_user,
                 conversation_id=local_session_id,
                 message=message,
@@ -399,7 +402,7 @@ class HubAssistantService:
             return ExecutedHubAssistantRun(
                 result=HubAssistantRunResult(
                     status=HubAssistantRunStatus.INTERRUPTED,
-                    answer=self._strip_write_approval_metadata(answer),
+                    answer=self._runtime.strip_write_approval_metadata(answer),
                     exhausted=exhausted,
                     runtime="swival",
                     resources=profile.resources,
@@ -464,9 +467,7 @@ class HubAssistantService:
             raise HubAssistantUnavailableError(
                 "The write approval request is missing the original prompt."
             )
-        requested_operation_ids = get_hub_assistant_interrupt_requested_operations(
-            claims
-        )
+        requested_operation_ids = get_hub_assistant_operation_ids(claims)
         if not requested_operation_ids:
             raise HubAssistantUnavailableError(
                 "The write approval request is missing the requested operations."
@@ -786,59 +787,6 @@ class HubAssistantService:
                 request.observed_target_agent_message_anchors
             ),
         )
-
-    def _answer_requests_write_approval(self, answer: str | None) -> bool:
-        return self._runtime.answer_requests_write_approval(answer)
-
-    def _strip_write_approval_metadata(self, answer: str | None) -> str | None:
-        return self._runtime.strip_write_approval_metadata(answer)
-
-    def _list_write_tool_definitions(
-        self,
-    ) -> tuple[HubAssistantToolDefinition, ...]:
-        return self._runtime.list_write_tool_definitions()
-
-    def _extract_requested_write_operation_ids(
-        self, answer: str | None
-    ) -> tuple[str, ...]:
-        return self._runtime.extract_requested_write_operation_ids(answer)
-
-    def _build_permission_interrupt(
-        self,
-        *,
-        current_user: Any,
-        conversation_id: str,
-        message: str,
-        answer: str | None,
-        requested_write_operation_ids: tuple[str, ...],
-    ) -> HubAssistantPermissionInterrupt:
-        return self._runtime.build_permission_interrupt(
-            current_user=current_user,
-            conversation_id=conversation_id,
-            message=message,
-            answer=answer,
-            requested_write_operation_ids=requested_write_operation_ids,
-        )
-
-    def _select_run_tool_definitions(
-        self,
-        *,
-        allow_write_tools: bool,
-        delegated_write_operation_ids: frozenset[str] = frozenset(),
-    ) -> tuple[HubAssistantToolDefinition, ...]:
-        return self._runtime.select_run_tool_definitions(
-            allow_write_tools=allow_write_tools,
-            delegated_write_operation_ids=delegated_write_operation_ids,
-        )
-
-    def _load_swival_session_cls(self) -> type[Any]:
-        return self._runtime.load_swival_session_cls()
-
-    def _resolve_swival_base_dir(self, current_user: Any) -> str:
-        return self._runtime.resolve_swival_base_dir(current_user)
-
-    def _is_swival_importable(self) -> bool:
-        return self._runtime.is_swival_importable()
 
 
 hub_assistant_service = HubAssistantService()

--- a/backend/app/features/hub_assistant/shared/hub_assistant_mcp.py
+++ b/backend/app/features/hub_assistant/shared/hub_assistant_mcp.py
@@ -17,8 +17,8 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.security import (
-    get_hub_assistant_allowed_operations,
     get_hub_assistant_conversation_id,
+    get_hub_assistant_operation_ids,
     verify_jwt_token_claims,
 )
 from app.db.session import AsyncSessionLocal
@@ -141,7 +141,7 @@ class HubAssistantMcpAuthMiddleware:
             await response(scope, receive, send)
             return
 
-        allowed_operation_ids = get_hub_assistant_allowed_operations(claims)
+        allowed_operation_ids = get_hub_assistant_operation_ids(claims)
         if self.require_delegated_claims and not allowed_operation_ids:
             response = JSONResponse(
                 status_code=403,

--- a/backend/app/features/hub_assistant/swival_runtime.py
+++ b/backend/app/features/hub_assistant/swival_runtime.py
@@ -26,7 +26,7 @@ from app.features.hub_access.operation_gateway import (
 )
 from app.features.hub_assistant.models import (
     ConversationRuntimeState,
-    HubAssistantInterrupt,
+    HubAssistantPermissionInterrupt,
     HubAssistantUnavailableError,
 )
 from app.features.hub_assistant.shared.hub_assistant_mcp import (
@@ -249,12 +249,12 @@ class HubAssistantSwivalRuntime:
         conversation_id: str,
         message: str,
         answer: str | None,
-        allowed_write_operation_ids: tuple[str, ...],
-    ) -> HubAssistantInterrupt:
+        requested_write_operation_ids: tuple[str, ...],
+    ) -> HubAssistantPermissionInterrupt:
         write_tool_definitions = tuple(
             definition
             for definition in self.list_write_tool_definitions()
-            if definition.operation_id in allowed_write_operation_ids
+            if definition.operation_id in requested_write_operation_ids
         )
         request_id = create_hub_assistant_interrupt_token(
             cast(Any, current_user.id),
@@ -263,13 +263,13 @@ class HubAssistantSwivalRuntime:
             tool_names=tuple(
                 definition.tool_name for definition in write_tool_definitions
             ),
-            allowed_operations=allowed_write_operation_ids,
+            requested_operations=requested_write_operation_ids,
         )
         display_message = self.strip_write_approval_metadata(answer) or (
             "This change requires explicit write approval before the Hub Assistant "
             "can continue."
         )
-        return HubAssistantInterrupt(
+        return HubAssistantPermissionInterrupt(
             request_id=request_id,
             permission="hub-assistant-write",
             patterns=tuple(

--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -308,7 +308,7 @@ def build_interrupt_lifecycle_message_code(event: dict[str, Any]) -> str:
 def build_interrupt_lifecycle_message_content(event: dict[str, Any]) -> str:
     message_code = build_interrupt_lifecycle_message_code(event)
     if message_code == "permission_expired":
-        return "Authorization request expired. Interrupt closed."
+        return "Permission request expired. Interrupt closed."
     if message_code == "permissions_expired":
         return "Permissions request expired. Interrupt closed."
     if message_code == "question_expired":
@@ -316,7 +316,7 @@ def build_interrupt_lifecycle_message_content(event: dict[str, Any]) -> str:
             return "Additional input request expired. Interrupt closed."
         return "Question request expired. Interrupt closed."
     if message_code == "permission_resolved":
-        return "Authorization request was handled. Agent resumed."
+        return "Permission request was handled. Agent resumed."
     if message_code == "permissions_resolved":
         return "Permissions request was handled. Agent resumed."
     if message_code == "question_rejected":
@@ -342,9 +342,7 @@ def build_interrupt_lifecycle_message_content(event: dict[str, Any]) -> str:
             if isinstance(patterns, list)
             else []
         )
-        base_message = (
-            display_message or f"Agent requested authorization: {permission}."
-        )
+        base_message = display_message or f"Agent requested permission: {permission}."
         if normalized_patterns:
             return f"{base_message}\nTargets: {', '.join(normalized_patterns)}"
         return base_message

--- a/backend/tests/hub_assistant/hub_assistant_support.py
+++ b/backend/tests/hub_assistant/hub_assistant_support.py
@@ -12,11 +12,10 @@ from sqlalchemy import select
 
 from app.core.config import settings
 from app.core.security import (
-    get_hub_assistant_allowed_operations,
     get_hub_assistant_conversation_id,
     get_hub_assistant_interrupt_message,
-    get_hub_assistant_interrupt_requested_operations,
     get_hub_assistant_interrupt_tool_names,
+    get_hub_assistant_operation_ids,
     verify_jwt_token_claims,
 )
 from app.db.models.agent_message import AgentMessage
@@ -216,11 +215,10 @@ __all__ = [
     "create_test_client",
     "create_user",
     "dispatch_due_hub_assistant_tasks",
-    "get_hub_assistant_allowed_operations",
     "get_hub_assistant_conversation_id",
     "get_hub_assistant_interrupt_message",
-    "get_hub_assistant_interrupt_requested_operations",
     "get_hub_assistant_interrupt_tool_names",
+    "get_hub_assistant_operation_ids",
     "hub_assistant_agent_router",
     "hub_assistant_agent_service_module",
     "hub_assistant_service",

--- a/backend/tests/hub_assistant/hub_assistant_support.py
+++ b/backend/tests/hub_assistant/hub_assistant_support.py
@@ -15,6 +15,7 @@ from app.core.security import (
     get_hub_assistant_allowed_operations,
     get_hub_assistant_conversation_id,
     get_hub_assistant_interrupt_message,
+    get_hub_assistant_interrupt_requested_operations,
     get_hub_assistant_interrupt_tool_names,
     verify_jwt_token_claims,
 )
@@ -218,6 +219,7 @@ __all__ = [
     "get_hub_assistant_allowed_operations",
     "get_hub_assistant_conversation_id",
     "get_hub_assistant_interrupt_message",
+    "get_hub_assistant_interrupt_requested_operations",
     "get_hub_assistant_interrupt_tool_names",
     "hub_assistant_agent_router",
     "hub_assistant_agent_service_module",

--- a/backend/tests/hub_assistant/test_hub_assistant_routes.py
+++ b/backend/tests/hub_assistant/test_hub_assistant_routes.py
@@ -482,7 +482,7 @@ async def test_hub_assistant_permission_reply_background_interrupt_persists_new_
     assert interrupted_reply["role"] == "agent"
     assert interrupted_reply["status"] == "interrupted"
 
-    recovered = await hub_assistant_service.recover_pending_interrupts(
+    recovered = await hub_assistant_service.recover_pending_permission_interrupts(
         db=async_db_session,
         current_user=user,
         conversation_id=conversation_id,
@@ -513,7 +513,7 @@ async def test_hub_assistant_can_recover_unresolved_permission_interrupts(
         allow_write_tools=False,
     )
 
-    recovered = await hub_assistant_service.recover_pending_interrupts(
+    recovered = await hub_assistant_service.recover_pending_permission_interrupts(
         db=async_db_session,
         current_user=user,
         conversation_id=conversation_id,
@@ -558,7 +558,7 @@ async def test_hub_assistant_recovery_ignores_resolved_interrupts(
         reply="reject",
     )
 
-    recovered = await hub_assistant_service.recover_pending_interrupts(
+    recovered = await hub_assistant_service.recover_pending_permission_interrupts(
         db=async_db_session,
         current_user=user,
         conversation_id=conversation_id,

--- a/backend/tests/hub_assistant/test_hub_assistant_runtime.py
+++ b/backend/tests/hub_assistant/test_hub_assistant_runtime.py
@@ -15,8 +15,8 @@ from tests.hub_assistant.hub_assistant_support import (
     _reset_hub_assistant_runtime,
     cast,
     create_user,
-    get_hub_assistant_allowed_operations,
     get_hub_assistant_conversation_id,
+    get_hub_assistant_operation_ids,
     hub_assistant_agent_service_module,
     hub_assistant_service,
     pytest,
@@ -77,8 +77,8 @@ async def test_hub_assistant_profile_reports_unconfigured_without_importable_swi
     _reset_hub_assistant_runtime()
     _configure_swival_settings(monkeypatch)
     monkeypatch.setattr(
-        hub_assistant_service,
-        "_is_swival_importable",
+        hub_assistant_service._runtime,
+        "is_swival_importable",
         lambda: False,
     )
 
@@ -117,7 +117,7 @@ async def test_hub_assistant_loads_swival_from_tool_installed_site_packages(
     )
     monkeypatch.delitem(sys.modules, "swival", raising=False)
 
-    session_cls = hub_assistant_service._load_swival_session_cls()
+    session_cls = hub_assistant_service._runtime.load_swival_session_cls()
 
     assert session_cls.__name__ == "Session"
     assert str(site_packages.resolve()) in sys.path
@@ -226,7 +226,7 @@ async def test_hub_assistant_run_uses_swival_with_authenticated_mcp_server(
     assert claims is not None
     assert claims.subject == str(user.id)
     assert get_hub_assistant_conversation_id(claims) == conversation_id
-    assert get_hub_assistant_allowed_operations(claims) == frozenset(result.tool_names)
+    assert get_hub_assistant_operation_ids(claims) == frozenset(result.tool_names)
 
 
 async def test_hub_assistant_can_resume_one_durable_follow_up_run(
@@ -393,8 +393,8 @@ async def test_hub_assistant_reuses_same_swival_base_dir_for_same_user(
     )
     user = await create_user(async_db_session)
 
-    first_dir = hub_assistant_service._resolve_swival_base_dir(user)
-    second_dir = hub_assistant_service._resolve_swival_base_dir(user)
+    first_dir = hub_assistant_service._runtime.resolve_swival_base_dir(user)
+    second_dir = hub_assistant_service._runtime.resolve_swival_base_dir(user)
 
     assert first_dir == second_dir
     assert first_dir == str((tmp_path / "swival-runtime" / str(user.id)).resolve())
@@ -415,8 +415,8 @@ async def test_hub_assistant_uses_distinct_swival_base_dirs_per_user(
     first_user = await create_user(async_db_session)
     second_user = await create_user(async_db_session)
 
-    first_dir = hub_assistant_service._resolve_swival_base_dir(first_user)
-    second_dir = hub_assistant_service._resolve_swival_base_dir(second_user)
+    first_dir = hub_assistant_service._runtime.resolve_swival_base_dir(first_user)
+    second_dir = hub_assistant_service._runtime.resolve_swival_base_dir(second_user)
 
     assert first_dir != second_dir
     assert first_dir.endswith(str(first_user.id))

--- a/backend/tests/hub_assistant/test_hub_assistant_write_approval.py
+++ b/backend/tests/hub_assistant/test_hub_assistant_write_approval.py
@@ -19,8 +19,8 @@ from tests.hub_assistant.hub_assistant_support import (
     create_user,
     dispatch_due_hub_assistant_tasks,
     get_hub_assistant_interrupt_message,
-    get_hub_assistant_interrupt_requested_operations,
     get_hub_assistant_interrupt_tool_names,
+    get_hub_assistant_operation_ids,
     hub_assistant_agent_router,
     hub_assistant_agent_service_module,
     hub_assistant_service,
@@ -107,7 +107,7 @@ async def test_hub_assistant_read_only_run_can_raise_permission_interrupt(
     assert get_hub_assistant_interrupt_tool_names(claims) == (
         "hub_assistant.jobs.pause",
     )
-    assert get_hub_assistant_interrupt_requested_operations(claims) == frozenset(
+    assert get_hub_assistant_operation_ids(claims) == frozenset(
         {"hub_assistant.jobs.pause"}
     )
 
@@ -121,7 +121,7 @@ async def test_hub_assistant_permission_reply_once_resumes_with_write_tools(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    interrupt = hub_assistant_service._build_permission_interrupt(
+    interrupt = hub_assistant_service._runtime.build_permission_interrupt(
         current_user=user,
         conversation_id=conversation_id,
         message="Pause my job",
@@ -218,7 +218,7 @@ async def test_hub_assistant_permission_reply_reject_returns_no_change_result(
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    interrupt = hub_assistant_service._build_permission_interrupt(
+    interrupt = hub_assistant_service._runtime.build_permission_interrupt(
         current_user=user,
         conversation_id=conversation_id,
         message="Pause my job",
@@ -644,7 +644,7 @@ async def test_hub_assistant_permission_reply_route_rejects_other_user_interrupt
     owner = await create_user(async_db_session)
     other_user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    interrupt = hub_assistant_service._build_permission_interrupt(
+    interrupt = hub_assistant_service._runtime.build_permission_interrupt(
         current_user=owner,
         conversation_id=conversation_id,
         message="Pause my job",
@@ -752,7 +752,7 @@ async def test_hub_assistant_permission_reply_always_enables_session_scoped_writ
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    interrupt = hub_assistant_service._build_permission_interrupt(
+    interrupt = hub_assistant_service._runtime.build_permission_interrupt(
         current_user=user,
         conversation_id=conversation_id,
         message="Pause my job",
@@ -798,7 +798,7 @@ async def test_hub_assistant_requests_additional_approval_for_new_write_operatio
     _install_fake_swival(monkeypatch)
     user = await create_user(async_db_session)
     conversation_id = _new_conversation_id()
-    interrupt = hub_assistant_service._build_permission_interrupt(
+    interrupt = hub_assistant_service._runtime.build_permission_interrupt(
         current_user=user,
         conversation_id=conversation_id,
         message="Pause my job",
@@ -875,7 +875,7 @@ async def test_hub_assistant_runtime_patches_private_swival_mcp_tool_fields(
     monkeypatch.setitem(sys.modules, "swival", swival_module)
     monkeypatch.setitem(sys.modules, "swival.mcp_client", mcp_module)
 
-    session_cls = hub_assistant_service._load_swival_session_cls()
+    session_cls = hub_assistant_service._runtime.load_swival_session_cls()
 
     assert session_cls is _FakeSwivalSession
     schema, _original_name = mcp_module._mcp_tool_to_openai(

--- a/backend/tests/hub_assistant/test_hub_assistant_write_approval.py
+++ b/backend/tests/hub_assistant/test_hub_assistant_write_approval.py
@@ -18,8 +18,8 @@ from tests.hub_assistant.hub_assistant_support import (
     create_test_client,
     create_user,
     dispatch_due_hub_assistant_tasks,
-    get_hub_assistant_allowed_operations,
     get_hub_assistant_interrupt_message,
+    get_hub_assistant_interrupt_requested_operations,
     get_hub_assistant_interrupt_tool_names,
     hub_assistant_agent_router,
     hub_assistant_agent_service_module,
@@ -107,7 +107,7 @@ async def test_hub_assistant_read_only_run_can_raise_permission_interrupt(
     assert get_hub_assistant_interrupt_tool_names(claims) == (
         "hub_assistant.jobs.pause",
     )
-    assert get_hub_assistant_allowed_operations(claims) == frozenset(
+    assert get_hub_assistant_interrupt_requested_operations(claims) == frozenset(
         {"hub_assistant.jobs.pause"}
     )
 
@@ -126,7 +126,7 @@ async def test_hub_assistant_permission_reply_once_resumes_with_write_tools(
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
-        allowed_write_operation_ids=("hub_assistant.jobs.pause",),
+        requested_write_operation_ids=("hub_assistant.jobs.pause",),
     )
 
     outcome = await hub_assistant_service.reply_permission_interrupt(
@@ -223,7 +223,7 @@ async def test_hub_assistant_permission_reply_reject_returns_no_change_result(
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
-        allowed_write_operation_ids=("hub_assistant.jobs.pause",),
+        requested_write_operation_ids=("hub_assistant.jobs.pause",),
     )
 
     outcome = await hub_assistant_service.reply_permission_interrupt(
@@ -492,7 +492,7 @@ async def test_hub_assistant_recovery_skips_invalid_interrupt_requests(
         ),
     )
 
-    recovered = await hub_assistant_service.recover_pending_interrupts(
+    recovered = await hub_assistant_service.recover_pending_permission_interrupts(
         db=async_db_session,
         current_user=user,
         conversation_id=conversation_id,
@@ -550,7 +550,7 @@ async def test_hub_assistant_recovery_skips_interrupts_for_other_conversations(
         lambda _claims: str(uuid4()),
     )
 
-    recovered = await hub_assistant_service.recover_pending_interrupts(
+    recovered = await hub_assistant_service.recover_pending_permission_interrupts(
         db=async_db_session,
         current_user=user,
         conversation_id=conversation_id,
@@ -649,7 +649,7 @@ async def test_hub_assistant_permission_reply_route_rejects_other_user_interrupt
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
-        allowed_write_operation_ids=("hub_assistant.jobs.pause",),
+        requested_write_operation_ids=("hub_assistant.jobs.pause",),
     )
 
     async with create_test_client(
@@ -757,7 +757,7 @@ async def test_hub_assistant_permission_reply_always_enables_session_scoped_writ
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
-        allowed_write_operation_ids=("hub_assistant.jobs.pause",),
+        requested_write_operation_ids=("hub_assistant.jobs.pause",),
     )
 
     always_outcome = await hub_assistant_service.reply_permission_interrupt(
@@ -803,7 +803,7 @@ async def test_hub_assistant_requests_additional_approval_for_new_write_operatio
         conversation_id=conversation_id,
         message="Pause my job",
         answer="Need approval",
-        allowed_write_operation_ids=("hub_assistant.jobs.pause",),
+        requested_write_operation_ids=("hub_assistant.jobs.pause",),
     )
 
     await hub_assistant_service.reply_permission_interrupt(

--- a/backend/tests/invoke/test_interrupt_metadata_normalization.py
+++ b/backend/tests/invoke/test_interrupt_metadata_normalization.py
@@ -338,12 +338,12 @@ def test_interrupt_event_block_content_round_trips_structured_payload() -> None:
         "details": {
             "permission": "read",
             "patterns": ["/repo/.env"],
-            "display_message": "Agent requested authorization: read.",
+            "display_message": "Agent requested permission: read.",
         },
     }
 
     serialized = serialize_interrupt_event_block_content(event)
     content, interrupt = deserialize_interrupt_event_block_content(serialized)
 
-    assert content == "Agent requested authorization: read.\nTargets: /repo/.env"
+    assert content == "Agent requested permission: read.\nTargets: /repo/.env"
     assert interrupt == build_interrupt_block_view(event)

--- a/backend/tests/invoke/test_invoke_route_runner_streaming.py
+++ b/backend/tests/invoke/test_invoke_route_runner_streaming.py
@@ -236,7 +236,7 @@ async def test_build_consume_stream_callbacks_persists_interrupt_lifecycle_event
     content, interrupt = deserialize_interrupt_event_block_content(
         interrupt_call["content"]
     )
-    assert content == "Agent requested authorization: read.\nTargets: /repo/.env"
+    assert content == "Agent requested permission: read.\nTargets: /repo/.env"
     assert interrupt is not None
     assert interrupt["requestId"] == "perm-1"
     assert interrupt["type"] == "permission"

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -1351,7 +1351,7 @@ async def test_messages_query_keeps_interrupt_event_blocks_inline_on_agent_messa
         "text",
     ]
     assert returned_message["blocks"][1]["content"].startswith(
-        "Agent requested authorization: read."
+        "Agent requested permission: read."
     )
     interrupt = returned_message["blocks"][1]["interrupt"]
     assert interrupt["requestId"] == "perm-inline-1"

--- a/docs/contracts/interrupt-lifecycle-message-cases.json
+++ b/docs/contracts/interrupt-lifecycle-message-cases.json
@@ -23,7 +23,7 @@
       "phase": "resolved",
       "resolution": "replied"
     },
-    "content": "Authorization request was handled. Agent resumed."
+    "content": "Permission request was handled. Agent resumed."
   },
   {
     "name": "permissions_asked_with_display_message_and_payload",

--- a/frontend/components/chat/ChatComposer.tsx
+++ b/frontend/components/chat/ChatComposer.tsx
@@ -100,7 +100,7 @@ export const ChatComposer = memo(function ChatComposer({
       {pendingInterrupt ? (
         <View className="mb-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2">
           <Text className="text-xs text-amber-200">
-            Agent is waiting for authorization/input. Resolve the action card
+            Agent is waiting for permission/input. Resolve the action card
             first.
           </Text>
           {pendingInterruptCount > 1 ? (

--- a/frontend/components/chat/InterruptActionCard.tsx
+++ b/frontend/components/chat/InterruptActionCard.tsx
@@ -51,7 +51,7 @@ export function InterruptActionCard({
     return (
       <View className="mt-3 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-4">
         <Text className="text-xs font-semibold uppercase tracking-wide text-amber-300">
-          Authorization Required
+          Permission Required
         </Text>
         {remainingInterruptCount > 0 ? (
           <Text className="mt-2 text-xs text-amber-200">

--- a/frontend/components/chat/__tests__/InterruptEventBlock.test.tsx
+++ b/frontend/components/chat/__tests__/InterruptEventBlock.test.tsx
@@ -10,7 +10,7 @@ describe("InterruptEventBlock", () => {
     const block: MessageBlock = {
       id: "interrupt-asked-1",
       type: "interrupt_event",
-      content: "Agent requested authorization: read.\nTargets: /repo/.env",
+      content: "Agent requested permission: read.\nTargets: /repo/.env",
       isFinished: true,
       interrupt: {
         requestId: "perm-1",
@@ -35,7 +35,7 @@ describe("InterruptEventBlock", () => {
     );
 
     expect(screen.getByText("Interrupt")).toBeTruthy();
-    expect(screen.getByText("Authorization requested")).toBeTruthy();
+    expect(screen.getByText("Permission requested")).toBeTruthy();
     expect(screen.getByText("Action Required")).toBeTruthy();
     expect(screen.getByText("Permission")).toBeTruthy();
     expect(screen.getByText("read")).toBeTruthy();
@@ -46,7 +46,7 @@ describe("InterruptEventBlock", () => {
     const block: MessageBlock = {
       id: "interrupt-resolved-1",
       type: "interrupt_event",
-      content: "Authorization request was handled. Agent resumed.",
+      content: "Permission request was handled. Agent resumed.",
       isFinished: true,
       interrupt: {
         requestId: "perm-2",
@@ -66,10 +66,10 @@ describe("InterruptEventBlock", () => {
       />,
     );
 
-    expect(screen.getByText("Authorization update")).toBeTruthy();
+    expect(screen.getByText("Permission update")).toBeTruthy();
     expect(screen.getByText("Handled")).toBeTruthy();
     expect(
-      screen.getByText("Authorization request was handled. Agent resumed."),
+      screen.getByText("Permission request was handled. Agent resumed."),
     ).toBeTruthy();
   });
 
@@ -77,7 +77,7 @@ describe("InterruptEventBlock", () => {
     const block: MessageBlock = {
       id: "interrupt-expired-1",
       type: "interrupt_event",
-      content: "Authorization request expired. Interrupt closed.",
+      content: "Permission request expired. Interrupt closed.",
       isFinished: true,
       interrupt: {
         requestId: "perm-3",
@@ -97,10 +97,10 @@ describe("InterruptEventBlock", () => {
       />,
     );
 
-    expect(screen.getByText("Authorization update")).toBeTruthy();
+    expect(screen.getByText("Permission update")).toBeTruthy();
     expect(screen.getByText("Expired")).toBeTruthy();
     expect(
-      screen.getByText("Authorization request expired. Interrupt closed."),
+      screen.getByText("Permission request expired. Interrupt closed."),
     ).toBeTruthy();
   });
 

--- a/frontend/components/chat/__tests__/MessageBlock.test.tsx
+++ b/frontend/components/chat/__tests__/MessageBlock.test.tsx
@@ -162,7 +162,7 @@ describe("MessageBlock and MessageContentFallback", () => {
     const block: MessageBlockType = {
       id: "interrupt-1",
       type: "interrupt_event",
-      content: "Agent requested authorization: read.",
+      content: "Agent requested permission: read.",
       isFinished: true,
       createdAt: "2026-02-24T00:00:00.000Z",
       updatedAt: "2026-02-24T00:00:00.000Z",

--- a/frontend/components/chat/blocks/InterruptEventBlock.tsx
+++ b/frontend/components/chat/blocks/InterruptEventBlock.tsx
@@ -56,7 +56,7 @@ const resolveInterruptTitle = (block: MessageBlock): string => {
   }
   if (interrupt.phase === "resolved") {
     if (interrupt.type === "permission") {
-      return "Authorization update";
+      return "Permission update";
     }
     if (interrupt.type === "permissions") {
       return "Permissions update";
@@ -67,7 +67,7 @@ const resolveInterruptTitle = (block: MessageBlock): string => {
     return "Question update";
   }
   if (interrupt.type === "permission") {
-    return "Authorization requested";
+    return "Permission requested";
   }
   if (interrupt.type === "permissions") {
     return "Permissions approval requested";

--- a/frontend/hooks/__tests__/useChatInterruptController.test.tsx
+++ b/frontend/hooks/__tests__/useChatInterruptController.test.tsx
@@ -198,7 +198,7 @@ describe("useChatInterruptController", () => {
         pendingQuestionCount: 0,
         clearPendingInterrupt,
         onPermissionReplyOverride,
-        permissionReplySuccessMessage: "Authorization request handled.",
+        permissionReplySuccessMessage: "Permission request handled.",
       }),
     );
 
@@ -218,7 +218,7 @@ describe("useChatInterruptController", () => {
     );
     expect(mockedToast.success).toHaveBeenCalledWith(
       "Action submitted",
-      "Authorization request handled.",
+      "Permission request handled.",
     );
   });
 
@@ -246,7 +246,7 @@ describe("useChatInterruptController", () => {
         pendingQuestionCount: 0,
         clearPendingInterrupt,
         onPermissionReplyOverride,
-        permissionReplySuccessMessage: "Authorization request handled.",
+        permissionReplySuccessMessage: "Permission request handled.",
       }),
     );
 
@@ -266,7 +266,7 @@ describe("useChatInterruptController", () => {
     );
     expect(mockedToast.success).toHaveBeenCalledWith(
       "Action submitted",
-      "Authorization request handled.",
+      "Permission request handled.",
     );
   });
 

--- a/frontend/hooks/__tests__/useChatInterruptController.test.tsx
+++ b/frontend/hooks/__tests__/useChatInterruptController.test.tsx
@@ -95,7 +95,7 @@ describe("useChatInterruptController", () => {
     });
   });
 
-  it("forwards working directory with permission replies", async () => {
+  it("uses ack-fast semantics for permission grants after upstream ack", async () => {
     const { result } = renderHook(() =>
       useChatInterruptController({
         activeAgentId: "agent-1",
@@ -127,6 +127,47 @@ describe("useChatInterruptController", () => {
       workingDirectory: "/workspace/app",
     });
     expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "perm-1");
+    expect(mockedToast.success).toHaveBeenCalledWith(
+      "Action submitted",
+      "Permission reply delivered to upstream.",
+    );
+  });
+
+  it("keeps permission rejects transactional after upstream ack", async () => {
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "agent-1",
+        agentSource: "personal",
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "perm-reject-1",
+          type: "permission",
+          phase: "asked",
+          details: { permission: "write", patterns: ["/workspace/**"] },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 0,
+        workingDirectory: "/workspace/app",
+        clearPendingInterrupt,
+      }),
+    );
+
+    await act(async () => {
+      result.current.handlePermissionReply("reject");
+      await Promise.resolve();
+    });
+
+    expect(mockedReplyPermissionInterrupt).toHaveBeenCalledWith({
+      source: "personal",
+      agentId: "agent-1",
+      requestId: "perm-reject-1",
+      reply: "reject",
+      workingDirectory: "/workspace/app",
+    });
+    expect(clearPendingInterrupt).toHaveBeenCalledWith(
+      "conv-1",
+      "perm-reject-1",
+    );
     expect(mockedToast.success).toHaveBeenCalledWith(
       "Action submitted",
       "Permission reply delivered to upstream.",
@@ -181,7 +222,55 @@ describe("useChatInterruptController", () => {
     );
   });
 
-  it("forwards working directory with question answers", async () => {
+  it("supports transactional permission reply overrides through the shared controller", async () => {
+    const onPermissionReplyOverride = jest.fn().mockResolvedValue({
+      mode: "transactional" as const,
+      resolvedRequestId: "perm-override-2",
+    });
+
+    const { result } = renderHook(() =>
+      useChatInterruptController({
+        activeAgentId: "hub-assistant",
+        agentSource: null,
+        conversationId: "conv-1",
+        pendingInterrupt: {
+          requestId: "perm-original-2",
+          type: "permission",
+          phase: "asked",
+          details: {
+            permission: "write",
+            patterns: ["hub_assistant.jobs.resume"],
+          },
+        },
+        lastResolvedInterrupt: null,
+        pendingQuestionCount: 0,
+        clearPendingInterrupt,
+        onPermissionReplyOverride,
+        permissionReplySuccessMessage: "Authorization request handled.",
+      }),
+    );
+
+    await act(async () => {
+      result.current.handlePermissionReply("always");
+      await Promise.resolve();
+    });
+
+    expect(onPermissionReplyOverride).toHaveBeenCalledWith({
+      requestId: "perm-original-2",
+      reply: "always",
+    });
+    expect(mockedReplyPermissionInterrupt).not.toHaveBeenCalled();
+    expect(clearPendingInterrupt).toHaveBeenCalledWith(
+      "conv-1",
+      "perm-override-2",
+    );
+    expect(mockedToast.success).toHaveBeenCalledWith(
+      "Action submitted",
+      "Authorization request handled.",
+    );
+  });
+
+  it("uses ack-fast semantics for question answers after upstream ack", async () => {
     const { result } = renderHook(() =>
       useChatInterruptController({
         activeAgentId: "agent-1",
@@ -231,7 +320,7 @@ describe("useChatInterruptController", () => {
     );
   });
 
-  it("parses permissions JSON and routes scope-aware replies", async () => {
+  it("uses ack-fast semantics for scope-aware permissions replies", async () => {
     const { result } = renderHook(() =>
       useChatInterruptController({
         activeAgentId: "agent-1",
@@ -272,7 +361,7 @@ describe("useChatInterruptController", () => {
     expect(clearPendingInterrupt).toHaveBeenCalledWith("conv-1", "perm-v2-1");
   });
 
-  it("parses elicitation JSON and submits accept replies", async () => {
+  it("keeps elicitation accept replies transactional", async () => {
     const { result } = renderHook(() =>
       useChatInterruptController({
         activeAgentId: "agent-1",

--- a/frontend/hooks/__tests__/useContinuationConvergence.test.ts
+++ b/frontend/hooks/__tests__/useContinuationConvergence.test.ts
@@ -1,0 +1,50 @@
+import { resolvePersistedHistoryContinuation } from "@/hooks/useContinuationConvergence";
+import { type ChatMessage } from "@/lib/api/chat-utils";
+
+const createMessage = (
+  id: string,
+  status: ChatMessage["status"],
+): ChatMessage => ({
+  id,
+  role: "agent",
+  content: status === "error" ? "Continuation failed." : "Result",
+  createdAt: "2026-04-21T00:00:00.000Z",
+  status,
+});
+
+describe("resolvePersistedHistoryContinuation", () => {
+  it("waits while the target agent message is still streaming", () => {
+    const event = resolvePersistedHistoryContinuation({
+      targetMessageId: "agent-1",
+      messages: [createMessage("agent-1", "streaming")],
+    });
+
+    expect(event).toBeNull();
+  });
+
+  it("ignores unrelated terminal agent messages", () => {
+    const event = resolvePersistedHistoryContinuation({
+      targetMessageId: "agent-1",
+      messages: [createMessage("agent-2", "done")],
+    });
+
+    expect(event).toBeNull();
+  });
+
+  it.each([["done" as const], ["interrupted" as const], ["error" as const]])(
+    "returns a persisted-history event for %s target messages",
+    (status) => {
+      const message = createMessage("agent-1", status);
+      const event = resolvePersistedHistoryContinuation({
+        targetMessageId: "agent-1",
+        messages: [message],
+      });
+
+      expect(event).toEqual({
+        source: "persisted-history",
+        status,
+        message,
+      });
+    },
+  );
+});

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -27,14 +27,11 @@ type ResolvedInterruptKeyInput = {
 };
 
 export type InterruptActionMode = "ack-fast" | "transactional";
-export type PermissionReplyActionMode = InterruptActionMode;
 
-type InterruptActionResult = {
+export type InterruptActionResult = {
   mode: InterruptActionMode;
   resolvedRequestId?: string;
 };
-
-type PermissionReplyActionResult = InterruptActionResult;
 
 type UseChatInterruptControllerParams = {
   activeAgentId?: string | null;
@@ -49,7 +46,7 @@ type UseChatInterruptControllerParams = {
     | ((input: {
         requestId: string;
         reply: "once" | "always" | "reject";
-      }) => Promise<PermissionReplyActionResult>)
+      }) => Promise<InterruptActionResult>)
     | null;
   permissionReplySuccessMessage?: string | null;
 };

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -26,12 +26,15 @@ type ResolvedInterruptKeyInput = {
   resolution: "replied" | "rejected" | "expired";
 };
 
-export type PermissionReplyActionMode = "ack-fast" | "transactional";
+export type InterruptActionMode = "ack-fast" | "transactional";
+export type PermissionReplyActionMode = InterruptActionMode;
 
-type PermissionReplyActionResult = {
-  mode: PermissionReplyActionMode;
+type InterruptActionResult = {
+  mode: InterruptActionMode;
   resolvedRequestId?: string;
 };
+
+type PermissionReplyActionResult = InterruptActionResult;
 
 type UseChatInterruptControllerParams = {
   activeAgentId?: string | null;
@@ -260,6 +263,32 @@ export function useChatInterruptController({
     ],
   );
 
+  const finalizeInterruptAction = useCallback(
+    ({
+      actionResult,
+      conversationId,
+      requestId,
+      interruptType,
+      resolution,
+    }: {
+      actionResult: InterruptActionResult;
+      conversationId: string;
+      requestId: string;
+      interruptType: "permission" | "question" | "permissions" | "elicitation";
+      resolution: "replied" | "rejected";
+    }) => {
+      const resolvedRequestId = actionResult.resolvedRequestId ?? requestId;
+      if (actionResult.mode === "ack-fast") {
+        clearPendingInterrupt(conversationId, resolvedRequestId);
+      }
+      acknowledgeLocalInterruptResolution(requestId, interruptType, resolution);
+      if (actionResult.mode === "transactional") {
+        clearPendingInterrupt(conversationId, resolvedRequestId);
+      }
+    },
+    [acknowledgeLocalInterruptResolution, clearPendingInterrupt],
+  );
+
   useEffect(() => {
     if (!lastResolvedInterrupt) {
       return;
@@ -367,8 +396,9 @@ export function useChatInterruptController({
       runInterruptAction(
         `permission:${reply}`,
         async () => {
-          let actionResult: PermissionReplyActionResult = {
-            mode: "transactional",
+          let actionResult: InterruptActionResult = {
+            mode: reply === "reject" ? "transactional" : "ack-fast",
+            resolvedRequestId: requestId,
           };
           if (onPermissionReplyOverride) {
             actionResult = await onPermissionReplyOverride({
@@ -385,18 +415,20 @@ export function useChatInterruptController({
                 ? { workingDirectory: normalizedWorkingDirectory }
                 : {}),
             });
+            actionResult = {
+              mode: reply === "reject" ? "transactional" : "ack-fast",
+              resolvedRequestId: requestId,
+            };
           } else {
             return;
           }
-          acknowledgeLocalInterruptResolution(
-            requestId,
-            "permission",
-            reply === "reject" ? "rejected" : "replied",
-          );
-          clearPendingInterrupt(
+          finalizeInterruptAction({
+            actionResult,
             conversationId,
-            actionResult.resolvedRequestId ?? requestId,
-          );
+            requestId,
+            interruptType: "permission",
+            resolution: reply === "reject" ? "rejected" : "replied",
+          });
         },
         permissionReplySuccessMessage ??
           "Permission reply delivered to upstream.",
@@ -409,9 +441,8 @@ export function useChatInterruptController({
     [
       activeAgentId,
       agentSource,
-      acknowledgeLocalInterruptResolution,
-      clearPendingInterrupt,
       conversationId,
+      finalizeInterruptAction,
       pendingInterrupt,
       runInterruptAction,
       normalizedWorkingDirectory,
@@ -474,8 +505,16 @@ export function useChatInterruptController({
             ? { workingDirectory: normalizedWorkingDirectory }
             : {}),
         });
-        acknowledgeLocalInterruptResolution(requestId, "question", "replied");
-        clearPendingInterrupt(conversationId, requestId);
+        finalizeInterruptAction({
+          actionResult: {
+            mode: "ack-fast",
+            resolvedRequestId: requestId,
+          },
+          conversationId,
+          requestId,
+          interruptType: "question",
+          resolution: "replied",
+        });
       },
       "Question answers delivered to upstream.",
       {
@@ -486,9 +525,8 @@ export function useChatInterruptController({
   }, [
     activeAgentId,
     agentSource,
-    acknowledgeLocalInterruptResolution,
-    clearPendingInterrupt,
     conversationId,
+    finalizeInterruptAction,
     pendingInterrupt,
     questionAnswers,
     runInterruptAction,
@@ -517,8 +555,16 @@ export function useChatInterruptController({
             ? { workingDirectory: normalizedWorkingDirectory }
             : {}),
         });
-        acknowledgeLocalInterruptResolution(requestId, "question", "rejected");
-        clearPendingInterrupt(conversationId, requestId);
+        finalizeInterruptAction({
+          actionResult: {
+            mode: "transactional",
+            resolvedRequestId: requestId,
+          },
+          conversationId,
+          requestId,
+          interruptType: "question",
+          resolution: "rejected",
+        });
       },
       "Question request rejected.",
       {
@@ -529,9 +575,8 @@ export function useChatInterruptController({
   }, [
     activeAgentId,
     agentSource,
-    acknowledgeLocalInterruptResolution,
-    clearPendingInterrupt,
     conversationId,
+    finalizeInterruptAction,
     pendingInterrupt,
     runInterruptAction,
     normalizedWorkingDirectory,
@@ -582,12 +627,16 @@ export function useChatInterruptController({
               ? { workingDirectory: normalizedWorkingDirectory }
               : {}),
           });
-          acknowledgeLocalInterruptResolution(
+          finalizeInterruptAction({
+            actionResult: {
+              mode: "ack-fast",
+              resolvedRequestId: requestId,
+            },
+            conversationId,
             requestId,
-            "permissions",
-            "replied",
-          );
-          clearPendingInterrupt(conversationId, requestId);
+            interruptType: "permissions",
+            resolution: "replied",
+          });
         },
         `Permissions reply delivered to upstream (${scope}).`,
         {
@@ -599,9 +648,8 @@ export function useChatInterruptController({
     [
       activeAgentId,
       agentSource,
-      acknowledgeLocalInterruptResolution,
-      clearPendingInterrupt,
       conversationId,
+      finalizeInterruptAction,
       parseStructuredResponseInput,
       pendingInterrupt,
       runInterruptAction,
@@ -646,12 +694,16 @@ export function useChatInterruptController({
               ? { workingDirectory: normalizedWorkingDirectory }
               : {}),
           });
-          acknowledgeLocalInterruptResolution(
+          finalizeInterruptAction({
+            actionResult: {
+              mode: "transactional",
+              resolvedRequestId: requestId,
+            },
+            conversationId,
             requestId,
-            "elicitation",
-            action === "accept" ? "replied" : "rejected",
-          );
-          clearPendingInterrupt(conversationId, requestId);
+            interruptType: "elicitation",
+            resolution: action === "accept" ? "replied" : "rejected",
+          });
         },
         action === "accept"
           ? "Elicitation response delivered to upstream."
@@ -665,9 +717,8 @@ export function useChatInterruptController({
     [
       activeAgentId,
       agentSource,
-      acknowledgeLocalInterruptResolution,
-      clearPendingInterrupt,
       conversationId,
+      finalizeInterruptAction,
       parseStructuredResponseInput,
       pendingInterrupt,
       runInterruptAction,

--- a/frontend/hooks/useChatInterruptController.ts
+++ b/frontend/hooks/useChatInterruptController.ts
@@ -156,12 +156,12 @@ export function useChatInterruptController({
         if (interrupt.resolution === "expired") {
           return {
             title: "Interrupt resolved",
-            message: "Authorization request expired and was closed.",
+            message: "Permission request expired and was closed.",
           };
         }
         return {
           title: "Interrupt resolved",
-          message: "Authorization request was handled.",
+          message: "Permission request was handled.",
         };
       }
       if (interrupt.type === "permissions") {

--- a/frontend/hooks/useChatScreenController.ts
+++ b/frontend/hooks/useChatScreenController.ts
@@ -411,7 +411,7 @@ export function useChatScreenController({
       ? handleHubAssistantPermissionReply
       : null,
     permissionReplySuccessMessage: isHubAssistantAgent
-      ? "Authorization request handled."
+      ? "Permission request handled."
       : null,
   });
 

--- a/frontend/hooks/useChatScreenHubAssistantController.ts
+++ b/frontend/hooks/useChatScreenHubAssistantController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
 
-import { type PermissionReplyActionMode } from "@/hooks/useChatInterruptController";
+import { type InterruptActionResult } from "@/hooks/useChatInterruptController";
 import {
   type ContinuationConvergenceEvent,
   useContinuationConvergence,
@@ -253,10 +253,7 @@ export function useChatScreenHubAssistantController({
     }: {
       requestId: string;
       reply: "once" | "always" | "reject";
-    }): Promise<{
-      mode: PermissionReplyActionMode;
-      resolvedRequestId?: string;
-    }> => {
+    }): Promise<InterruptActionResult> => {
       if (!conversationId || !activeAgentId) {
         return {
           mode: "transactional",

--- a/frontend/hooks/useChatScreenHubAssistantController.ts
+++ b/frontend/hooks/useChatScreenHubAssistantController.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import { type PermissionReplyActionMode } from "@/hooks/useChatInterruptController";
+import {
+  type ContinuationConvergenceEvent,
+  useContinuationConvergence,
+} from "@/hooks/useContinuationConvergence";
 import { type PendingRuntimeInterrupt } from "@/lib/api/chat-utils";
 import {
   getHubAssistantProfile,
@@ -58,10 +62,6 @@ export function useChatScreenHubAssistantController({
   const lastInterruptRecoveryRef = useRef<{
     key: string;
     triggeredAt: number;
-  } | null>(null);
-  const continuationMonitorRef = useRef<{
-    key: string;
-    cancelled: boolean;
   } | null>(null);
 
   const applyHubAssistantSessionUpdate = useCallback(
@@ -406,123 +406,101 @@ export function useChatScreenHubAssistantController({
     streamState,
   ]);
 
-  useEffect(() => {
-    if (
-      !conversationId ||
-      !activeAgentId ||
-      !isHubAssistantAgent ||
-      streamState !== "continuing" ||
-      !lastAgentMessageId
-    ) {
-      return;
+  const loadContinuationMessages = useCallback(async () => {
+    if (!conversationId) {
+      return [];
     }
+    const page = await listSessionMessagesPage(conversationId, {
+      before: null,
+      limit: 8,
+    });
+    return mapSessionMessagesToChatMessages(
+      Array.isArray(page?.items) ? page.items : [],
+      {
+        keepEmptyMessages: true,
+      },
+    );
+  }, [conversationId]);
 
-    const targetAgentMessageId = lastAgentMessageId;
-    const monitorKey = `${conversationId}:${targetAgentMessageId}`;
-    const previousMonitor = continuationMonitorRef.current;
-    if (previousMonitor?.key === monitorKey && !previousMonitor.cancelled) {
-      return;
-    }
-    if (previousMonitor) {
-      previousMonitor.cancelled = true;
-    }
+  const handleContinuationConverged = useCallback(
+    async (event: ContinuationConvergenceEvent) => {
+      if (!conversationId || !activeAgentId) {
+        return;
+      }
+      if (event.status === "interrupted") {
+        await recoverPendingInterrupts({
+          nextConversationId: conversationId,
+        });
+      }
+      applyHubAssistantSessionUpdate(
+        conversationId,
+        activeAgentId,
+        (current) => ({
+          ...current,
+          agentId: activeAgentId,
+          lastActiveAt: new Date().toISOString(),
+          streamState: event.status === "error" ? "error" : "idle",
+          lastStreamError:
+            event.status === "error"
+              ? event.message.content.trim() ||
+                "Hub Assistant continuation failed."
+              : null,
+        }),
+      );
+    },
+    [
+      activeAgentId,
+      applyHubAssistantSessionUpdate,
+      conversationId,
+      recoverPendingInterrupts,
+    ],
+  );
 
-    const monitor = {
-      key: monitorKey,
-      cancelled: false,
-    };
-    continuationMonitorRef.current = monitor;
-
-    const sleep = (ms: number) =>
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
+  const handleContinuationRefreshError = useCallback(
+    (error: unknown) => {
+      console.warn("[Chat] Hub Assistant continuation refresh failed", {
+        conversationId,
+        agentId: activeAgentId,
+        agentMessageId: lastAgentMessageId,
+        error:
+          error instanceof Error
+            ? error.message
+            : "hub_assistant_continuation_refresh_failed",
       });
+    },
+    [activeAgentId, conversationId, lastAgentMessageId],
+  );
 
-    const monitorContinuation = async () => {
-      let pollDelayMs = HUB_ASSISTANT_CONTINUATION_POLL_INTERVAL_MS;
-      while (!monitor.cancelled) {
-        try {
-          const page = await listSessionMessagesPage(conversationId, {
-            before: null,
-            limit: 8,
-          });
-          const mappedMessages = mapSessionMessagesToChatMessages(
-            Array.isArray(page?.items) ? page.items : [],
-            {
-              keepEmptyMessages: true,
-            },
-          );
-          mergeConversationMessages(conversationId, mappedMessages);
-
-          const currentAgentMessage = mappedMessages.find(
-            (message) =>
-              message.id === targetAgentMessageId && message.role === "agent",
-          );
-          if (
-            currentAgentMessage &&
-            currentAgentMessage.status &&
-            currentAgentMessage.status !== "streaming"
-          ) {
-            if (currentAgentMessage.status === "interrupted") {
-              await recoverPendingInterrupts({
-                nextConversationId: conversationId,
-              });
-            }
-            applyHubAssistantSessionUpdate(
-              conversationId,
-              activeAgentId,
-              (current) => ({
-                ...current,
-                agentId: activeAgentId,
-                lastActiveAt: new Date().toISOString(),
-                streamState:
-                  currentAgentMessage.status === "error" ? "error" : "idle",
-                lastStreamError:
-                  currentAgentMessage.status === "error"
-                    ? currentAgentMessage.content.trim() ||
-                      "Hub Assistant continuation failed."
-                    : null,
-              }),
-            );
-            return;
-          }
-        } catch (error) {
-          console.warn("[Chat] Hub Assistant continuation refresh failed", {
-            conversationId,
-            agentId: activeAgentId,
-            agentMessageId: targetAgentMessageId,
-            error:
-              error instanceof Error
-                ? error.message
-                : "hub_assistant_continuation_refresh_failed",
-          });
-        }
-        await sleep(pollDelayMs);
-        pollDelayMs = Math.min(
-          HUB_ASSISTANT_CONTINUATION_POLL_MAX_INTERVAL_MS,
-          Math.round(pollDelayMs * 1.5),
-        );
+  const handleContinuationMessagesLoaded = useCallback(
+    (messages: Awaited<ReturnType<typeof loadContinuationMessages>>) => {
+      if (conversationId) {
+        mergeConversationMessages(conversationId, messages);
       }
-    };
+    },
+    [conversationId],
+  );
 
-    const continuationPromise = monitorContinuation();
-    continuationPromise.catch(() => undefined);
-
-    return () => {
-      monitor.cancelled = true;
-      if (continuationMonitorRef.current === monitor) {
-        continuationMonitorRef.current = null;
-      }
-    };
-  }, [
-    activeAgentId,
-    applyHubAssistantSessionUpdate,
-    conversationId,
-    isHubAssistantAgent,
-    lastAgentMessageId,
-    recoverPendingInterrupts,
-    streamState,
-  ]);
+  useContinuationConvergence({
+    enabled: Boolean(
+      conversationId &&
+      activeAgentId &&
+      isHubAssistantAgent &&
+      streamState === "continuing" &&
+      lastAgentMessageId,
+    ),
+    source: "persisted-history",
+    monitorKey:
+      conversationId && lastAgentMessageId
+        ? `${conversationId}:${lastAgentMessageId}`
+        : null,
+    targetMessageId: lastAgentMessageId ?? null,
+    loadMessages: loadContinuationMessages,
+    onMessagesLoaded: handleContinuationMessagesLoaded,
+    onConverged: handleContinuationConverged,
+    onRefreshError: handleContinuationRefreshError,
+    initialPollDelayMs: HUB_ASSISTANT_CONTINUATION_POLL_INTERVAL_MS,
+    maxPollDelayMs: HUB_ASSISTANT_CONTINUATION_POLL_MAX_INTERVAL_MS,
+  });
 
   useEffect(() => {
     if (

--- a/frontend/hooks/useChatScreenHubAssistantController.ts
+++ b/frontend/hooks/useChatScreenHubAssistantController.ts
@@ -8,10 +8,10 @@ import {
 import { type PendingRuntimeInterrupt } from "@/lib/api/chat-utils";
 import {
   getHubAssistantProfile,
-  recoverHubAssistantInterrupts,
+  recoverHubAssistantPermissionInterrupts,
   replyHubAssistantPermissionInterrupt,
   runHubAssistant,
-  toPendingRuntimeInterrupt,
+  toPendingRuntimePermissionInterrupt,
 } from "@/lib/api/hubAssistant";
 import { listSessionMessagesPage } from "@/lib/api/sessions";
 import {
@@ -122,7 +122,7 @@ export function useChatScreenHubAssistantController({
       };
 
       try {
-        const result = await recoverHubAssistantInterrupts({
+        const result = await recoverHubAssistantPermissionInterrupts({
           conversationId: resolvedSessionId,
         });
         replaceRecoveredInterrupts(nextConversationId, result.items, {
@@ -198,7 +198,7 @@ export function useChatScreenHubAssistantController({
           agentMessageId,
         });
         const nextInterrupt = result.interrupt
-          ? toPendingRuntimeInterrupt(result.interrupt)
+          ? toPendingRuntimePermissionInterrupt(result.interrupt)
           : null;
 
         updateConversationMessage(nextConversationId, agentMessageId, {
@@ -293,7 +293,7 @@ export function useChatScreenHubAssistantController({
 
         const resolution = reply === "reject" ? "rejected" : "replied";
         const nextInterrupt = result.interrupt
-          ? toPendingRuntimeInterrupt(result.interrupt)
+          ? toPendingRuntimePermissionInterrupt(result.interrupt)
           : null;
 
         if (result.status === "accepted") {

--- a/frontend/hooks/useContinuationConvergence.ts
+++ b/frontend/hooks/useContinuationConvergence.ts
@@ -1,0 +1,153 @@
+import { useEffect, useRef } from "react";
+
+import { type ChatMessage } from "@/lib/api/chat-utils";
+
+type ContinuationConvergenceSource =
+  | "persisted-history"
+  | "runtime-status"
+  | "stream";
+
+type ContinuationConvergenceStatus = Exclude<
+  NonNullable<ChatMessage["status"]>,
+  "streaming"
+>;
+
+export type ContinuationConvergenceEvent = {
+  source: ContinuationConvergenceSource;
+  status: ContinuationConvergenceStatus;
+  message: ChatMessage;
+};
+
+type UseContinuationConvergenceParams = {
+  enabled: boolean;
+  source: "persisted-history";
+  monitorKey: string | null;
+  targetMessageId: string | null;
+  loadMessages: () => Promise<ChatMessage[]>;
+  onMessagesLoaded?: (messages: ChatMessage[]) => void;
+  onConverged: (event: ContinuationConvergenceEvent) => void | Promise<void>;
+  onRefreshError?: (error: unknown) => void;
+  initialPollDelayMs: number;
+  maxPollDelayMs: number;
+};
+
+export const resolvePersistedHistoryContinuation = ({
+  messages,
+  targetMessageId,
+}: {
+  messages: ChatMessage[];
+  targetMessageId: string;
+}): ContinuationConvergenceEvent | null => {
+  const currentAgentMessage = messages.find(
+    (message) => message.id === targetMessageId && message.role === "agent",
+  );
+  if (
+    !currentAgentMessage?.status ||
+    currentAgentMessage.status === "streaming"
+  ) {
+    return null;
+  }
+  return {
+    source: "persisted-history",
+    status: currentAgentMessage.status,
+    message: currentAgentMessage,
+  };
+};
+
+export function useContinuationConvergence({
+  enabled,
+  source,
+  monitorKey,
+  targetMessageId,
+  loadMessages,
+  onMessagesLoaded,
+  onConverged,
+  onRefreshError,
+  initialPollDelayMs,
+  maxPollDelayMs,
+}: UseContinuationConvergenceParams) {
+  const monitorRef = useRef<{
+    key: string;
+    cancelled: boolean;
+  } | null>(null);
+
+  useEffect(() => {
+    const resolvedTargetMessageId = targetMessageId?.trim() ?? "";
+    const resolvedMonitorKey = monitorKey?.trim() ?? "";
+    if (!enabled || !resolvedTargetMessageId || !resolvedMonitorKey) {
+      return;
+    }
+
+    const nextMonitorKey = `${source}:${resolvedMonitorKey}`;
+    const previousMonitor = monitorRef.current;
+    if (previousMonitor?.key === nextMonitorKey && !previousMonitor.cancelled) {
+      return;
+    }
+    if (previousMonitor) {
+      previousMonitor.cancelled = true;
+    }
+
+    const monitor = {
+      key: nextMonitorKey,
+      cancelled: false,
+    };
+    monitorRef.current = monitor;
+
+    const sleep = (ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      });
+
+    const runConvergence = async () => {
+      let pollDelayMs = initialPollDelayMs;
+      while (!monitor.cancelled) {
+        try {
+          const messages = await loadMessages();
+          if (monitor.cancelled) {
+            return;
+          }
+          onMessagesLoaded?.(messages);
+          const event = resolvePersistedHistoryContinuation({
+            messages,
+            targetMessageId: resolvedTargetMessageId,
+          });
+          if (event) {
+            await onConverged(event);
+            return;
+          }
+        } catch (error) {
+          if (!monitor.cancelled) {
+            onRefreshError?.(error);
+          }
+        }
+        await sleep(pollDelayMs);
+        pollDelayMs = Math.min(maxPollDelayMs, Math.round(pollDelayMs * 1.5));
+      }
+    };
+
+    const convergencePromise = runConvergence();
+    convergencePromise.catch((error) => {
+      if (!monitor.cancelled) {
+        onRefreshError?.(error);
+      }
+    });
+
+    return () => {
+      monitor.cancelled = true;
+      if (monitorRef.current === monitor) {
+        monitorRef.current = null;
+      }
+    };
+  }, [
+    enabled,
+    initialPollDelayMs,
+    loadMessages,
+    maxPollDelayMs,
+    monitorKey,
+    onConverged,
+    onMessagesLoaded,
+    onRefreshError,
+    source,
+    targetMessageId,
+  ]);
+}

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -230,7 +230,7 @@ describe("block-based stream parser and reducer", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks?.[0]?.type).toBe("interrupt_event");
     expect(blocks?.[0]?.content).toBe(
-      "Agent requested authorization: read.\nTargets: /repo/.env",
+      "Agent requested permission: read.\nTargets: /repo/.env",
     );
     expect(blocks?.[0]?.interrupt).toEqual({
       requestId: "perm-1",
@@ -279,7 +279,7 @@ describe("block-based stream parser and reducer", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks?.[0]?.type).toBe("interrupt_event");
     expect(blocks?.[0]?.content).toBe(
-      "Agent requested authorization: write.\nTargets: /repo/config.yml",
+      "Agent requested permission: write.\nTargets: /repo/config.yml",
     );
     expect(blocks?.[0]?.interrupt).toEqual({
       requestId: "perm-2",

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -322,13 +322,13 @@ const stringifyInterruptObject = (value: unknown): string | null => {
 const buildInterruptEventContent = (interrupt: RuntimeInterrupt): string => {
   const messageCode = buildInterruptEventMessageCode(interrupt);
   if (messageCode === "permission_expired") {
-    return "Authorization request expired. Interrupt closed.";
+    return "Permission request expired. Interrupt closed.";
   }
   if (messageCode === "permissions_expired") {
     return "Permissions request expired. Interrupt closed.";
   }
   if (messageCode === "permission_resolved") {
-    return "Authorization request was handled. Agent resumed.";
+    return "Permission request was handled. Agent resumed.";
   }
   if (messageCode === "permissions_resolved") {
     return "Permissions request was handled. Agent resumed.";
@@ -360,7 +360,7 @@ const buildInterruptEventContent = (interrupt: RuntimeInterrupt): string => {
     const permission = askedInterrupt.details.permission?.trim() || "unknown";
     const patterns = askedInterrupt.details.patterns ?? [];
     const baseMessage =
-      displayMessage || `Agent requested authorization: ${permission}.`;
+      displayMessage || `Agent requested permission: ${permission}.`;
     if (patterns.length > 0) {
       return `${baseMessage}\nTargets: ${patterns.join(", ")}`;
     }

--- a/frontend/lib/api/hubAssistant.ts
+++ b/frontend/lib/api/hubAssistant.ts
@@ -23,7 +23,7 @@ export type HubAssistantProfileResponse = {
   tools: HubAssistantToolResponse[];
 };
 
-type HubAssistantInterruptResponse = {
+type HubAssistantPermissionInterruptResponse = {
   requestId: string;
   type: "permission";
   phase: "asked";
@@ -34,7 +34,7 @@ type HubAssistantInterruptResponse = {
   };
 };
 
-type HubAssistantRecoveredInterruptResponse = {
+type HubAssistantRecoveredPermissionInterruptResponse = {
   requestId: string;
   sessionId: string;
   type: "permission";
@@ -54,7 +54,7 @@ type HubAssistantRunResponse = {
   resources: string[];
   tools: string[];
   write_tools_enabled: boolean;
-  interrupt?: HubAssistantInterruptResponse | null;
+  interrupt?: HubAssistantPermissionInterruptResponse | null;
   continuation?: {
     phase: "running";
     agentMessageId: string;
@@ -102,11 +102,11 @@ export const replyHubAssistantPermissionInterrupt = (payload: {
     body: payload,
   });
 
-export const recoverHubAssistantInterrupts = async (payload: {
+export const recoverHubAssistantPermissionInterrupts = async (payload: {
   conversationId: string;
 }) => {
   const response = await apiRequest<{
-    items?: HubAssistantRecoveredInterruptResponse[];
+    items?: HubAssistantRecoveredPermissionInterruptResponse[];
   }>("/me/hub-assistant/interrupts:recover", {
     method: "POST",
     body: payload,
@@ -123,16 +123,16 @@ export const recoverHubAssistantInterrupts = async (payload: {
 
 const buildInterruptDetails = (
   interrupt:
-    | HubAssistantInterruptResponse
-    | HubAssistantRecoveredInterruptResponse,
+    | HubAssistantPermissionInterruptResponse
+    | HubAssistantRecoveredPermissionInterruptResponse,
 ) => ({
   permission: interrupt.details.permission ?? null,
   patterns: interrupt.details.patterns ?? [],
   displayMessage: interrupt.details.displayMessage ?? null,
 });
 
-export const toPendingRuntimeInterrupt = (
-  interrupt: HubAssistantInterruptResponse,
+export const toPendingRuntimePermissionInterrupt = (
+  interrupt: HubAssistantPermissionInterruptResponse,
 ): PendingRuntimeInterrupt => ({
   requestId: interrupt.requestId,
   type: interrupt.type,
@@ -141,7 +141,7 @@ export const toPendingRuntimeInterrupt = (
 });
 
 const toRecoveredPendingRuntimeInterrupt = (
-  interrupt: HubAssistantRecoveredInterruptResponse,
+  interrupt: HubAssistantRecoveredPermissionInterruptResponse,
 ): PendingRuntimeInterrupt | null => {
   const requestId = interrupt.requestId.trim();
   const sessionId = interrupt.sessionId.trim();

--- a/frontend/screens/__tests__/ChatScreen.interrupt.hub-assistant.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.hub-assistant.test.tsx
@@ -23,7 +23,7 @@ const mockInvokeAgent = jest.fn();
 const mockInvokeHubAgent = jest.fn();
 const mockGetHubAssistantProfile = jest.fn();
 const mockRunHubAssistant = jest.fn();
-const mockRecoverHubAssistantInterrupts = jest.fn();
+const mockRecoverHubAssistantPermissionInterrupts = jest.fn();
 const mockReplyHubAssistantPermissionInterrupt = jest.fn();
 const mockAddConversationMessage = jest.fn();
 const mockMergeConversationMessages = jest.fn();
@@ -166,7 +166,7 @@ jest.mock("@/components/chat/ChatTimelinePanel", () => ({
         {!props.pendingInterrupt ? null : (
           <>
             <Text>
-              Agent is waiting for authorization/input. Resolve the action card
+              Agent is waiting for permission/input. Resolve the action card
               first.
             </Text>
             {props.pendingInterrupt.type === "permission" ? (
@@ -498,11 +498,11 @@ jest.mock("@/lib/api/hubAssistant", () => ({
   getHubAssistantProfile: (...args: unknown[]) =>
     mockGetHubAssistantProfile(...args),
   runHubAssistant: (...args: unknown[]) => mockRunHubAssistant(...args),
-  recoverHubAssistantInterrupts: (...args: unknown[]) =>
-    mockRecoverHubAssistantInterrupts(...args),
+  recoverHubAssistantPermissionInterrupts: (...args: unknown[]) =>
+    mockRecoverHubAssistantPermissionInterrupts(...args),
   replyHubAssistantPermissionInterrupt: (...args: unknown[]) =>
     mockReplyHubAssistantPermissionInterrupt(...args),
-  toPendingRuntimeInterrupt: (interrupt: {
+  toPendingRuntimePermissionInterrupt: (interrupt: {
     requestId: string;
     type: "permission";
     phase: "asked";
@@ -583,7 +583,7 @@ describe("ChatScreen interrupt handling", () => {
       mockInvokeHubAgent,
       mockGetHubAssistantProfile,
       mockRunHubAssistant,
-      mockRecoverHubAssistantInterrupts,
+      mockRecoverHubAssistantPermissionInterrupts,
       mockReplyHubAssistantPermissionInterrupt,
       mockAddConversationMessage,
       mockMergeConversationMessages,
@@ -778,7 +778,7 @@ describe("ChatScreen interrupt handling", () => {
       });
       expect(mockToastSuccess).toHaveBeenCalledWith(
         "Action submitted",
-        "Authorization request handled.",
+        "Permission request handled.",
       );
 
       act(() => {
@@ -787,7 +787,7 @@ describe("ChatScreen interrupt handling", () => {
     },
   );
 
-  it("closes the Hub Assistant authorization card on fast-ack and enters continuation state", async () => {
+  it("closes the Hub Assistant permission card on fast-ack and enters continuation state", async () => {
     mockReplyHubAssistantPermissionInterrupt.mockImplementationOnce(
       async (payload: { agentMessageId: string }) => {
         return {
@@ -863,7 +863,7 @@ describe("ChatScreen interrupt handling", () => {
     });
     expect(mockToastSuccess).toHaveBeenCalledWith(
       "Action submitted",
-      "Authorization request handled.",
+      "Permission request handled.",
     );
 
     act(() => {
@@ -1061,7 +1061,7 @@ describe("ChatScreen interrupt handling", () => {
       await act(async () => {
         await Promise.resolve();
       });
-      mockRecoverHubAssistantInterrupts.mockClear();
+      mockRecoverHubAssistantPermissionInterrupts.mockClear();
 
       await act(async () => {
         jest.advanceTimersByTime(5_000);
@@ -1073,7 +1073,9 @@ describe("ChatScreen interrupt handling", () => {
         before: null,
         limit: 8,
       });
-      expect(mockRecoverHubAssistantInterrupts).not.toHaveBeenCalled();
+      expect(
+        mockRecoverHubAssistantPermissionInterrupts,
+      ).not.toHaveBeenCalled();
 
       act(() => {
         tree.unmount();

--- a/frontend/screens/__tests__/ChatScreen.interrupt.recovery.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.recovery.test.tsx
@@ -23,7 +23,7 @@ const mockInvokeAgent = jest.fn();
 const mockInvokeHubAgent = jest.fn();
 const mockGetHubAssistantProfile = jest.fn();
 const mockRunHubAssistant = jest.fn();
-const mockRecoverHubAssistantInterrupts = jest.fn();
+const mockRecoverHubAssistantPermissionInterrupts = jest.fn();
 const mockReplyHubAssistantPermissionInterrupt = jest.fn();
 const mockAddConversationMessage = jest.fn();
 const mockMergeConversationMessages = jest.fn();
@@ -166,7 +166,7 @@ jest.mock("@/components/chat/ChatTimelinePanel", () => ({
         {!props.pendingInterrupt ? null : (
           <>
             <Text>
-              Agent is waiting for authorization/input. Resolve the action card
+              Agent is waiting for permission/input. Resolve the action card
               first.
             </Text>
             {props.pendingInterrupt.type === "permission" ? (
@@ -498,11 +498,11 @@ jest.mock("@/lib/api/hubAssistant", () => ({
   getHubAssistantProfile: (...args: unknown[]) =>
     mockGetHubAssistantProfile(...args),
   runHubAssistant: (...args: unknown[]) => mockRunHubAssistant(...args),
-  recoverHubAssistantInterrupts: (...args: unknown[]) =>
-    mockRecoverHubAssistantInterrupts(...args),
+  recoverHubAssistantPermissionInterrupts: (...args: unknown[]) =>
+    mockRecoverHubAssistantPermissionInterrupts(...args),
   replyHubAssistantPermissionInterrupt: (...args: unknown[]) =>
     mockReplyHubAssistantPermissionInterrupt(...args),
-  toPendingRuntimeInterrupt: (interrupt: {
+  toPendingRuntimePermissionInterrupt: (interrupt: {
     requestId: string;
     type: "permission";
     phase: "asked";
@@ -583,7 +583,7 @@ describe("ChatScreen interrupt handling", () => {
       mockInvokeHubAgent,
       mockGetHubAssistantProfile,
       mockRunHubAssistant,
-      mockRecoverHubAssistantInterrupts,
+      mockRecoverHubAssistantPermissionInterrupts,
       mockReplyHubAssistantPermissionInterrupt,
       mockAddConversationMessage,
       mockMergeConversationMessages,
@@ -669,7 +669,7 @@ describe("ChatScreen interrupt handling", () => {
       ...baseSession(),
       agentId: HUB_ASSISTANT_AGENT_ID,
     };
-    mockRecoverHubAssistantInterrupts.mockResolvedValue({
+    mockRecoverHubAssistantPermissionInterrupts.mockResolvedValue({
       items: [
         {
           requestId: "perm-hub_assistant-1",
@@ -695,7 +695,7 @@ describe("ChatScreen interrupt handling", () => {
       await Promise.resolve();
     });
 
-    expect(mockRecoverHubAssistantInterrupts).toHaveBeenCalledWith({
+    expect(mockRecoverHubAssistantPermissionInterrupts).toHaveBeenCalledWith({
       conversationId,
     });
     expect(mockRecoverInterrupts).not.toHaveBeenCalled();
@@ -748,7 +748,7 @@ describe("ChatScreen interrupt handling", () => {
     expect(
       root.findByProps({
         children:
-          "Agent is waiting for authorization/input. Resolve the action card first.",
+          "Agent is waiting for permission/input. Resolve the action card first.",
       }),
     ).toBeTruthy();
     act(() => {
@@ -1001,7 +1001,7 @@ describe("ChatScreen interrupt handling", () => {
     expect(
       root.findByProps({
         children:
-          "Agent is waiting for authorization/input. Resolve the action card first.",
+          "Agent is waiting for permission/input. Resolve the action card first.",
       }),
     ).toBeTruthy();
 

--- a/frontend/screens/__tests__/ChatScreen.interrupt.session-controls.test.tsx
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.session-controls.test.tsx
@@ -22,7 +22,7 @@ const mockInvokeAgent = jest.fn();
 const mockInvokeHubAgent = jest.fn();
 const mockGetHubAssistantProfile = jest.fn();
 const mockRunHubAssistant = jest.fn();
-const mockRecoverHubAssistantInterrupts = jest.fn();
+const mockRecoverHubAssistantPermissionInterrupts = jest.fn();
 const mockReplyHubAssistantPermissionInterrupt = jest.fn();
 const mockAddConversationMessage = jest.fn();
 const mockMergeConversationMessages = jest.fn();
@@ -165,7 +165,7 @@ jest.mock("@/components/chat/ChatTimelinePanel", () => ({
         {!props.pendingInterrupt ? null : (
           <>
             <Text>
-              Agent is waiting for authorization/input. Resolve the action card
+              Agent is waiting for permission/input. Resolve the action card
               first.
             </Text>
             {props.pendingInterrupt.type === "permission" ? (
@@ -497,11 +497,11 @@ jest.mock("@/lib/api/hubAssistant", () => ({
   getHubAssistantProfile: (...args: unknown[]) =>
     mockGetHubAssistantProfile(...args),
   runHubAssistant: (...args: unknown[]) => mockRunHubAssistant(...args),
-  recoverHubAssistantInterrupts: (...args: unknown[]) =>
-    mockRecoverHubAssistantInterrupts(...args),
+  recoverHubAssistantPermissionInterrupts: (...args: unknown[]) =>
+    mockRecoverHubAssistantPermissionInterrupts(...args),
   replyHubAssistantPermissionInterrupt: (...args: unknown[]) =>
     mockReplyHubAssistantPermissionInterrupt(...args),
-  toPendingRuntimeInterrupt: (interrupt: {
+  toPendingRuntimePermissionInterrupt: (interrupt: {
     requestId: string;
     type: "permission";
     phase: "asked";
@@ -582,7 +582,7 @@ describe("ChatScreen interrupt handling", () => {
       mockInvokeHubAgent,
       mockGetHubAssistantProfile,
       mockRunHubAssistant,
-      mockRecoverHubAssistantInterrupts,
+      mockRecoverHubAssistantPermissionInterrupts,
       mockReplyHubAssistantPermissionInterrupt,
       mockAddConversationMessage,
       mockMergeConversationMessages,

--- a/frontend/screens/__tests__/ChatScreen.interrupt.test.common.ts
+++ b/frontend/screens/__tests__/ChatScreen.interrupt.test.common.ts
@@ -82,7 +82,7 @@ type ChatScreenInterruptHarnessDependencies = {
   mockInvokeHubAgent: jest.Mock;
   mockGetHubAssistantProfile: jest.Mock;
   mockRunHubAssistant: jest.Mock;
-  mockRecoverHubAssistantInterrupts: jest.Mock;
+  mockRecoverHubAssistantPermissionInterrupts: jest.Mock;
   mockReplyHubAssistantPermissionInterrupt: jest.Mock;
   mockAddConversationMessage: jest.Mock;
   mockMergeConversationMessages: jest.Mock;
@@ -164,7 +164,7 @@ export function resetChatScreenInterruptHarness(
     write_tools_enabled: false,
     interrupt: null,
   });
-  deps.mockRecoverHubAssistantInterrupts
+  deps.mockRecoverHubAssistantPermissionInterrupts
     .mockReset()
     .mockResolvedValue({ items: [] });
   deps.mockReplyHubAssistantPermissionInterrupt.mockReset().mockResolvedValue({

--- a/frontend/store/__tests__/chatRuntime.interrupts.test.ts
+++ b/frontend/store/__tests__/chatRuntime.interrupts.test.ts
@@ -140,7 +140,7 @@ describe("executeChatRuntime empty-content recovery", () => {
 
     expect(interruptBlockSnapshot).toMatchObject({
       type: "interrupt_event",
-      content: "Agent requested authorization: read.\nTargets: /repo/.env",
+      content: "Agent requested permission: read.\nTargets: /repo/.env",
     });
     expect(state.sessions[conversationId]?.pendingInterrupts).toEqual([]);
     expect(state.sessions[conversationId]?.pendingInterrupt).toBeNull();


### PR DESCRIPTION
## 概述
- Closes #843
- Closes #827
- 将 shared interrupt controller 的 action mode 从 permission 专用返回值扩展为通用 `InterruptActionMode` / `InterruptActionResult`。
- 将 `permission once/always`、`permissions:reply`、`question:reply` 收敛为 ack-fast 语义：upstream callback ack 成功后关闭旧 interrupt 卡片。
- 保留 `permission reject`、`question reject`、`elicitation accept/decline/cancel` 的 transactional 行为；本 PR 明确不迁移 `elicitation:accept`。
- 抽出轻量 `useContinuationConvergence`，让 Hub Assistant continuation 通过统一 convergence event 形状从 persisted history 收敛，削薄 controller 内部专用 polling 逻辑。
- 收敛 Hub Assistant permission interrupt 命名与写入授权 operation ids 生命周期命名，避免 `permission` / `authorization` / `approval` / `allowed` 在不同阶段混用。

## 前端
- 在 `useChatInterruptController` 中新增统一 finalize 分支，集中处理 ack-fast 与 transactional 的清卡和本地 resolved interrupt acknowledgement。
- `permission once/always` 默认走 ack-fast；`permission reject` 默认走 transactional。
- `question:reply` 与 `permissions:reply` 走 ack-fast；`question:reject` 与全部 elicitation action 继续 transactional。
- 清理迁移期 `PermissionReplyActionMode` / `PermissionReplyActionResult` alias，统一使用语义更清晰的 `InterruptActionMode` / `InterruptActionResult`。
- 新增 `useContinuationConvergence`，当前仅实现必要的 `persisted-history` source，并在事件模型中保留 `stream` / `runtime-status` source 边界，避免过度抽象但为后续收敛留出明确入口。
- `useChatScreenHubAssistantController` 仍负责 Hub Assistant 业务状态更新，但不再内联维护 continuation monitor、poll delay 与终态判断。
- 将 Hub Assistant API 类型和测试 mock 命名收敛为 `PermissionInterrupt`，避免通用 `Interrupt` 名称掩盖当前实体只有 permission interrupt 的事实。
- 将 interrupt UI 与事件消息中的 `Authorization` 文案统一改为 `Permission`，保留 HTTP Authorization 相关命名不动。

## 后端
- 将 Hub Assistant domain/schema 命名收敛为 `HubAssistantPermissionInterrupt*`，避免 domain model 与 response schema 共用泛化 `HubAssistantInterrupt`。
- 将 write approval token 中待用户批准的操作命名为 `requested_operations`，用户同意后才进入 `approved_operation_ids`，运行时/MCP access token 边界继续使用 `allowed_operation_ids`。
- 将 Hub Assistant recovery 内部方法改为 `recover_pending_permission_interrupts`，并显式过滤非 permission interrupt。
- 更新 interrupt lifecycle message contract，将 permission interrupt 用户文案统一为 `Permission request ...` / `Agent requested permission ...`。

## 测试
- 更新 shared interrupt controller 单测，覆盖 permission grant ack-fast、permission reject transactional、question answer ack-fast、permissions reply ack-fast、elicitation accept transactional。
- 新增 continuation convergence 单测，覆盖 persisted history 下的 streaming 等待、非目标消息忽略、done / interrupted / error 终态识别。
- 更新 Hub Assistant write approval、recovery、session/invoke interrupt contract 与前端 stream contract 测试，覆盖命名与文案收敛后的行为。
- 保留 terminal error 与非终态 callback error 的既有保护。

## 死代码与命名审查
- 已执行全仓高置信死代码扫描：`bash scripts/check-dead-code.sh all`。
- 本次收尾再次执行全仓高置信死代码扫描：`bash scripts/check-dead-code.sh all`，无 backend strict vulture 或 frontend strict unused exports 输出，因此未做无依据删除。
- 本次新增 hook 后又执行 frontend strict unused exports：`bash scripts/check-dead-code.sh frontend`。
- 全局扫描同义类型 alias；移除本 PR 迁移残留的 permission action aliases。
- 保留 `UUID`、`AgentHeader`、`HeaderRow` 这类领域语义别名，因为它们表达 API/domain 边界，不属于无意义迁移残留。
- 本次进一步清理 Hub Assistant token claim 操作解析薄壳：删除 `get_hub_assistant_allowed_operations` / `get_hub_assistant_interrupt_requested_operations` 双 wrapper，改为单一 `get_hub_assistant_operation_ids`，由调用点变量名表达 delegated allowed 与 interrupt requested 语义。
- 删除 `HubAssistantService` 中仅转发到 `_runtime` 的私有方法，避免 service 层制造无行为边界的二次命名。
- 最新命名残留搜索未发现旧 `PermissionReplyAction*` alias、旧 Hub Assistant 泛化 interrupt 类型、旧 `Authorization` interrupt 文案或旧 `allowed_write_operation_ids` 调用。

## Issue 关系
- `Closes #843`：准确。本 PR 完成该 issue 明确列出的 ack-fast 迁移范围，并按要求排除 `elicitation:accept`。
- `Closes #827`：准确。本 PR 完成 action mode 明确分流，将 Hub Assistant continuation 从 controller 内嵌专用 monitor 收敛到轻量统一 convergence abstraction，并补齐 permission interrupt 命名语义收敛；未强行把 persisted history 包装成 stream/runtime status，符合“避免过度抽象”的边界。

## 验证
- `bash scripts/check-dead-code.sh all`
- 结果：通过，无高置信死代码输出。
- `cd backend && uv run --locked pre-commit run --files ... --config ../.pre-commit-config.yaml`
- 结果：通过，包含 Black/isort/Ruff/mypy/secrets 等 scoped checks。
- `cd backend && uv run --locked pytest tests/hub_assistant/test_hub_assistant_routes.py tests/hub_assistant/test_hub_assistant_write_approval.py tests/invoke/test_interrupt_metadata_normalization.py tests/invoke/test_invoke_route_runner_streaming.py tests/sessions/test_unified_session_domain_routes.py tests/hub_assistant/test_hub_assistant_runtime.py`
- 结果：`82 passed`。
- `cd backend && uv run --locked pre-commit run --files app/core/security.py app/features/hub_assistant/service.py app/features/hub_assistant/shared/hub_assistant_mcp.py tests/hub_assistant/hub_assistant_support.py tests/hub_assistant/test_hub_assistant_runtime.py tests/hub_assistant/test_hub_assistant_write_approval.py --config ../.pre-commit-config.yaml`
- 结果：通过，包含 Black/isort/Ruff/mypy/secrets 等 scoped checks。
- `cd backend && uv run --locked pytest tests/hub_assistant/test_hub_assistant_runtime.py tests/hub_assistant/test_hub_assistant_write_approval.py tests/hub_assistant/test_hub_assistant_mcp.py`
- 结果：`48 passed`。
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests ... --maxWorkers=25%`
- 结果：相关 Jest 套件 `60 passed, 359 tests passed`。
- 此前完整相关套件：`5 passed, 45 tests passed`。
- `bash scripts/check-dead-code.sh frontend`
- 结果：通过，无高置信死代码输出。

