### PR TITLE
feat(sessions): add upstream task query (#539)

### DIFF
--- a/backend/alembic/versions/20260422_0830_r202604220830_add_conversation_upstream_tasks.py
+++ b/backend/alembic/versions/20260422_0830_r202604220830_add_conversation_upstream_tasks.py
@@ -1,0 +1,216 @@
+"""Add durable conversation upstream task bindings.
+
+Revision ID: r202604220830
+Revises: r202604201030
+Create Date: 2026-04-22 08:30:00.000000
+"""
+
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "r202604220830"
+down_revision = "r202604201030"
+branch_labels = None
+depends_on = None
+
+SCHEMA_NAME = os.getenv("SCHEMA_NAME", "a2a_client_hub_schema")
+TABLE_NAME = "conversation_upstream_tasks"
+
+
+def upgrade() -> None:
+    op.create_table(
+        TABLE_NAME,
+        sa.Column("conversation_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("agent_source", sa.String(length=16), nullable=True),
+        sa.Column("upstream_task_id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "first_seen_message_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("latest_message_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "source",
+            sa.String(length=32),
+            server_default="stream_identity",
+            nullable=False,
+        ),
+        sa.Column("status_hint", sa.String(length=32), nullable=True),
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            [f"{SCHEMA_NAME}.conversation_threads.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["first_seen_message_id"],
+            [f"{SCHEMA_NAME}.agent_messages.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["latest_message_id"],
+            [f"{SCHEMA_NAME}.agent_messages.id"],
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            [f"{SCHEMA_NAME}.users.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "conversation_id",
+            "upstream_task_id",
+            name="uq_conversation_upstream_tasks_user_conversation_task",
+        ),
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_conversation_upstream_tasks_agent_id",
+        TABLE_NAME,
+        ["agent_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_conversation_upstream_tasks_user_id",
+        TABLE_NAME,
+        ["user_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_conversation_upstream_tasks_user_conversation_updated",
+        TABLE_NAME,
+        ["user_id", "conversation_id", "updated_at"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.create_index(
+        "ix_conversation_upstream_tasks_user_task",
+        TABLE_NAME,
+        ["user_id", "upstream_task_id"],
+        unique=False,
+        schema=SCHEMA_NAME,
+    )
+    op.execute(
+        sa.text(
+            f"""
+            INSERT INTO {SCHEMA_NAME}.{TABLE_NAME} (
+                id,
+                user_id,
+                conversation_id,
+                agent_id,
+                agent_source,
+                upstream_task_id,
+                first_seen_message_id,
+                latest_message_id,
+                source,
+                status_hint,
+                created_at,
+                updated_at
+            )
+            SELECT
+                (
+                    SUBSTR(grouped.binding_hash, 1, 8) || '-' ||
+                    SUBSTR(grouped.binding_hash, 9, 4) || '-' ||
+                    SUBSTR(grouped.binding_hash, 13, 4) || '-' ||
+                    SUBSTR(grouped.binding_hash, 17, 4) || '-' ||
+                    SUBSTR(grouped.binding_hash, 21, 12)
+                )::uuid,
+                grouped.user_id,
+                grouped.conversation_id,
+                ct.agent_id,
+                ct.agent_source,
+                grouped.upstream_task_id,
+                grouped.first_seen_message_id,
+                grouped.latest_message_id,
+                'metadata_backfill',
+                grouped.status_hint,
+                grouped.first_seen_at,
+                grouped.latest_seen_at
+            FROM (
+                SELECT
+                    am.user_id,
+                    am.conversation_id,
+                    BTRIM(am.metadata->>'upstream_task_id') AS upstream_task_id,
+                    MD5(
+                        am.user_id::text || ':' ||
+                        am.conversation_id::text || ':' ||
+                        BTRIM(am.metadata->>'upstream_task_id')
+                    ) AS binding_hash,
+                    (ARRAY_AGG(
+                        am.id ORDER BY am.created_at ASC, am.id ASC
+                    ))[1] AS first_seen_message_id,
+                    (ARRAY_AGG(
+                        am.id ORDER BY am.updated_at DESC, am.id DESC
+                    ))[1] AS latest_message_id,
+                    (ARRAY_AGG(
+                        am.status ORDER BY am.updated_at DESC, am.id DESC
+                    ))[1] AS status_hint,
+                    MIN(am.created_at) AS first_seen_at,
+                    MAX(am.updated_at) AS latest_seen_at
+                FROM {SCHEMA_NAME}.agent_messages am
+                WHERE am.metadata ? 'upstream_task_id'
+                  AND NULLIF(BTRIM(am.metadata->>'upstream_task_id'), '') IS NOT NULL
+                GROUP BY
+                    am.user_id,
+                    am.conversation_id,
+                    BTRIM(am.metadata->>'upstream_task_id')
+            ) grouped
+            JOIN {SCHEMA_NAME}.conversation_threads ct
+              ON ct.id = grouped.conversation_id
+             AND ct.user_id = grouped.user_id
+            ON CONFLICT (
+                user_id,
+                conversation_id,
+                upstream_task_id
+            ) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_conversation_upstream_tasks_user_task",
+        table_name=TABLE_NAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_conversation_upstream_tasks_user_conversation_updated",
+        table_name=TABLE_NAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_conversation_upstream_tasks_user_id",
+        table_name=TABLE_NAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_index(
+        "ix_conversation_upstream_tasks_agent_id",
+        table_name=TABLE_NAME,
+        schema=SCHEMA_NAME,
+    )
+    op.drop_table(TABLE_NAME, schema=SCHEMA_NAME)

--- a/backend/app/db/models/__init__.py
+++ b/backend/app/db/models/__init__.py
@@ -16,6 +16,7 @@ from app.db.models.auth_audit_event import AuthAuditEvent
 from app.db.models.auth_legacy_refresh_revocation import AuthLegacyRefreshRevocation
 from app.db.models.auth_refresh_session import AuthRefreshSession
 from app.db.models.conversation_thread import ConversationThread
+from app.db.models.conversation_upstream_task import ConversationUpstreamTask
 from app.db.models.external_session_directory_cache import (
     ExternalSessionDirectoryCacheEntry,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "AuthLegacyRefreshRevocation",
     "AuthRefreshSession",
     "ConversationThread",
+    "ConversationUpstreamTask",
     "HubA2AAgentAllowlistEntry",
     "HubA2AUserCredential",
     "Invitation",

--- a/backend/app/db/models/conversation_upstream_task.py
+++ b/backend/app/db/models/conversation_upstream_task.py
@@ -1,0 +1,81 @@
+"""Durable upstream task binding for one conversation."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.models.base import SCHEMA_NAME, Base, TimestampMixin, UserOwnedMixin
+
+
+class ConversationUpstreamTask(Base, TimestampMixin, UserOwnedMixin):
+    """Locally observed upstream A2A task owned by a conversation."""
+
+    __tablename__ = "conversation_upstream_tasks"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "conversation_id",
+            "upstream_task_id",
+            name="uq_conversation_upstream_tasks_user_conversation_task",
+        ),
+        Index(
+            "ix_conversation_upstream_tasks_user_conversation_updated",
+            "user_id",
+            "conversation_id",
+            "updated_at",
+        ),
+        Index(
+            "ix_conversation_upstream_tasks_user_task",
+            "user_id",
+            "upstream_task_id",
+        ),
+        {"schema": SCHEMA_NAME},
+    )
+
+    conversation_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey(f"{SCHEMA_NAME}.conversation_threads.id", ondelete="CASCADE"),
+        nullable=False,
+        comment="Conversation that first observed this upstream task.",
+    )
+    agent_id = Column(
+        UUID(as_uuid=True),
+        nullable=True,
+        index=True,
+        comment="Agent id used when the upstream task was observed.",
+    )
+    agent_source = Column(
+        String(16),
+        nullable=True,
+        comment="Agent source scope used when the upstream task was observed.",
+    )
+    upstream_task_id = Column(
+        String(255),
+        nullable=False,
+        comment="Upstream A2A task identifier.",
+    )
+    first_seen_message_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey(f"{SCHEMA_NAME}.agent_messages.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="First local agent message that carried this upstream task id.",
+    )
+    latest_message_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey(f"{SCHEMA_NAME}.agent_messages.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="Latest local agent message associated with this upstream task id.",
+    )
+    source = Column(
+        String(32),
+        nullable=False,
+        default="stream_identity",
+        server_default="stream_identity",
+        comment="Local observation source for this binding.",
+    )
+    status_hint = Column(
+        String(32),
+        nullable=True,
+        comment="Best-effort latest local status hint for this upstream task.",
+    )

--- a/backend/app/features/invoke/route_runner.py
+++ b/backend/app/features/invoke/route_runner.py
@@ -43,6 +43,7 @@ from app.features.invoke.route_runner_state import (
     preempt_previous_invoke_if_requested,
     prepare_state,
     record_preempt_history_event,
+    record_upstream_task_binding,
     register_inflight_invoke,
     unregister_inflight_invoke,
 )
@@ -196,6 +197,22 @@ async def _record_preempt_history_event(
     )
 
 
+async def _record_upstream_task_binding(
+    *,
+    state: InvokeState,
+    user_id: UUID,
+    task_id: str,
+) -> None:
+    await record_upstream_task_binding(
+        state=state,
+        user_id=user_id,
+        task_id=task_id,
+        session_factory=AsyncSessionLocal,
+        commit_fn=commit_safely,
+        session_hub=session_hub_service,
+    )
+
+
 async def _preempt_previous_invoke_if_requested(
     *,
     state: InvokeState,
@@ -221,6 +238,7 @@ async def _bind_inflight_task_if_needed(
         state=state,
         user_id=user_id,
         record_preempt_history_event_fn=_record_preempt_history_event,
+        record_upstream_task_binding_fn=_record_upstream_task_binding,
     )
 
 

--- a/backend/app/features/invoke/route_runner_state.py
+++ b/backend/app/features/invoke/route_runner_state.py
@@ -177,6 +177,28 @@ async def record_preempt_history_event(
         await commit_fn(db)
 
 
+async def record_upstream_task_binding(
+    *,
+    state: InvokeState,
+    user_id: UUID,
+    task_id: str,
+    session_factory: Callable[[], Any] = AsyncSessionLocal,
+    commit_fn: Callable[[Any], Awaitable[None]] = commit_safely,
+    session_hub: Any = session_hub_service,
+) -> None:
+    if state.local_session_id is None:
+        return
+    async with session_factory() as db:
+        await session_hub.record_upstream_task_binding(
+            db,
+            user_id=user_id,
+            conversation_id=state.local_session_id,
+            task_id=task_id,
+            source="stream_identity",
+        )
+        await commit_fn(db)
+
+
 async def preempt_previous_invoke_if_requested(
     *,
     state: InvokeState,
@@ -238,6 +260,9 @@ async def bind_inflight_task_if_needed(
     record_preempt_history_event_fn: Callable[..., Awaitable[None]] = (
         record_preempt_history_event
     ),
+    record_upstream_task_binding_fn: Callable[..., Awaitable[None]] = (
+        record_upstream_task_binding
+    ),
 ) -> None:
     if state.local_session_id is None or state.inflight_token is None:
         return
@@ -259,6 +284,11 @@ async def bind_inflight_task_if_needed(
     )
     if bind_report.bound:
         state.upstream_task_id = normalized_task_id
+        await record_upstream_task_binding_fn(
+            state=state,
+            user_id=user_id,
+            task_id=normalized_task_id,
+        )
     if bind_report.preempt_event is not None:
         await record_preempt_history_event_fn(
             state=state,

--- a/backend/app/features/invoke/stream_persistence.py
+++ b/backend/app/features/invoke/stream_persistence.py
@@ -556,6 +556,28 @@ async def persist_local_outcome(
                 user_sender=request.user_sender,
             )
         )
+        raw_task_id = (
+            state.stream_identity.get("upstream_task_id")
+            if isinstance(state.stream_identity, dict)
+            else None
+        )
+        normalized_task_id = normalize_non_empty_text(
+            raw_task_id if isinstance(raw_task_id, str) else None
+        )
+        if normalized_task_id:
+            binding_conversation_id = coerce_uuid(message_refs.get("conversation_id"))
+            binding_agent_message_id = coerce_uuid(message_refs.get("agent_message_id"))
+            await session_hub.record_upstream_task_binding(
+                persist_db,
+                user_id=request.user_id,
+                conversation_id=binding_conversation_id or state.local_session_id,
+                task_id=normalized_task_id,
+                agent_id=request.agent_id,
+                agent_source=request.agent_source,
+                message_id=binding_agent_message_id,
+                source="final_metadata",
+                status_hint=resolve_agent_status_from_outcome(outcome),
+            )
         await commit_fn(persist_db)
     state.message_refs = message_refs
     state.persisted_success = outcome.success

--- a/backend/app/features/sessions/router.py
+++ b/backend/app/features/sessions/router.py
@@ -798,7 +798,7 @@ async def cancel_unified_session(
 
 
 @router.get(
-    "/{conversation_id}/upstream-tasks/{task_id}",
+    "/{conversation_id}/upstream-tasks/{task_id:path}",
     response_model=SessionUpstreamTaskResponse,
 )
 async def get_unified_session_upstream_task(

--- a/backend/app/features/sessions/router.py
+++ b/backend/app/features/sessions/router.py
@@ -6,7 +6,7 @@ import json
 from typing import Any, cast
 from uuid import UUID, uuid4
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Query
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -46,10 +46,12 @@ from app.features.sessions.schemas import (
     SessionMessagesQueryRequest,
     SessionMessagesQueryResponse,
     SessionQueryRequest,
+    SessionUpstreamTaskResponse,
     SessionViewItem,
 )
 from app.features.sessions.service import session_hub_service
 from app.features.working_directory import merge_working_directory_metadata
+from app.integrations.a2a_client.service import get_a2a_service
 from app.integrations.a2a_extensions import get_a2a_extensions_service
 from app.utils.session_identity import normalize_non_empty_text
 
@@ -77,10 +79,16 @@ def _status_code_for_session_error(detail: str) -> int:
         return 404
     if detail == "upstream_resource_not_found":
         return 404
+    if detail == "task_not_found":
+        return 404
     if detail == "upstream_unauthorized":
         return 401
     if detail == "upstream_quota_exceeded":
         return 429
+    if detail == "timeout":
+        return 504
+    if detail == "agent_unavailable":
+        return 503
     if detail in {
         "append_requires_bound_session",
         "session_command_requires_bound_session",
@@ -90,13 +98,17 @@ def _status_code_for_session_error(detail: str) -> int:
         return 409
     if detail in _FORBIDDEN_ERRORS:
         return 403
-    if detail == "upstream_permission_denied":
+    if detail in {"upstream_permission_denied", "outbound_not_allowed"}:
         return 403
+    if detail == "unsupported_operation":
+        return 501
     if detail in _UPSTREAM_ERRORS:
         if detail == "upstream_bad_request":
             return 400
         if detail == "upstream_unreachable":
             return 503
+        return 502
+    if detail in {"client_reset", "upstream_payload_error"}:
         return 502
     return 400
 
@@ -783,3 +795,61 @@ async def cancel_unified_session(
     if db_mutated:
         await commit_safely(db)
     return SessionCancelResponse.model_validate(payload)
+
+
+@router.get(
+    "/{conversation_id}/upstream-tasks/{task_id}",
+    response_model=SessionUpstreamTaskResponse,
+)
+async def get_unified_session_upstream_task(
+    *,
+    conversation_id: str,
+    task_id: str,
+    history_length: int | None = Query(
+        default=None,
+        ge=0,
+        le=100,
+        alias="historyLength",
+    ),
+    db: AsyncSession = Depends(get_async_db),
+    current_user: User = Depends(get_current_user),
+) -> SessionUpstreamTaskResponse:
+    current_user_id = cast(UUID, current_user.id)
+    try:
+        thread = await _get_conversation_thread_or_404(
+            db=db,
+            user_id=current_user_id,
+            conversation_id=conversation_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid_conversation_id") from exc
+
+    runtime = await _load_runtime_for_thread(
+        db=db,
+        current_user=current_user,
+        thread=thread,
+    )
+    result = await get_a2a_service().get_task(
+        resolved=runtime.resolved,
+        task_id=task_id,
+        history_length=history_length,
+        metadata=_build_session_action_metadata(thread=thread, metadata=None),
+    )
+    if not result.get("success"):
+        detail = str(result.get("error_code") or "upstream_error")
+        raise HTTPException(
+            status_code=_status_code_for_session_error(detail),
+            detail=detail,
+        )
+
+    task = result.get("task")
+    if not isinstance(task, dict):
+        raise HTTPException(status_code=502, detail="upstream_payload_error")
+
+    return SessionUpstreamTaskResponse.model_validate(
+        {
+            "conversationId": str(thread.id),
+            "taskId": result.get("task_id") or task_id.strip(),
+            "task": task,
+        }
+    )

--- a/backend/app/features/sessions/router.py
+++ b/backend/app/features/sessions/router.py
@@ -824,6 +824,15 @@ async def get_unified_session_upstream_task(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail="invalid_conversation_id") from exc
 
+    is_bound_task = await session_hub_service.verify_upstream_task_binding(
+        db,
+        user_id=current_user_id,
+        conversation_id=cast(UUID, thread.id),
+        task_id=task_id,
+    )
+    if not is_bound_task:
+        raise HTTPException(status_code=404, detail="task_not_found")
+
     runtime = await _load_runtime_for_thread(
         db=db,
         current_user=current_user,

--- a/backend/app/features/sessions/schemas.py
+++ b/backend/app/features/sessions/schemas.py
@@ -312,3 +312,11 @@ class SessionCancelResponse(BaseModel):
     ]
 
     model_config = {"populate_by_name": True}
+
+
+class SessionUpstreamTaskResponse(BaseModel):
+    conversation_id: str = Field(alias="conversationId")
+    task_id: str = Field(alias="taskId")
+    task: Dict[str, Any]
+
+    model_config = {"populate_by_name": True}

--- a/backend/app/features/sessions/service.py
+++ b/backend/app/features/sessions/service.py
@@ -13,6 +13,7 @@ from app.features.sessions.history_projection import SessionHistoryProjectionSer
 from app.features.sessions.inflight_service import SessionInflightService
 from app.features.sessions.query_service import SessionQueryService
 from app.features.sessions.support import SessionHubSupport
+from app.features.sessions.upstream_tasks import conversation_upstream_task_service
 
 if TYPE_CHECKING:
     from app.features.sessions.common import (
@@ -221,6 +222,49 @@ class SessionHubService:
             db,
             user_id=user_id,
             conversation_id=conversation_id,
+        )
+
+    async def record_upstream_task_binding(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        conversation_id: UUID,
+        task_id: str,
+        agent_id: UUID | None = None,
+        agent_source: str | None = None,
+        message_id: UUID | None = None,
+        source: Literal["stream_identity", "final_metadata", "metadata_backfill"] = (
+            "stream_identity"
+        ),
+        status_hint: str | None = None,
+    ) -> bool:
+        binding = await conversation_upstream_task_service.record_binding(
+            db,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            task_id=task_id,
+            agent_id=agent_id,
+            agent_source=agent_source,
+            message_id=message_id,
+            source=source,
+            status_hint=status_hint,
+        )
+        return binding is not None
+
+    async def verify_upstream_task_binding(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        conversation_id: UUID,
+        task_id: str,
+    ) -> bool:
+        return await conversation_upstream_task_service.verify_binding(
+            db,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            task_id=task_id,
         )
 
     async def ensure_local_session_for_invoke(

--- a/backend/app/features/sessions/upstream_tasks.py
+++ b/backend/app/features/sessions/upstream_tasks.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from typing import Literal, cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models.conversation_thread import ConversationThread
@@ -55,69 +56,62 @@ class ConversationUpstreamTaskService:
         if thread is None:
             return None
 
+        resolved_agent_id = agent_id or cast(UUID | None, thread.agent_id)
+        resolved_agent_source = agent_source or cast(str | None, thread.agent_source)
+        normalized_status_hint = normalize_non_empty_text(status_hint)
+        observed_at = utc_now()
+        insert_stmt = insert(ConversationUpstreamTask).values(
+            id=uuid4(),
+            user_id=user_id,
+            conversation_id=conversation_id,
+            agent_id=resolved_agent_id,
+            agent_source=resolved_agent_source,
+            upstream_task_id=normalized_task_id,
+            first_seen_message_id=message_id,
+            latest_message_id=message_id,
+            source=source,
+            status_hint=normalized_status_hint,
+            updated_at=observed_at,
+        )
+        excluded = insert_stmt.excluded
+        upsert_stmt = insert_stmt.on_conflict_do_update(
+            constraint="uq_conversation_upstream_tasks_user_conversation_task",
+            set_={
+                "agent_id": func.coalesce(
+                    excluded.agent_id,
+                    ConversationUpstreamTask.agent_id,
+                ),
+                "agent_source": func.coalesce(
+                    excluded.agent_source,
+                    ConversationUpstreamTask.agent_source,
+                ),
+                "first_seen_message_id": func.coalesce(
+                    ConversationUpstreamTask.first_seen_message_id,
+                    excluded.first_seen_message_id,
+                ),
+                "latest_message_id": func.coalesce(
+                    excluded.latest_message_id,
+                    ConversationUpstreamTask.latest_message_id,
+                ),
+                "source": excluded.source,
+                "status_hint": func.coalesce(
+                    excluded.status_hint,
+                    ConversationUpstreamTask.status_hint,
+                ),
+                "updated_at": observed_at,
+            },
+        ).returning(ConversationUpstreamTask.id)
+        binding_id = (await db.execute(upsert_stmt)).scalar_one_or_none()
+        if binding_id is None:
+            return None
         binding = cast(
             ConversationUpstreamTask | None,
             await db.scalar(
                 select(ConversationUpstreamTask).where(
-                    and_(
-                        ConversationUpstreamTask.user_id == user_id,
-                        ConversationUpstreamTask.conversation_id == conversation_id,
-                        ConversationUpstreamTask.upstream_task_id == normalized_task_id,
-                    )
+                    ConversationUpstreamTask.id == binding_id
                 )
             ),
         )
-        if binding is None:
-            binding = ConversationUpstreamTask(
-                user_id=user_id,
-                conversation_id=conversation_id,
-                agent_id=agent_id or cast(UUID | None, thread.agent_id),
-                agent_source=agent_source or cast(str | None, thread.agent_source),
-                upstream_task_id=normalized_task_id,
-                first_seen_message_id=message_id,
-                latest_message_id=message_id,
-                source=source,
-                status_hint=normalize_non_empty_text(status_hint),
-            )
-            db.add(binding)
-            await db.flush()
-            return binding
-
-        mutated = False
-        if agent_id is not None and cast(UUID | None, binding.agent_id) != agent_id:
-            setattr(binding, "agent_id", agent_id)
-            mutated = True
-        normalized_agent_source = normalize_non_empty_text(agent_source)
-        if (
-            normalized_agent_source is not None
-            and cast(str | None, binding.agent_source) != normalized_agent_source
-        ):
-            setattr(binding, "agent_source", normalized_agent_source)
-            mutated = True
-        if (
-            message_id is not None
-            and cast(UUID | None, binding.first_seen_message_id) is None
-        ):
-            setattr(binding, "first_seen_message_id", message_id)
-            mutated = True
-        if (
-            message_id is not None
-            and cast(UUID | None, binding.latest_message_id) != message_id
-        ):
-            setattr(binding, "latest_message_id", message_id)
-            mutated = True
-        normalized_status_hint = normalize_non_empty_text(status_hint)
-        if (
-            normalized_status_hint is not None
-            and cast(str | None, binding.status_hint) != normalized_status_hint
-        ):
-            setattr(binding, "status_hint", normalized_status_hint)
-            mutated = True
-        if cast(str | None, binding.source) != source:
-            setattr(binding, "source", source)
-            mutated = True
-        if mutated:
-            setattr(binding, "updated_at", utc_now())
         return binding
 
     async def verify_binding(

--- a/backend/app/features/sessions/upstream_tasks.py
+++ b/backend/app/features/sessions/upstream_tasks.py
@@ -1,0 +1,148 @@
+"""Durable upstream task ownership helpers for conversations."""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+from uuid import UUID
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models.conversation_thread import ConversationThread
+from app.db.models.conversation_upstream_task import ConversationUpstreamTask
+from app.features.sessions.common import normalize_non_empty_text
+from app.utils.timezone_util import utc_now
+
+UpstreamTaskBindingSource = Literal[
+    "stream_identity",
+    "final_metadata",
+    "metadata_backfill",
+]
+
+
+class ConversationUpstreamTaskService:
+    """Maintains local proof that an upstream task belongs to a conversation."""
+
+    async def record_binding(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        conversation_id: UUID,
+        task_id: str,
+        agent_id: UUID | None = None,
+        agent_source: str | None = None,
+        message_id: UUID | None = None,
+        source: UpstreamTaskBindingSource = "stream_identity",
+        status_hint: str | None = None,
+    ) -> ConversationUpstreamTask | None:
+        normalized_task_id = normalize_non_empty_text(task_id)
+        if not normalized_task_id:
+            return None
+
+        thread = cast(
+            ConversationThread | None,
+            await db.scalar(
+                select(ConversationThread).where(
+                    and_(
+                        ConversationThread.id == conversation_id,
+                        ConversationThread.user_id == user_id,
+                        ConversationThread.status == ConversationThread.STATUS_ACTIVE,
+                    )
+                )
+            ),
+        )
+        if thread is None:
+            return None
+
+        binding = cast(
+            ConversationUpstreamTask | None,
+            await db.scalar(
+                select(ConversationUpstreamTask).where(
+                    and_(
+                        ConversationUpstreamTask.user_id == user_id,
+                        ConversationUpstreamTask.conversation_id == conversation_id,
+                        ConversationUpstreamTask.upstream_task_id == normalized_task_id,
+                    )
+                )
+            ),
+        )
+        if binding is None:
+            binding = ConversationUpstreamTask(
+                user_id=user_id,
+                conversation_id=conversation_id,
+                agent_id=agent_id or cast(UUID | None, thread.agent_id),
+                agent_source=agent_source or cast(str | None, thread.agent_source),
+                upstream_task_id=normalized_task_id,
+                first_seen_message_id=message_id,
+                latest_message_id=message_id,
+                source=source,
+                status_hint=normalize_non_empty_text(status_hint),
+            )
+            db.add(binding)
+            await db.flush()
+            return binding
+
+        mutated = False
+        if agent_id is not None and cast(UUID | None, binding.agent_id) != agent_id:
+            setattr(binding, "agent_id", agent_id)
+            mutated = True
+        normalized_agent_source = normalize_non_empty_text(agent_source)
+        if (
+            normalized_agent_source is not None
+            and cast(str | None, binding.agent_source) != normalized_agent_source
+        ):
+            setattr(binding, "agent_source", normalized_agent_source)
+            mutated = True
+        if (
+            message_id is not None
+            and cast(UUID | None, binding.first_seen_message_id) is None
+        ):
+            setattr(binding, "first_seen_message_id", message_id)
+            mutated = True
+        if (
+            message_id is not None
+            and cast(UUID | None, binding.latest_message_id) != message_id
+        ):
+            setattr(binding, "latest_message_id", message_id)
+            mutated = True
+        normalized_status_hint = normalize_non_empty_text(status_hint)
+        if (
+            normalized_status_hint is not None
+            and cast(str | None, binding.status_hint) != normalized_status_hint
+        ):
+            setattr(binding, "status_hint", normalized_status_hint)
+            mutated = True
+        if cast(str | None, binding.source) != source:
+            setattr(binding, "source", source)
+            mutated = True
+        if mutated:
+            setattr(binding, "updated_at", utc_now())
+        return binding
+
+    async def verify_binding(
+        self,
+        db: AsyncSession,
+        *,
+        user_id: UUID,
+        conversation_id: UUID,
+        task_id: str,
+    ) -> bool:
+        normalized_task_id = normalize_non_empty_text(task_id)
+        if not normalized_task_id:
+            return False
+        binding_id = await db.scalar(
+            select(ConversationUpstreamTask.id)
+            .where(
+                and_(
+                    ConversationUpstreamTask.user_id == user_id,
+                    ConversationUpstreamTask.conversation_id == conversation_id,
+                    ConversationUpstreamTask.upstream_task_id == normalized_task_id,
+                )
+            )
+            .limit(1)
+        )
+        return binding_id is not None
+
+
+conversation_upstream_task_service = ConversationUpstreamTaskService()

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -62,6 +62,7 @@ from app.integrations.a2a_client.selection import (
     build_peer_descriptor,
     normalize_transport_label,
 )
+from app.integrations.a2a_client.task_payloads import normalize_task_payload
 from app.integrations.a2a_error_contract import (
     build_upstream_error_details_from_protocol_error,
 )
@@ -459,6 +460,15 @@ class A2AClient:
                     history_length=history_length,
                     metadata=metadata,
                 )
+                normalized_task = normalize_task_payload(task)
+                if normalized_task is None:
+                    return {
+                        "success": False,
+                        "agent_url": self.agent_url,
+                        "task_id": normalized_task_id,
+                        "error": "Task payload must be a JSON object.",
+                        "error_code": "upstream_payload_error",
+                    }
                 logger.info(
                     "Fetched A2A task %s for %s",
                     normalized_task_id,
@@ -468,7 +478,7 @@ class A2AClient:
                     "success": True,
                     "agent_url": self.agent_url,
                     "task_id": normalized_task_id,
-                    "task": task,
+                    "task": normalized_task,
                 }
             except A2AClientHTTPError as exc:
                 status_code = getattr(exc, "status_code", None)

--- a/backend/app/integrations/a2a_client/task_payloads.py
+++ b/backend/app/integrations/a2a_client/task_payloads.py
@@ -1,0 +1,51 @@
+"""Helpers for normalizing upstream A2A task payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def normalize_task_payload(task: Any) -> dict[str, Any] | None:
+    """Return a JSON-like dict for task payloads from SDK or JSON-RPC adapters."""
+
+    normalized = _to_json_like(task)
+    return normalized if isinstance(normalized, dict) else None
+
+
+def _to_json_like(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _to_json_like(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_to_json_like(item) for item in value]
+
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped = model_dump(mode="json", by_alias=True, exclude_none=True)
+        except TypeError:
+            dumped = model_dump()
+        return _to_json_like(dumped)
+
+    legacy_dict = getattr(value, "dict", None)
+    if callable(legacy_dict):
+        try:
+            dumped = legacy_dict(by_alias=True, exclude_none=True)
+        except TypeError:
+            dumped = legacy_dict()
+        return _to_json_like(dumped)
+
+    raw_dict = getattr(value, "__dict__", None)
+    if isinstance(raw_dict, Mapping):
+        return {
+            str(key): _to_json_like(item)
+            for key, item in raw_dict.items()
+            if item is not None and not str(key).startswith("_")
+        }
+    return value

--- a/backend/tests/client/test_a2a_client.py
+++ b/backend/tests/client/test_a2a_client.py
@@ -1070,6 +1070,40 @@ async def test_get_task_returns_success_for_valid_request() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_task_normalizes_model_like_task_payload() -> None:
+    class _TaskPayload:
+        def model_dump(self, **kwargs):  # noqa: ANN001
+            assert kwargs["mode"] == "json"
+            assert kwargs["by_alias"] is True
+            return {
+                "id": "task-1",
+                "status": {"state": "working", "empty": None},
+            }
+
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_task_with_fallback = AsyncMock(return_value=_TaskPayload())
+
+    result = await a2a_client.get_task("task-1")
+
+    assert result["success"] is True
+    assert result["task"] == {
+        "id": "task-1",
+        "status": {"state": "working"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_task_rejects_non_object_task_payload() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_task_with_fallback = AsyncMock(return_value=["task-1"])
+
+    result = await a2a_client.get_task("task-1")
+
+    assert result["success"] is False
+    assert result["error_code"] == "upstream_payload_error"
+
+
+@pytest.mark.asyncio
 async def test_get_task_maps_http_status_error_codes() -> None:
     a2a_client = A2AClient("http://example-agent.internal:24020")
     a2a_client._get_task_with_fallback = AsyncMock(

--- a/backend/tests/invoke/test_invoke_route_runner_streaming.py
+++ b/backend/tests/invoke/test_invoke_route_runner_streaming.py
@@ -286,6 +286,9 @@ async def test_consume_stream_callbacks_bind_task_id_and_unregister_inflight(
     async def fake_persist_local_outcome(**_kwargs):  # noqa: ANN001
         return None
 
+    async def fake_record_upstream_task_binding(**kwargs):  # noqa: ANN001
+        captured["recorded_task_id"] = kwargs["task_id"]
+
     monkeypatch.setattr(
         invoke_route_runner.session_hub_service,
         "bind_inflight_task_id_report",
@@ -300,6 +303,11 @@ async def test_consume_stream_callbacks_bind_task_id_and_unregister_inflight(
         invoke_route_runner,
         "_persist_local_outcome",
         fake_persist_local_outcome,
+    )
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_record_upstream_task_binding",
+        fake_record_upstream_task_binding,
     )
 
     state = invoke_route_runner._InvokeState(
@@ -323,6 +331,7 @@ async def test_consume_stream_callbacks_bind_task_id_and_unregister_inflight(
     await on_event({"task": {"id": "task-xyz"}})
     assert captured["bound_token"] == "token-1"
     assert captured["bound_task_id"] == "task-xyz"
+    assert captured["recorded_task_id"] == "task-xyz"
     assert state.upstream_task_id == "task-xyz"
 
     await on_finalized(
@@ -374,6 +383,9 @@ async def test_bind_inflight_task_if_needed_records_deferred_preempt_history(
     ) -> None:
         recorded_events.append(dict(event))
 
+    async def fake_record_upstream_task_binding(**_kwargs):  # noqa: ANN001
+        return None
+
     monkeypatch.setattr(
         invoke_route_runner.session_hub_service,
         "bind_inflight_task_id_report",
@@ -383,6 +395,11 @@ async def test_bind_inflight_task_if_needed_records_deferred_preempt_history(
         invoke_route_runner,
         "_record_preempt_history_event",
         fake_record_preempt_history_event,
+    )
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_record_upstream_task_binding",
+        fake_record_upstream_task_binding,
     )
 
     state = invoke_route_runner._InvokeState(

--- a/backend/tests/invoke/test_invoke_stream_persistence.py
+++ b/backend/tests/invoke/test_invoke_stream_persistence.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from app.db.models.agent_message import AgentMessage
 from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
+from app.db.models.conversation_upstream_task import ConversationUpstreamTask
 from app.features.invoke.service import (
     StreamFinishReason,
     StreamOutcome,
@@ -371,6 +372,81 @@ async def test_persist_local_outcome_keeps_typed_blocks_after_stream_completion(
         "text",
     ]
     assert agent_item["content"] == "final answer"
+
+
+@pytest.mark.asyncio
+async def test_persist_local_outcome_records_upstream_task_binding(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent_id = uuid4()
+    thread = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent_id,
+        agent_source="personal",
+        title="Task Binding Stream",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(thread)
+    await async_db_session.flush()
+
+    state = _FakeState(
+        local_session_id=thread.id,
+        local_source="manual",
+        context_id="ctx-task-binding",
+        metadata={},
+        stream_identity={"upstream_task_id": "task-stream-1"},
+        stream_usage={},
+    )
+
+    def _session_factory() -> _SessionContext:
+        return _SessionContext(async_db_session)
+
+    async def _commit(_db) -> None:  # noqa: ANN001
+        await async_db_session.flush()
+
+    async def _ensure_headers_adapter(**kwargs) -> None:  # noqa: ANN001
+        await ensure_local_message_headers(
+            **kwargs,
+            session_factory=_session_factory,
+            commit_fn=_commit,
+            session_hub=session_hub_service,
+        )
+
+    await persist_local_outcome(
+        state=state,
+        outcome=StreamOutcome(
+            success=True,
+            finish_reason=StreamFinishReason.SUCCESS,
+            final_text="done",
+            error_message=None,
+            error_code=None,
+            elapsed_seconds=1.0,
+            idle_seconds=0.1,
+            terminal_event_seen=True,
+        ),
+        request=_build_request(user_id=user.id, agent_id=agent_id),
+        session_factory=_session_factory,
+        commit_fn=_commit,
+        session_hub=session_hub_service,
+        ensure_headers_fn=_ensure_headers_adapter,
+    )
+
+    binding = await async_db_session.scalar(
+        select(ConversationUpstreamTask).where(
+            ConversationUpstreamTask.conversation_id == thread.id,
+            ConversationUpstreamTask.upstream_task_id == "task-stream-1",
+        )
+    )
+    assert binding is not None
+    assert binding.user_id == user.id
+    assert binding.agent_id == agent_id
+    assert binding.source == "final_metadata"
+    assert binding.status_hint == "done"
+    assert binding.latest_message_id == state.message_refs["agent_message_id"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -630,6 +630,16 @@ async def test_upstream_task_route_fetches_task_for_bound_conversation(
         status=ConversationThread.STATUS_ACTIVE,
     )
     async_db_session.add(session)
+    await async_db_session.flush()
+    await session_hub_service.record_upstream_task_binding(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=session.id,
+        task_id="task-1",
+        agent_id=agent.id,
+        agent_source="personal",
+        source="stream_identity",
+    )
     await async_db_session.commit()
 
     resolved = SimpleNamespace(
@@ -727,6 +737,16 @@ async def test_upstream_task_route_maps_a2a_service_errors(
         status=ConversationThread.STATUS_ACTIVE,
     )
     async_db_session.add(session)
+    await async_db_session.flush()
+    await session_hub_service.record_upstream_task_binding(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=session.id,
+        task_id="task-1",
+        agent_id=agent.id,
+        agent_source="personal",
+        source="stream_identity",
+    )
     await async_db_session.commit()
 
     async def _fake_load_runtime_for_thread(**_kwargs):
@@ -762,6 +782,110 @@ async def test_upstream_task_route_maps_a2a_service_errors(
 
     assert resp.status_code == expected_status
     assert resp.json()["detail"] == error_code
+
+
+async def test_upstream_task_route_rejects_unbound_task_without_upstream_call(
+    async_db_session,
+    async_session_maker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(
+        async_db_session, user_id=user.id, suffix="task-unbound"
+    )
+    session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        title="Task Unbound Session",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(session)
+    await async_db_session.commit()
+
+    async def _runtime_should_not_load(**_kwargs):
+        raise AssertionError("unbound tasks should not load runtime")
+
+    monkeypatch.setattr(
+        me_sessions, "_load_runtime_for_thread", _runtime_should_not_load
+    )
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.get(
+            f"/me/conversations/{session.id}/upstream-tasks/task-unbound"
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "task_not_found"
+
+
+async def test_upstream_task_route_rejects_task_bound_to_another_conversation(
+    async_db_session,
+    async_session_maker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(async_db_session, user_id=user.id, suffix="task-cross")
+    now = utc_now()
+    first_session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        title="Task Owner Session",
+        last_active_at=now,
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    second_session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        title="Task Other Session",
+        last_active_at=now,
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(first_session)
+    async_db_session.add(second_session)
+    await async_db_session.flush()
+    await session_hub_service.record_upstream_task_binding(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=first_session.id,
+        task_id="task-owned",
+        agent_id=agent.id,
+        agent_source="personal",
+        source="stream_identity",
+    )
+    await async_db_session.commit()
+
+    async def _runtime_should_not_load(**_kwargs):
+        raise AssertionError("cross-conversation tasks should not load runtime")
+
+    monkeypatch.setattr(
+        me_sessions, "_load_runtime_for_thread", _runtime_should_not_load
+    )
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.get(
+            f"/me/conversations/{second_session.id}/upstream-tasks/task-owned"
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "task_not_found"
 
 
 async def test_blocks_query_returns_404_when_block_not_found(

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -610,6 +610,160 @@ async def test_command_route_persists_canonical_command_messages(
         )
 
 
+async def test_upstream_task_route_fetches_task_for_bound_conversation(
+    async_db_session,
+    async_session_maker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(async_db_session, user_id=user.id, suffix="task-query")
+    session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        external_provider="opencode",
+        external_session_id="ses-task-1",
+        title="Task Query Session",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(session)
+    await async_db_session.commit()
+
+    resolved = SimpleNamespace(
+        name="TaskAgent",
+        url="https://example.com/a2a",
+        headers={},
+        metadata={},
+    )
+    calls: list[dict[str, object]] = []
+
+    async def _fake_load_runtime_for_thread(**kwargs):
+        assert kwargs["thread"].id == session.id
+        return SimpleNamespace(resolved=resolved)
+
+    class _FakeA2AService:
+        async def get_task(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "success": True,
+                "task_id": "task-1",
+                "task": {
+                    "id": "task-1",
+                    "status": {"state": "working"},
+                },
+            }
+
+    monkeypatch.setattr(
+        me_sessions, "_load_runtime_for_thread", _fake_load_runtime_for_thread
+    )
+    monkeypatch.setattr(me_sessions, "get_a2a_service", lambda: _FakeA2AService())
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.get(
+            f"/me/conversations/{session.id}/upstream-tasks/task-1",
+            params={"historyLength": 3},
+        )
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload == {
+        "conversationId": str(session.id),
+        "taskId": "task-1",
+        "task": {
+            "id": "task-1",
+            "status": {"state": "working"},
+        },
+    }
+    assert calls == [
+        {
+            "resolved": resolved,
+            "task_id": "task-1",
+            "history_length": 3,
+            "metadata": {
+                "provider": "opencode",
+                "externalSessionId": "ses-task-1",
+            },
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("error_code", "expected_status"),
+    [
+        ("invalid_task_id", 400),
+        ("task_not_found", 404),
+        ("unsupported_operation", 501),
+        ("timeout", 504),
+    ],
+)
+async def test_upstream_task_route_maps_a2a_service_errors(
+    async_db_session,
+    async_session_maker,
+    monkeypatch: pytest.MonkeyPatch,
+    error_code: str,
+    expected_status: int,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix=f"task-{error_code}",
+    )
+    session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        title="Task Error Session",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(session)
+    await async_db_session.commit()
+
+    async def _fake_load_runtime_for_thread(**_kwargs):
+        return SimpleNamespace(
+            resolved=SimpleNamespace(
+                name="TaskAgent",
+                url="https://example.com/a2a",
+                headers={},
+                metadata={},
+            )
+        )
+
+    class _FakeA2AService:
+        async def get_task(self, **_kwargs):
+            return {
+                "success": False,
+                "task_id": "task-1",
+                "error": error_code,
+                "error_code": error_code,
+            }
+
+    monkeypatch.setattr(
+        me_sessions, "_load_runtime_for_thread", _fake_load_runtime_for_thread
+    )
+    monkeypatch.setattr(me_sessions, "get_a2a_service", lambda: _FakeA2AService())
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.get(f"/me/conversations/{session.id}/upstream-tasks/task-1")
+
+    assert resp.status_code == expected_status
+    assert resp.json()["detail"] == error_code
+
+
 async def test_blocks_query_returns_404_when_block_not_found(
     async_db_session,
     async_session_maker,

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -5,11 +5,13 @@ from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from app.db.models.a2a_schedule_execution import A2AScheduleExecution
 from app.db.models.agent_message import AgentMessage
 from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
+from app.db.models.conversation_upstream_task import ConversationUpstreamTask
 from app.features.schedules.service import a2a_schedule_service
 from app.features.sessions import router as me_sessions
 from app.features.sessions.common import serialize_interrupt_event_block_content
@@ -886,6 +888,85 @@ async def test_upstream_task_route_rejects_task_bound_to_another_conversation(
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "task_not_found"
+
+
+async def test_upstream_task_binding_upsert_preserves_first_seen_and_updates_latest(
+    async_db_session,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(async_db_session, user_id=user.id, suffix="task-upsert")
+    session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        title="Task Upsert Session",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(session)
+    await async_db_session.flush()
+    first_message = AgentMessage(
+        id=uuid4(),
+        user_id=user.id,
+        sender="agent",
+        conversation_id=session.id,
+        status="streaming",
+    )
+    latest_message = AgentMessage(
+        id=uuid4(),
+        user_id=user.id,
+        sender="agent",
+        conversation_id=session.id,
+        status="done",
+    )
+    async_db_session.add(first_message)
+    async_db_session.add(latest_message)
+    await async_db_session.flush()
+
+    first_binding = await session_hub_service.record_upstream_task_binding(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=session.id,
+        task_id="task-upsert-1",
+        agent_id=agent.id,
+        agent_source="personal",
+        message_id=first_message.id,
+        source="stream_identity",
+        status_hint="streaming",
+    )
+    second_binding = await session_hub_service.record_upstream_task_binding(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=session.id,
+        task_id="task-upsert-1",
+        agent_id=agent.id,
+        agent_source="personal",
+        message_id=latest_message.id,
+        source="final_metadata",
+        status_hint="done",
+    )
+    await async_db_session.flush()
+
+    assert first_binding is True
+    assert second_binding is True
+    bindings = list(
+        (
+            await async_db_session.scalars(
+                select(ConversationUpstreamTask).where(
+                    ConversationUpstreamTask.conversation_id == session.id,
+                    ConversationUpstreamTask.upstream_task_id == "task-upsert-1",
+                )
+            )
+        ).all()
+    )
+    assert len(bindings) == 1
+    binding = bindings[0]
+    assert binding.first_seen_message_id == first_message.id
+    assert binding.latest_message_id == latest_message.id
+    assert binding.source == "final_metadata"
+    assert binding.status_hint == "done"
 
 
 async def test_blocks_query_returns_404_when_block_not_found(

--- a/backend/tests/sessions/test_unified_session_domain_routes.py
+++ b/backend/tests/sessions/test_unified_session_domain_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
+from urllib.parse import quote
 from uuid import uuid4
 
 import pytest
@@ -704,6 +705,86 @@ async def test_upstream_task_route_fetches_task_for_bound_conversation(
             },
         }
     ]
+
+
+async def test_upstream_task_route_accepts_opaque_task_ids_with_slashes(
+    async_db_session,
+    async_session_maker,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    agent = await _create_agent(
+        async_db_session,
+        user_id=user.id,
+        suffix="task-query-slash",
+    )
+    session = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        agent_id=agent.id,
+        agent_source="personal",
+        external_provider="opencode",
+        external_session_id="ses-task-slash",
+        title="Task Query Slash Session",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(session)
+    await async_db_session.flush()
+    task_id = "run/task-1/step-2"
+    await session_hub_service.record_upstream_task_binding(
+        async_db_session,
+        user_id=user.id,
+        conversation_id=session.id,
+        task_id=task_id,
+        agent_id=agent.id,
+        agent_source="personal",
+        source="stream_identity",
+    )
+    await async_db_session.commit()
+
+    resolved = SimpleNamespace(
+        name="TaskAgent",
+        url="https://example.com/a2a",
+        headers={},
+        metadata={},
+    )
+    calls: list[dict[str, object]] = []
+
+    async def _fake_load_runtime_for_thread(**kwargs):
+        assert kwargs["thread"].id == session.id
+        return SimpleNamespace(resolved=resolved)
+
+    class _FakeA2AService:
+        async def get_task(self, **kwargs):
+            calls.append(kwargs)
+            return {
+                "success": True,
+                "task_id": task_id,
+                "task": {
+                    "id": task_id,
+                    "status": {"state": "working"},
+                },
+            }
+
+    monkeypatch.setattr(
+        me_sessions, "_load_runtime_for_thread", _fake_load_runtime_for_thread
+    )
+    monkeypatch.setattr(me_sessions, "get_a2a_service", lambda: _FakeA2AService())
+
+    async with create_test_client(
+        me_sessions.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+    ) as client:
+        resp = await client.get(
+            f"/me/conversations/{session.id}/upstream-tasks/{quote(task_id, safe='')}"
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["taskId"] == task_id
+    assert calls[0]["task_id"] == task_id
 
 
 @pytest.mark.parametrize(

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -114,6 +114,7 @@ Message id contract:
 - The chat timeline must not merge non-canonical overlay-only messages into `messages:query` results.
 - Canonical history items also carry `kind` and optional `operationId` so command/action messages do not have to be rediscovered from ad hoc metadata parsing.
 - `append` and `commands:run` requests should send an explicit `operationId` (UUID) for idempotent retries; message ids remain canonical message identity, not operation identity.
+- Upstream A2A task state is fetched on demand via `GET /me/conversations/{conversation_id}/upstream-tasks/{task_id}`. Use `useSessionUpstreamTaskQuery` only for explicit recovery/detail views; it intentionally does not poll globally.
 - Non-text block details (`reasoning`/`tool_call`) are fetched on demand via `POST /me/conversations/{conversation_id}/blocks:query`.
 - Structured command results may be persisted as `data` blocks and should render as first-class canonical history blocks rather than overlay text fallbacks.
 - `blocks:query` detail items include `messageId` and must match the target message before cache patching.

--- a/frontend/hooks/__tests__/useSessionUpstreamTaskQuery.test.tsx
+++ b/frontend/hooks/__tests__/useSessionUpstreamTaskQuery.test.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react-native";
+
+import { useSessionUpstreamTaskQuery } from "@/hooks/useSessionUpstreamTaskQuery";
+import { getSessionUpstreamTask } from "@/lib/api/sessions";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock("@/lib/api/sessions", () => ({
+  getSessionUpstreamTask: jest.fn(),
+}));
+
+jest.mock("@/lib/storage/mmkv", () =>
+  require("@/test-utils/mockMmkv").createMockMmkvModule(),
+);
+
+const mockedUseQuery = jest.mocked(useQuery);
+const mockedGetSessionUpstreamTask = jest.mocked(getSessionUpstreamTask);
+
+describe("useSessionUpstreamTaskQuery", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseQuery.mockReturnValue({} as ReturnType<typeof useQuery>);
+  });
+
+  it("enables an on-demand task query with normalized ids", async () => {
+    renderHook(() =>
+      useSessionUpstreamTaskQuery({
+        conversationId: " conv-1 ",
+        taskId: " task-1 ",
+        historyLength: 3.9,
+      }),
+    );
+
+    const options = mockedUseQuery.mock.calls[0]?.[0];
+    expect(options?.enabled).toBe(true);
+    expect(options?.queryKey).toEqual([
+      "sessions",
+      "upstream-task",
+      "conv-1",
+      "task-1",
+      3,
+    ]);
+    expect(options?.refetchInterval).toBe(false);
+    expect(options?.refetchOnWindowFocus).toBe(false);
+
+    const queryFn = options?.queryFn as (() => Promise<unknown>) | undefined;
+    await queryFn?.();
+    expect(mockedGetSessionUpstreamTask).toHaveBeenCalledWith(
+      "conv-1",
+      "task-1",
+      { historyLength: 3 },
+    );
+  });
+
+  it("stays disabled until both ids are available", () => {
+    renderHook(() =>
+      useSessionUpstreamTaskQuery({
+        conversationId: "conv-1",
+        taskId: " ",
+      }),
+    );
+
+    const options = mockedUseQuery.mock.calls[0]?.[0];
+    expect(options?.enabled).toBe(false);
+    expect(options?.queryKey).toEqual(["sessions", "upstream-task", "idle"]);
+  });
+});

--- a/frontend/hooks/useSessionUpstreamTaskQuery.ts
+++ b/frontend/hooks/useSessionUpstreamTaskQuery.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getSessionUpstreamTask } from "@/lib/api/sessions";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useSessionUpstreamTaskQuery(options: {
+  conversationId?: string | null;
+  taskId?: string | null;
+  historyLength?: number | null;
+  enabled?: boolean;
+}) {
+  const conversationId = options.conversationId?.trim() || null;
+  const taskId = options.taskId?.trim() || null;
+  const historyLength =
+    typeof options.historyLength === "number" &&
+    Number.isFinite(options.historyLength) &&
+    options.historyLength >= 0
+      ? Math.floor(options.historyLength)
+      : null;
+
+  return useQuery({
+    enabled: options.enabled !== false && Boolean(conversationId && taskId),
+    queryKey:
+      conversationId && taskId
+        ? [
+            ...queryKeys.sessions.upstreamTask(conversationId, taskId),
+            historyLength,
+          ]
+        : (["sessions", "upstream-task", "idle"] as const),
+    queryFn: async () =>
+      await getSessionUpstreamTask(conversationId as string, taskId as string, {
+        historyLength,
+      }),
+    staleTime: 10_000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: true,
+    refetchInterval: false,
+  });
+}

--- a/frontend/lib/api/__tests__/sessions.test.ts
+++ b/frontend/lib/api/__tests__/sessions.test.ts
@@ -66,6 +66,26 @@ describe("sessions api", () => {
     expect(result.task.status?.state).toBe("working");
   });
 
+  it("encodes opaque upstream task ids as a single path parameter", async () => {
+    mockedApiRequest.mockResolvedValue({
+      conversationId: "conv-1",
+      taskId: "run/task-1/step-2",
+      task: {
+        id: "run/task-1/step-2",
+      },
+    });
+
+    await getSessionUpstreamTask("conv-1", "run/task-1/step-2");
+
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      "/me/conversations/conv-1/upstream-tasks/run%2Ftask-1%2Fstep-2",
+      {
+        method: "GET",
+        query: undefined,
+      },
+    );
+  });
+
   it("rejects upstream task query without ids", async () => {
     await expect(getSessionUpstreamTask(" ", "task-1")).rejects.toThrow(
       "Conversation id is required.",

--- a/frontend/lib/api/__tests__/sessions.test.ts
+++ b/frontend/lib/api/__tests__/sessions.test.ts
@@ -3,6 +3,7 @@ import {
   appendSessionMessage,
   cancelSession,
   continueSession,
+  getSessionUpstreamTask,
   runSessionCommand,
 } from "@/lib/api/sessions";
 
@@ -39,6 +40,40 @@ describe("sessions api", () => {
       cancelled: true,
       status: "accepted",
     });
+  });
+
+  it("gets upstream task by conversation and task id", async () => {
+    mockedApiRequest.mockResolvedValue({
+      conversationId: "conv-1",
+      taskId: "task-1",
+      task: {
+        id: "task-1",
+        status: { state: "working" },
+      },
+    });
+
+    const result = await getSessionUpstreamTask(" conv-1 ", " task-1 ", {
+      historyLength: 3,
+    });
+
+    expect(mockedApiRequest).toHaveBeenCalledWith(
+      "/me/conversations/conv-1/upstream-tasks/task-1",
+      {
+        method: "GET",
+        query: { historyLength: 3 },
+      },
+    );
+    expect(result.task.status?.state).toBe("working");
+  });
+
+  it("rejects upstream task query without ids", async () => {
+    await expect(getSessionUpstreamTask(" ", "task-1")).rejects.toThrow(
+      "Conversation id is required.",
+    );
+    await expect(getSessionUpstreamTask("conv-1", " ")).rejects.toThrow(
+      "Task id is required.",
+    );
+    expect(mockedApiRequest).not.toHaveBeenCalled();
   });
 
   it("normalizes continue session payload conversation id", async () => {

--- a/frontend/lib/api/sessions.ts
+++ b/frontend/lib/api/sessions.ts
@@ -79,6 +79,19 @@ export type SessionCancelResult = {
   status: "accepted" | "pending" | "no_inflight" | "already_terminal";
 };
 
+export type UpstreamTaskPayload = Record<string, unknown> & {
+  id?: string;
+  status?: {
+    state?: string;
+  } | null;
+};
+
+export type SessionUpstreamTaskResult = {
+  conversationId: string;
+  taskId: string;
+  task: UpstreamTaskPayload;
+};
+
 export type SessionControlResult = {
   intent: "append" | "preempt";
   status: "accepted" | "completed" | "no_inflight" | "unavailable" | "failed";
@@ -245,6 +258,43 @@ export const cancelSession = async (
       method: "POST",
     },
   );
+
+export const getSessionUpstreamTask = async (
+  conversationId: string,
+  taskId: string,
+  options?: { historyLength?: number | null },
+): Promise<SessionUpstreamTaskResult> => {
+  const normalizedConversationId = conversationId.trim();
+  const normalizedTaskId = taskId.trim();
+  if (!normalizedConversationId) {
+    throw new Error("Conversation id is required.");
+  }
+  if (!normalizedTaskId) {
+    throw new Error("Task id is required.");
+  }
+
+  const historyLength =
+    typeof options?.historyLength === "number" &&
+    Number.isFinite(options.historyLength) &&
+    options.historyLength >= 0
+      ? Math.floor(options.historyLength)
+      : null;
+
+  return await apiRequest<SessionUpstreamTaskResult>(
+    `/me/conversations/${encodeURIComponent(
+      normalizedConversationId,
+    )}/upstream-tasks/${encodeURIComponent(normalizedTaskId)}`,
+    {
+      method: "GET",
+      query:
+        historyLength !== null
+          ? {
+              historyLength,
+            }
+          : undefined,
+    },
+  );
+};
 
 export const appendSessionMessage = async (
   conversationId: string,

--- a/frontend/lib/queryKeys.ts
+++ b/frontend/lib/queryKeys.ts
@@ -112,6 +112,8 @@ export const queryKeys = {
     scheduledJobs: () => ["scheduled-jobs", "list"] as const,
     scheduledJobExecutions: (taskId: string) =>
       ["scheduled-jobs", "executions", taskId] as const,
+    upstreamTask: (conversationId: string, taskId: string) =>
+      ["sessions", "upstream-task", conversationId, taskId] as const,
   },
   history: {
     chat: (conversationId: string) =>


### PR DESCRIPTION
## 概述

本 PR 针对 #539 补齐统一会话域中的 upstream A2A task 查询闭环。底层 A2A adapter / client / gateway / service 已经具备 `get_task()` 能力，本次变更把该能力暴露为 conversation-scoped 产品 API，并提供前端按需查询入口。

## 后端变更

- 新增 `GET /me/conversations/{conversation_id}/upstream-tasks/{task_id}`。
- 后端路由使用 `{task_id:path}` 捕获 opaque upstream task id，避免包含 `/` 的上游 task id 被路径分段破坏。
- 新增 `conversation_upstream_tasks` durable binding 表与 SQLAlchemy model，用本地一等事实记录 upstream task 与 conversation 的归属关系。
- 新增迁移 `r202604220830`，创建 durable binding 表，并从已有 `agent_messages.metadata.upstream_task_id` 回填历史绑定。
- 在 stream identity 首次发现 task id 时记录 binding；在最终 stream outcome 持久化时再次 upsert binding，补齐 message、agent 和 status hint。
- binding 写入改为基于唯一约束的数据库层 upsert，避免重复 stream/finalization 或并发写入触发唯一约束失败。
- 查询 upstream task 前先校验本地 durable binding；未绑定到该 conversation 的 task id 返回 `task_not_found`，不加载 runtime，不调用 upstream。
- 在 A2A client 边界新增 task payload normalization，统一处理 SDK model-like payload、Pydantic payload 和 JSON-RPC dict payload，保证产品 API 获得 JSON object。
- 扩展 session API 错误映射，覆盖 `task_not_found`、`unsupported_operation`、`timeout`、`agent_unavailable`、`outbound_not_allowed` 等 task 查询路径会返回的错误。

## 前端变更

- 新增 `getSessionUpstreamTask()` API client，按 conversation id 与 task id 查询 upstream task 状态。
- API client 对 conversation id 与 task id 做 trim，并用 `encodeURIComponent` 保持 opaque task id 作为单个路径参数传递。
- 新增 `useSessionUpstreamTaskQuery()` hook，默认仅在显式提供 `conversationId + taskId` 时启用，并关闭全局轮询。
- 扩展 `queryKeys.sessions.upstreamTask()`，保证 task detail 查询缓存键稳定。
- 在 `frontend/README.md` 记录该能力仅用于显式恢复/详情场景，不作为全局 polling 机制。

## 测试

- 后端新增 session route 测试，覆盖成功查询、错误映射、未绑定 task 拒绝、跨 conversation task 拒绝、包含 `/` 的 opaque task id。
- 后端新增 durable binding upsert 测试，覆盖重复记录同一 task 时保留 first seen、更新 latest/status/source，并只产生一条 binding。
- 后端新增 stream persistence 测试，覆盖 final outcome 持久化时写入 durable upstream task binding。
- 后端新增 A2A client 测试，覆盖 SDK/model-like task payload normalization 和非 object payload 拒绝。
- 前端新增 API client 测试，覆盖路径、query 参数、空 id 校验和包含 `/` 的 opaque task id 编码。
- 前端新增 hook 测试，覆盖启用条件、query key、禁用轮询和 id normalization。

## 相关提交

- `dd0186df feat(sessions): add upstream task query (#539)`
- `c469bb98 fix(sessions): enforce upstream task ownership (#539)`
- `73edc654 fix(sessions): make upstream task binding upserts atomic (#539)`
- `a81d5576 fix(sessions): support opaque upstream task ids (#539)`

## Issue 关系

Closes #539

Related #848，但 #848 是 cg kernel / Workspace / Work Timeline 的大范围执行事实层 epic，本 PR 不应关闭或合并其范围。

## 验证

- `cd backend && uv run --locked pre-commit run --files app/db/models/conversation_upstream_task.py app/db/models/__init__.py alembic/versions/20260422_0830_r202604220830_add_conversation_upstream_tasks.py app/features/sessions/upstream_tasks.py app/features/sessions/service.py app/features/sessions/router.py app/features/invoke/route_runner_state.py app/features/invoke/route_runner.py app/features/invoke/stream_persistence.py app/integrations/a2a_client/task_payloads.py app/integrations/a2a_client/client.py tests/sessions/test_unified_session_domain_routes.py tests/invoke/test_invoke_route_runner_streaming.py tests/invoke/test_invoke_stream_persistence.py tests/client/test_a2a_client.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/sessions/test_unified_session_domain_routes.py tests/invoke/test_invoke_route_runner_streaming.py tests/invoke/test_invoke_stream_persistence.py tests/client/test_a2a_client.py -q`
- `cd backend && SCHEMA_NAME=a2a_client_hub_schema uv run alembic upgrade head`
- `cd backend && uv run --locked pre-commit run --files app/features/sessions/upstream_tasks.py tests/sessions/test_unified_session_domain_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pre-commit run --files app/features/sessions/router.py tests/sessions/test_unified_session_domain_routes.py --config ../.pre-commit-config.yaml`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/api/sessions.ts lib/api/__tests__/sessions.test.ts hooks/useSessionUpstreamTaskQuery.ts hooks/__tests__/useSessionUpstreamTaskQuery.test.tsx lib/queryKeys.ts --maxWorkers=25%`
