### PR TITLE
fix(frontend): update xmldom override (#855)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4340,9 +4340,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,7 +82,7 @@
     "typescript": "~5.9.2"
   },
   "overrides": {
-    "@xmldom/xmldom": "^0.8.12",
+    "@xmldom/xmldom": "^0.8.13",
     "markdown-it": "^12.3.2"
   },
   "expo": {


### PR DESCRIPTION
## 关联 Issue
- Closes #855

## Frontend 依赖
- 将 `frontend/package.json` 中 `@xmldom/xmldom` 的 npm override 从 `^0.8.12` 更新到 `^0.8.13`。
- 重新执行 `npm install`，同步更新 `frontend/package-lock.json` 中 `@xmldom/xmldom` 的解析版本、tarball 地址与 integrity。

## 安全审计
- 目标问题：修复前端依赖审计中的 high 级别 `@xmldom/xmldom <0.8.13` 漏洞。
- `npm ls @xmldom/xmldom` 确认 Expo 相关传递依赖已解析到 `@xmldom/xmldom@0.8.13`。
- `npm audit --json` 确认 high/critical 为 0，剩余为 4 low、13 moderate。
- 剩余 moderate/low 项集中在 Expo/Jest-Expo 传递依赖链路，npm 提示的自动修复涉及跨 Expo/Jest-Expo 大版本或不合适的自动修复路径，本 PR 不做高风险升级。

## 验证
- `cd frontend && npm run lint` 通过。
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types` 通过。
- `cd frontend && npm test -- --findRelatedTests package.json package-lock.json --maxWorkers=25%` 未找到关联测试，Jest 按默认行为返回 1。
- `cd frontend && npm test -- --maxWorkers=25%` 通过：81 个 test suites、476 个 tests。
