### PR TITLE
fix(backend): ignore soft-deleted a2a agents in card URL uniqueness (#871)

### DIFF
--- a/backend/alembic/versions/20260428_1500_r202604281500_make_a2a_agent_url_uniqueness_ignore_soft_deletes.py
+++ b/backend/alembic/versions/20260428_1500_r202604281500_make_a2a_agent_url_uniqueness_ignore_soft_deletes.py
@@ -1,0 +1,54 @@
+"""Make A2A agent URL uniqueness ignore soft-deleted rows.
+
+Revision ID: r202604281500
+Revises: r202604220830
+Create Date: 2026-04-28 15:00:00.000000
+"""
+
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "r202604281500"
+down_revision = "r202604220830"
+branch_labels = None
+depends_on = None
+
+SCHEMA_NAME = os.getenv("SCHEMA_NAME", "a2a_client_hub_schema")
+TABLE_NAME = "a2a_agents"
+UNIQUE_NAME = "uq_a2a_agents_user_scope_card_url"
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        UNIQUE_NAME,
+        TABLE_NAME,
+        schema=SCHEMA_NAME,
+        type_="unique",
+    )
+    op.create_index(
+        UNIQUE_NAME,
+        TABLE_NAME,
+        ["user_id", "agent_scope", "card_url"],
+        unique=True,
+        schema=SCHEMA_NAME,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        UNIQUE_NAME,
+        table_name=TABLE_NAME,
+        schema=SCHEMA_NAME,
+    )
+    op.create_unique_constraint(
+        UNIQUE_NAME,
+        TABLE_NAME,
+        ["user_id", "agent_scope", "card_url"],
+        schema=SCHEMA_NAME,
+    )

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -257,6 +257,12 @@ def setup_logging() -> None:
     card_resolver_logger.setLevel(logging.WARNING)
     card_resolver_logger.propagate = True
 
+    # Suppress APScheduler executor heartbeat noise while keeping warnings
+    # and failures visible.
+    apscheduler_executor_logger = logging.getLogger("apscheduler.executors.default")
+    apscheduler_executor_logger.setLevel(logging.WARNING)
+    apscheduler_executor_logger.propagate = True
+
 
 def get_logger(name: str) -> logging.Logger:
     """

--- a/backend/app/db/models/a2a_agent.py
+++ b/backend/app/db/models/a2a_agent.py
@@ -5,10 +5,11 @@ from sqlalchemy import (
     Column,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
-    UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSON, UUID
 
@@ -26,11 +27,13 @@ class A2AAgent(Base, TimestampMixin, SoftDeleteMixin, UserOwnedMixin):
 
     __tablename__ = "a2a_agents"
     __table_args__ = (
-        UniqueConstraint(
+        Index(
+            "uq_a2a_agents_user_scope_card_url",
             "user_id",
             "agent_scope",
             "card_url",
-            name="uq_a2a_agents_user_scope_card_url",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
         ),
         {"schema": SCHEMA_NAME},
     )

--- a/backend/tests/agents/personal/test_a2a_agent_credentials.py
+++ b/backend/tests/agents/personal/test_a2a_agent_credentials.py
@@ -73,6 +73,46 @@ async def test_delete_agent_hard_deletes_credential(async_db_session):
 
 
 @pytest.mark.asyncio
+async def test_soft_deleted_agent_does_not_block_recreate_with_same_card_url(
+    async_db_session,
+):
+    user = await create_user(
+        async_db_session, email="a2a-soft-delete-recreate@example.com"
+    )
+    card_url = "https://example.com/recreate"
+    original = await a2a_agent_service.create_agent(
+        async_db_session,
+        user_id=user.id,
+        name="original-agent",
+        card_url=card_url,
+        auth_type="none",
+        enabled=True,
+        tags=["test"],
+        extra_headers={"X-Test": "1"},
+    )
+
+    await a2a_agent_service.delete_agent(
+        async_db_session,
+        user_id=user.id,
+        agent_id=original.id,
+    )
+
+    recreated = await a2a_agent_service.create_agent(
+        async_db_session,
+        user_id=user.id,
+        name="recreated-agent",
+        card_url=card_url,
+        auth_type="none",
+        enabled=True,
+        tags=["test"],
+        extra_headers={"X-Test": "1"},
+    )
+
+    assert recreated.id != original.id
+    assert recreated.card_url == card_url
+
+
+@pytest.mark.asyncio
 async def test_upsert_keeps_single_credential_row(async_db_session):
     user = await create_user(
         async_db_session, email="a2a-hard-delete-legacy@example.com"

--- a/backend/tests/agents/personal/test_a2a_routes.py
+++ b/backend/tests/agents/personal/test_a2a_routes.py
@@ -254,6 +254,50 @@ async def test_personal_agent_card_validate_logs_traceback_for_upstream_failure(
 
 
 @pytest.mark.asyncio
+async def test_personal_agent_can_recreate_same_card_url_after_soft_delete(
+    async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "a2a_proxy_allowed_hosts", ["example.com"])
+    user = await create_user(
+        async_db_session, email="personal-soft-delete-recreate-route@example.com"
+    )
+    payload = {
+        "name": "Reusable Agent",
+        "card_url": "https://example.com/.well-known/agent-card.json",
+        "auth_type": "none",
+        "enabled": True,
+        "tags": [],
+        "extra_headers": {},
+        "invoke_metadata_defaults": {},
+    }
+
+    async with create_test_client(
+        personal_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as client:
+        created_response = await client.post(
+            f"{settings.api_v1_prefix}/me/a2a/agents",
+            json=payload,
+        )
+        assert created_response.status_code == 201
+        created_id = created_response.json()["id"]
+
+        deleted_response = await client.delete(
+            f"{settings.api_v1_prefix}/me/a2a/agents/{created_id}"
+        )
+        assert deleted_response.status_code == 204
+
+        recreated_response = await client.post(
+            f"{settings.api_v1_prefix}/me/a2a/agents",
+            json=payload,
+        )
+        assert recreated_response.status_code == 201
+        assert recreated_response.json()["id"] != created_id
+
+
+@pytest.mark.asyncio
 async def test_personal_agent_http_invoke_injects_session_bound_invoke_metadata(
     async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## 关联事项

- Closes #871
- 本 PR 包含 commits：
  - `fix(backend): allow recreating soft-deleted a2a agents (#871)`
  - `chore(backend): reduce apscheduler executor log noise (#871)`

## 问题背景

### personal agent 重建返回 500

用户在 personal agent 已软删除、但 `card_url` 与待新增记录相同的情况下，再次调用 `POST /api/v1/me/a2a/agents` 会触发数据库唯一约束 `uq_a2a_agents_user_scope_card_url`，最终返回 500。

根因是：
- 应用层唯一性检查只判断活跃记录，即 `deleted_at IS NULL`
- 数据库层唯一约束却作用于全部记录，没有忽略软删除行

这导致“业务层允许复用、数据库层禁止复用”的规则不一致。

### APScheduler 执行日志刷屏

`apscheduler.executors.default` 会在每次轮询周期输出 `Running job ...` 和 `Job ... executed successfully` 两类 INFO 日志，稳定运行时噪音较大。

## 代码变更审查

### backend/app/db/models

- 将 `a2a_agents` 的 `card_url` 唯一性从普通唯一约束调整为 PostgreSQL 部分唯一索引
- 新规则只约束活跃记录：`deleted_at IS NULL`
- 该实现与 personal agent service 中现有的唯一性检查语义保持一致，方向合理

### backend/alembic/versions

- 新增迁移，删除旧唯一约束并创建同名部分唯一索引
- 迁移方向正确，能把数据库规则与应用层规则对齐
- 由于旧约束此前禁止任何重复 `(user_id, agent_scope, card_url)`，因此正常线上数据不会因为本次迁移产生新的活跃重复冲突

### backend/app/core/logging

- 将 `apscheduler.executors.default` logger 级别调整为 `WARNING`
- 这样可抑制 steady-state 的 INFO 心跳日志，同时保留 warning/error 可见性
- 这是比包装 filter 更直接、更稳妥的降噪实现

### backend/tests/agents/personal

- 新增 service 层回归测试，覆盖“软删除后使用相同 `card_url` 重新创建”场景
- 新增 route 层回归测试，覆盖 `POST -> DELETE -> POST` 的真实接口链路
- 测试覆盖面与本次修复目标一致，没有明显冗余

## 审查结论

### 结论

本次改动整体是合理的。

- 主修复部分直接消除了 personal agent 软删除后重建触发 500 的根因
- 日志部分采用 logger 级别下调到 `WARNING` 的方式抑制 APScheduler executor 噪音，改动小、行为清晰

### 当前未见阻塞问题

- 未发现本 PR 新引入的阻塞性缺陷
- 未发现与 #871 目标明显偏离的实现
- 未发现明显冗余代码

### 仍需关注的残余风险

- 若两个并发请求同时创建同一活跃 `card_url`，数据库仍可能抛出唯一索引冲突，其中一个请求仍可能表现为 500；这属于当前系统原有的并发冲突处理缺口，本 PR 未扩展处理
- shared agent 也使用同一张表和同一索引规则，本次结构修复同样会影响 shared scope；从一致性上看这是合理的，但当前 PR 的测试重点仍集中在 personal agent
- `apscheduler.executors.default` 下若未来新增了真正有价值的 INFO 级日志，也会一并被压到不可见；就当前目标而言这属于可接受取舍

## 验证记录

### Backend scoped checks

- `cd backend && uv run --locked pre-commit run --files app/db/models/a2a_agent.py alembic/versions/20260428_1500_r202604281500_make_a2a_agent_url_uniqueness_ignore_soft_deletes.py tests/agents/personal/test_a2a_agent_credentials.py tests/agents/personal/test_a2a_routes.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/agents/personal/test_a2a_agent_credentials.py tests/agents/personal/test_a2a_routes.py`
  - 结果：`15 passed in 15.57s`
- `cd backend && uv run --locked pre-commit run --files app/core/logging.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_logging_config.py`
  - 结果：`5 passed in 0.79s`

### Migration check

- `cd backend && SCHEMA_NAME=a2a_client_hub_schema uv run --locked alembic upgrade head`

## 建议的后续关注点

### 并发冲突处理

- 可后续补充对 `IntegrityError` 的定向转换，把活跃记录重复创建/更新冲突稳定转换为业务层 4xx，而不是裸 500

### shared scope 回归

- 如后续要进一步收紧回归覆盖，可补一条 shared agent 软删除后复用相同 `card_url` 的测试，确认两种 scope 的行为一致
