### PR TITLE
refactor(invoke): normalize A2A stream content handling

### DIFF
--- a/backend/app/features/invoke/payload_analysis.py
+++ b/backend/app/features/invoke/payload_analysis.py
@@ -115,6 +115,8 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
         else _dict_field(root, "status")
     )
     status_metadata = _dict_field(status, "metadata")
+    status_message = stream_payloads._resolve_status_message(root)
+    status_message_metadata = _dict_field(status_message, "metadata")
     task = stream_body if stream_kind == "task" else _dict_field(root, "task")
     task_status = _dict_field(task, "status")
     task_status_metadata = _dict_field(task_status, "metadata")
@@ -138,6 +140,8 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
         message_metadata,
         status,
         status_metadata,
+        status_message,
+        status_message_metadata,
         task,
         task_status,
         task_status_metadata,
@@ -154,6 +158,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
     task_id = pick_first_non_empty_str(
         (
             stream_body,
+            status_message,
             task,
             _dict_field(status, "task"),
             _dict_field(result, "task"),
@@ -173,7 +178,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
     )
 
     usage: dict[str, Any] = {}
-    for cand in (stream_body, artifact, message, status, task, result):
+    for cand in (stream_body, artifact, message, status_message, status, task, result):
         cand_usage = _extract_usage_from_candidate(cand)
         if cand_usage:
             usage.update(cand_usage)
@@ -183,7 +188,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
     external_session_id = None
     binding_meta: dict[str, Any] = {}
 
-    for cand in (stream_body, message, result):
+    for cand in (stream_body, message, status_message, result):
         if context_id is None:
             context_id = extract_context_id(cand)
 

--- a/backend/app/features/invoke/payload_analysis.py
+++ b/backend/app/features/invoke/payload_analysis.py
@@ -14,12 +14,10 @@ from app.features.invoke.payload_helpers import pick_int as _pick_int
 from app.features.invoke.shared_metadata import (
     extract_preferred_usage_metadata,
     merge_preferred_session_binding_metadata,
-    merge_shared_metadata_sections,
 )
 from app.integrations.a2a_client.protobuf import (
     to_protojson_object,
 )
-from app.integrations.a2a_extensions.shared_contract import SHARED_STREAM_KEY
 from app.utils.payload_extract import (
     extract_context_id,
     extract_provider_and_external_session_id,
@@ -103,19 +101,21 @@ def _extract_usage_from_candidate(payload: dict[str, Any]) -> dict[str, Any]:
 def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
     root = payload
 
-    stream_kind, stream_body = stream_payloads._resolve_stream_response_body(root)
-    event_metadata = _dict_field(stream_body, "metadata")
-    artifact = stream_payloads._resolve_stream_artifact(root)
-    artifact_metadata = _dict_field(artifact, "metadata")
+    content_envelope = stream_payloads.resolve_stream_content_envelope(root)
+    stream_kind = content_envelope.event_kind
+    stream_body = content_envelope.event_body
+    event_metadata = content_envelope.event_metadata
+    artifact = content_envelope.artifact
+    artifact_metadata = content_envelope.artifact_metadata
     message = stream_body if stream_kind == "message" else _dict_field(root, "message")
     message_metadata = _dict_field(message, "metadata")
     status = (
-        _dict_field(stream_body, "status")
+        content_envelope.status
         if stream_kind == "status-update"
         else _dict_field(root, "status")
     )
     status_metadata = _dict_field(status, "metadata")
-    status_message = stream_payloads._resolve_status_message(root)
+    status_message = content_envelope.status_message
     status_message_metadata = _dict_field(status_message, "metadata")
     task = stream_body if stream_kind == "task" else _dict_field(root, "task")
     task_status = _dict_field(task, "status")
@@ -124,14 +124,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
     result_status = _dict_field(result, "status")
     result_status_metadata = _dict_field(result_status, "metadata")
     root_metadata = event_metadata if stream_body else _dict_field(root, "metadata")
-    artifact_shared_stream = merge_shared_metadata_sections(
-        tuple(
-            candidate
-            for candidate in ((stream_body if stream_body else root), artifact)
-            if candidate
-        ),
-        section=SHARED_STREAM_KEY,
-    )
+    artifact_shared_stream = content_envelope.shared_stream
 
     identity_candidates = (
         artifact,

--- a/backend/app/features/invoke/service_streaming.py
+++ b/backend/app/features/invoke/service_streaming.py
@@ -510,12 +510,12 @@ class A2AInvokeStreamingRuntime:
         if message_id is not None:
             shared_stream["messageId"] = message_id
         shared_stream["eventId"] = event_id or fallback_event_id
-        if kind == "message":
+        if kind in {"message", "status-update"}:
             if (
                 not isinstance(shared_stream.get("blockType"), str)
                 or not str(shared_stream.get("blockType")).strip()
             ):
-                parts = body.get("parts")
+                parts = artifact.get("parts")
                 if stream_payloads.extract_stream_data_from_parts(parts):
                     shared_stream["blockType"] = "tool_call"
                 elif stream_payloads.extract_stream_text_from_parts(parts):

--- a/backend/app/features/invoke/service_streaming.py
+++ b/backend/app/features/invoke/service_streaming.py
@@ -18,7 +18,6 @@ from app.features.invoke import (
     service_streaming_transport,
     stream_payloads,
 )
-from app.features.invoke.payload_helpers import dict_field as _dict_field
 from app.features.invoke.payload_helpers import (
     pick_first_non_empty_str,
     pick_non_empty_str,
@@ -438,11 +437,12 @@ class A2AInvokeStreamingRuntime:
         *,
         event_sequence: int,
     ) -> None:
-        kind = stream_payloads._resolved_stream_event_kind(payload)
+        content_envelope = stream_payloads.resolve_stream_content_envelope(payload)
+        kind = content_envelope.event_kind
         if kind not in {"artifact-update", "message", "status-update", "task"}:
             return
 
-        _, body = stream_payloads._resolve_stream_response_body(payload)
+        body = content_envelope.event_body
         if not body:
             return
 
@@ -463,11 +463,9 @@ class A2AInvokeStreamingRuntime:
 
         shared_stream["seq"] = event_sequence
 
-        artifact = stream_payloads._resolve_stream_artifact(payload)
-        artifact_metadata = _dict_field(artifact, "metadata")
-        artifact_shared_stream = stream_payloads.extract_shared_stream_metadata(
-            payload, artifact
-        )
+        artifact = content_envelope.artifact
+        artifact_metadata = content_envelope.artifact_metadata
+        artifact_shared_stream = content_envelope.shared_stream
         message_id = pick_first_non_empty_str(
             (
                 body,

--- a/backend/app/features/invoke/service_streaming_consume.py
+++ b/backend/app/features/invoke/service_streaming_consume.py
@@ -21,7 +21,7 @@ from app.features.invoke.service_types import (
 from app.features.invoke.stream_diagnostics import (
     build_artifact_update_log_sample,
     build_validation_errors_log_sample,
-    extract_artifact_validation_errors,
+    extract_stream_content_validation_errors,
     warn_non_contract_stream_content_once,
 )
 
@@ -186,7 +186,7 @@ async def consume_stream(
             runtime._ensure_outbound_stream_contract(
                 serialized, event_sequence=event_sequence
             )
-            validation_errors = extract_artifact_validation_errors(
+            validation_errors = extract_stream_content_validation_errors(
                 serialized,
                 validate_message=validate_message,
             )

--- a/backend/app/features/invoke/service_streaming_consume.py
+++ b/backend/app/features/invoke/service_streaming_consume.py
@@ -19,7 +19,7 @@ from app.features.invoke.service_types import (
     ValidateMessageFn,
 )
 from app.features.invoke.stream_diagnostics import (
-    build_artifact_update_log_sample,
+    build_stream_content_log_sample,
     build_validation_errors_log_sample,
     extract_stream_content_validation_errors,
     warn_non_contract_stream_content_once,
@@ -197,7 +197,7 @@ async def consume_stream(
                     "validation_errors_sample": build_validation_errors_log_sample(
                         validation_errors
                     ),
-                    "artifact_update_sample": build_artifact_update_log_sample(
+                    "stream_content_sample": build_stream_content_log_sample(
                         serialized
                     ),
                 }

--- a/backend/app/features/invoke/service_streaming_consume.py
+++ b/backend/app/features/invoke/service_streaming_consume.py
@@ -22,7 +22,7 @@ from app.features.invoke.stream_diagnostics import (
     build_artifact_update_log_sample,
     build_validation_errors_log_sample,
     extract_artifact_validation_errors,
-    warn_non_contract_artifact_update_once,
+    warn_non_contract_stream_content_once,
 )
 
 
@@ -215,7 +215,7 @@ async def consume_stream(
             stream_block, non_contract_reason = (
                 stream_payloads.analyze_stream_chunk_contract(serialized)
             )
-            warn_non_contract_artifact_update_once(
+            warn_non_contract_stream_content_once(
                 seen_reasons=non_contract_drop_reasons,
                 reason=non_contract_reason,
                 payload=serialized,

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -24,7 +24,7 @@ from app.features.invoke.service_types import (
 from app.features.invoke.stream_diagnostics import (
     build_artifact_update_log_sample,
     build_validation_errors_log_sample,
-    extract_artifact_validation_errors,
+    extract_stream_content_validation_errors,
     warn_non_contract_stream_content_once,
 )
 from app.utils.json_encoder import json_dumps
@@ -113,7 +113,7 @@ def stream_sse(
                 serialized = runtime.serialize_stream_event(
                     event, validate_message=validate_message
                 )
-                validation_errors = extract_artifact_validation_errors(
+                validation_errors = extract_stream_content_validation_errors(
                     serialized,
                     validate_message=validate_message,
                 )
@@ -333,7 +333,7 @@ async def stream_ws(
             serialized = runtime.serialize_stream_event(
                 event, validate_message=validate_message
             )
-            validation_errors = extract_artifact_validation_errors(
+            validation_errors = extract_stream_content_validation_errors(
                 serialized,
                 validate_message=validate_message,
             )

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -10,6 +10,7 @@ from fastapi import WebSocket
 from fastapi.responses import StreamingResponse
 
 from app.features.invoke import stream_payloads
+from app.features.invoke.payload_helpers import pick_first_int
 from app.features.invoke.service_types import (
     StreamErrorMetadataCallbackFn,
     StreamEventPayloadCallbackFn,
@@ -22,7 +23,7 @@ from app.features.invoke.service_types import (
     ValidateMessageFn,
 )
 from app.features.invoke.stream_diagnostics import (
-    build_artifact_update_log_sample,
+    build_stream_content_log_sample,
     build_validation_errors_log_sample,
     extract_stream_content_validation_errors,
     warn_non_contract_stream_content_once,
@@ -77,10 +78,14 @@ def stream_sse(
                 cache_key, resume_from_sequence
             )
             for cached_sequence, cached_event in cached_events:
-                parsed_sequence = (
-                    stream_payloads.extract_stream_sequence_from_serialized_event(
-                        cached_event
-                    )
+                envelope = stream_payloads.resolve_stream_content_envelope(cached_event)
+                parsed_sequence = pick_first_int(
+                    (
+                        envelope.shared_stream,
+                        envelope.event_metadata,
+                        envelope.artifact_metadata,
+                    ),
+                    ("seq",),
                 )
                 if parsed_sequence is not None:
                     seq_counter = max(seq_counter, parsed_sequence)
@@ -126,8 +131,8 @@ def stream_sse(
                             "validation_errors_sample": (
                                 build_validation_errors_log_sample(validation_errors)
                             ),
-                            "artifact_update_sample": (
-                                build_artifact_update_log_sample(serialized)
+                            "stream_content_sample": (
+                                build_stream_content_log_sample(serialized)
                             ),
                         },
                     )
@@ -295,10 +300,14 @@ async def stream_ws(
             cache_key, resume_from_sequence
         )
         for cached_sequence, cached_event in cached_events:
-            parsed_sequence = (
-                stream_payloads.extract_stream_sequence_from_serialized_event(
-                    cached_event
-                )
+            envelope = stream_payloads.resolve_stream_content_envelope(cached_event)
+            parsed_sequence = pick_first_int(
+                (
+                    envelope.shared_stream,
+                    envelope.event_metadata,
+                    envelope.artifact_metadata,
+                ),
+                ("seq",),
             )
             if parsed_sequence is not None:
                 seq_counter = max(seq_counter, parsed_sequence)
@@ -346,8 +355,8 @@ async def stream_ws(
                         "validation_errors_sample": (
                             build_validation_errors_log_sample(validation_errors)
                         ),
-                        "artifact_update_sample": (
-                            build_artifact_update_log_sample(serialized)
+                        "stream_content_sample": (
+                            build_stream_content_log_sample(serialized)
                         ),
                     },
                 )

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -25,7 +25,7 @@ from app.features.invoke.stream_diagnostics import (
     build_artifact_update_log_sample,
     build_validation_errors_log_sample,
     extract_artifact_validation_errors,
-    warn_non_contract_artifact_update_once,
+    warn_non_contract_stream_content_once,
 )
 from app.utils.json_encoder import json_dumps
 
@@ -145,7 +145,7 @@ def stream_sse(
                 stream_block, non_contract_reason = (
                     stream_payloads.analyze_stream_chunk_contract(serialized)
                 )
-                warn_non_contract_artifact_update_once(
+                warn_non_contract_stream_content_once(
                     seen_reasons=non_contract_drop_reasons,
                     reason=non_contract_reason,
                     payload=serialized,
@@ -365,7 +365,7 @@ async def stream_ws(
             stream_block, non_contract_reason = (
                 stream_payloads.analyze_stream_chunk_contract(serialized)
             )
-            warn_non_contract_artifact_update_once(
+            warn_non_contract_stream_content_once(
                 seen_reasons=non_contract_drop_reasons,
                 reason=non_contract_reason,
                 payload=serialized,

--- a/backend/app/features/invoke/stream_diagnostics.py
+++ b/backend/app/features/invoke/stream_diagnostics.py
@@ -26,10 +26,12 @@ _LOG_SAMPLE_SENSITIVE_KEYWORDS = (
 )
 
 
-def extract_artifact_validation_errors(
+def extract_stream_content_validation_errors(
     payload: dict[str, Any], *, validate_message: ValidateMessageFn
 ) -> list[str]:
-    if not any(field in payload for field in ("artifactUpdate", "message")):
+    if not any(
+        field in payload for field in ("artifactUpdate", "message", "statusUpdate")
+    ):
         return []
     return [str(item) for item in validate_message(payload)]
 

--- a/backend/app/features/invoke/stream_diagnostics.py
+++ b/backend/app/features/invoke/stream_diagnostics.py
@@ -112,7 +112,7 @@ def build_validation_errors_log_sample(validation_errors: list[str]) -> list[str
     ]
 
 
-def warn_non_contract_artifact_update_once(
+def warn_non_contract_stream_content_once(
     *,
     seen_reasons: set[str],
     reason: str | None,
@@ -131,12 +131,12 @@ def warn_non_contract_artifact_update_once(
     }
     if callable(log_warning):
         log_warning(
-            "Dropped non-contract artifact-update event",
+            "Dropped non-contract stream content event",
             extra=warning_payload,
         )
         return
     if callable(log_info):
         log_info(
-            "Dropped non-contract artifact-update event",
+            "Dropped non-contract stream content event",
             extra=warning_payload,
         )

--- a/backend/app/features/invoke/stream_diagnostics.py
+++ b/backend/app/features/invoke/stream_diagnostics.py
@@ -103,7 +103,7 @@ def _sanitize_log_sample(
     return _truncate_log_string(repr(value))
 
 
-def build_artifact_update_log_sample(payload: dict[str, Any]) -> dict[str, Any]:
+def build_stream_content_log_sample(payload: dict[str, Any]) -> dict[str, Any]:
     return cast(dict[str, Any], _sanitize_log_sample(payload))
 
 
@@ -129,7 +129,7 @@ def warn_non_contract_stream_content_once(
     warning_payload = {
         **log_extra,
         "drop_reason": reason,
-        "artifact_update_sample": build_artifact_update_log_sample(payload),
+        "stream_content_sample": build_stream_content_log_sample(payload),
     }
     if callable(log_warning):
         log_warning(

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -51,13 +51,6 @@ class ResolvedStreamContentEnvelope:
     shared_stream: dict[str, Any]
 
 
-def _resolved_stream_event_kind(payload: dict[str, Any]) -> str | None:
-    for field_name, kind in _STREAM_RESPONSE_FIELD_TO_KIND:
-        if isinstance(payload.get(field_name), dict):
-            return kind
-    return None
-
-
 def _resolve_stream_response_body(
     payload: dict[str, Any],
 ) -> tuple[str | None, dict[str, Any]]:
@@ -183,10 +176,6 @@ def _infer_message_block_type(parts: Any) -> str | None:
         return "tool_call"
     if extract_stream_text_from_parts(parts):
         return "text"
-    return None
-
-
-def coerce_message_event_to_artifact_update(payload: dict[str, Any]) -> None:
     return None
 
 
@@ -384,20 +373,6 @@ def extract_block_base_seq(
             artifact,
         ),
         ("baseSeq",),
-    )
-
-
-def extract_stream_sequence_from_serialized_event(
-    payload: dict[str, Any],
-) -> int | None:
-    envelope = resolve_stream_content_envelope(payload)
-    return pick_first_int(
-        (
-            envelope.shared_stream,
-            envelope.event_metadata,
-            envelope.artifact_metadata,
-        ),
-        ("seq",),
     )
 
 

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -136,10 +136,6 @@ def resolve_stream_content_envelope(
     )
 
 
-def _resolve_status_message(payload: dict[str, Any]) -> dict[str, Any]:
-    return resolve_stream_content_envelope(payload).status_message
-
-
 def extract_stream_text_from_parts(parts: Any) -> str:
     if not isinstance(parts, list):
         return ""
@@ -188,10 +184,6 @@ def _infer_message_block_type(parts: Any) -> str | None:
     if extract_stream_text_from_parts(parts):
         return "text"
     return None
-
-
-def _resolve_stream_artifact(payload: dict[str, Any]) -> dict[str, Any]:
-    return resolve_stream_content_envelope(payload).artifact
 
 
 def coerce_message_event_to_artifact_update(payload: dict[str, Any]) -> None:

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -58,6 +58,29 @@ def _event_metadata(payload: dict[str, Any]) -> dict[str, Any]:
     return _dict_field(body, "metadata")
 
 
+def _build_synthetic_artifact_from_message(message: dict[str, Any]) -> dict[str, Any]:
+    parts = message.get("parts")
+    if not isinstance(parts, list):
+        return {}
+    synthetic_artifact: dict[str, Any] = {"parts": list(parts)}
+    metadata = _dict_field(message, "metadata")
+    if metadata:
+        synthetic_artifact["metadata"] = dict(metadata)
+    for field_name in ("messageId", "taskId", "role", "eventId", "toolCall"):
+        value = message.get(field_name)
+        if value is not None:
+            synthetic_artifact[field_name] = value
+    return synthetic_artifact
+
+
+def _resolve_status_message(payload: dict[str, Any]) -> dict[str, Any]:
+    kind, body = _resolve_stream_response_body(payload)
+    if kind != "status-update":
+        return {}
+    status = _dict_field(body, "status")
+    return _dict_field(status, "message")
+
+
 def extract_stream_text_from_parts(parts: Any) -> str:
     if not isinstance(parts, list):
         return ""
@@ -113,16 +136,13 @@ def _resolve_stream_artifact(payload: dict[str, Any]) -> dict[str, Any]:
     if kind == "artifact-update":
         artifact = body.get("artifact")
         return artifact if isinstance(artifact, dict) else {}
+    if kind == "message":
+        return _build_synthetic_artifact_from_message(body)
+    if kind == "status-update":
+        return _build_synthetic_artifact_from_message(_resolve_status_message(payload))
     if kind != "message":
         return {}
-    parts = body.get("parts")
-    if not isinstance(parts, list):
-        return {}
-    synthetic_artifact: dict[str, Any] = {"parts": list(parts)}
-    metadata = _dict_field(body, "metadata")
-    if metadata:
-        synthetic_artifact["metadata"] = dict(metadata)
-    return synthetic_artifact
+    return {}
 
 
 def coerce_message_event_to_artifact_update(payload: dict[str, Any]) -> None:
@@ -167,8 +187,8 @@ def extract_artifact_type(
         raw = event_metadata.get("blockType")
 
     if not isinstance(raw, str) or not raw.strip():
-        if kind == "message":
-            return _infer_message_block_type(body.get("parts"))
+        if kind in {"message", "status-update"}:
+            return _infer_message_block_type(artifact.get("parts"))
         return None
 
     normalized = raw.strip().lower()
@@ -240,7 +260,10 @@ def extract_block_operation(
         normalized = raw.lower()
         if normalized in BLOCK_OPERATION_TYPES:
             return normalized
-    if kind == "message" and _infer_message_block_type(body.get("parts")) is not None:
+    if (
+        kind in {"message", "status-update"}
+        and _infer_message_block_type(artifact.get("parts")) is not None
+    ):
         return "replace"
     return None
 
@@ -346,7 +369,7 @@ def extract_stream_chunk_from_serialized_event(
     payload: dict[str, Any],
 ) -> dict[str, Any] | None:
     normalized_kind = _resolved_stream_event_kind(payload)
-    if normalized_kind not in ("artifact-update", "message"):
+    if normalized_kind not in ("artifact-update", "message", "status-update"):
         return None
 
     _, body = _resolve_stream_response_body(payload)
@@ -437,7 +460,7 @@ def analyze_stream_chunk_contract(
     payload: dict[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
     normalized_kind = _resolved_stream_event_kind(payload)
-    if normalized_kind not in ("artifact-update", "message"):
+    if normalized_kind not in ("artifact-update", "message", "status-update"):
         return None, None
     stream_block = extract_stream_chunk_from_serialized_event(payload)
     if stream_block is not None:

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any
 
 from app.features.invoke.interrupt_metadata import (
@@ -34,6 +35,20 @@ _STREAM_RESPONSE_FIELD_TO_KIND = (
     ("message", "message"),
     ("task", "task"),
 )
+
+
+@dataclass(frozen=True)
+class ResolvedStreamContentEnvelope:
+    event_kind: str | None
+    event_body: dict[str, Any]
+    event_metadata: dict[str, Any]
+    status: dict[str, Any]
+    status_message: dict[str, Any]
+    content_source_kind: str | None
+    artifact: dict[str, Any]
+    artifact_metadata: dict[str, Any]
+    parts: list[Any]
+    shared_stream: dict[str, Any]
 
 
 def _resolved_stream_event_kind(payload: dict[str, Any]) -> str | None:
@@ -73,12 +88,56 @@ def _build_synthetic_artifact_from_message(message: dict[str, Any]) -> dict[str,
     return synthetic_artifact
 
 
-def _resolve_status_message(payload: dict[str, Any]) -> dict[str, Any]:
+def resolve_stream_content_envelope(
+    payload: dict[str, Any],
+) -> ResolvedStreamContentEnvelope:
     kind, body = _resolve_stream_response_body(payload)
-    if kind != "status-update":
-        return {}
-    status = _dict_field(body, "status")
-    return _dict_field(status, "message")
+    event_metadata = _dict_field(body, "metadata")
+    status = _dict_field(body, "status") if kind == "status-update" else {}
+    status_message = _dict_field(status, "message")
+
+    content_source_kind: str | None = None
+    artifact: dict[str, Any] = {}
+    if kind == "artifact-update":
+        candidate = body.get("artifact")
+        artifact = candidate if isinstance(candidate, dict) else {}
+        if artifact:
+            content_source_kind = "artifact"
+    elif kind == "message":
+        artifact = _build_synthetic_artifact_from_message(body)
+        if artifact:
+            content_source_kind = "message"
+    elif kind == "status-update":
+        artifact = _build_synthetic_artifact_from_message(status_message)
+        if artifact:
+            content_source_kind = "status_message"
+
+    artifact_metadata = _dict_field(artifact, "metadata")
+    parts = artifact.get("parts")
+    shared_stream = merge_shared_metadata_sections(
+        tuple(
+            candidate
+            for candidate in (event_metadata, artifact)
+            if isinstance(candidate, dict)
+        ),
+        section=SHARED_STREAM_KEY,
+    )
+    return ResolvedStreamContentEnvelope(
+        event_kind=kind,
+        event_body=body,
+        event_metadata=event_metadata,
+        status=status,
+        status_message=status_message,
+        content_source_kind=content_source_kind,
+        artifact=artifact,
+        artifact_metadata=artifact_metadata,
+        parts=list(parts) if isinstance(parts, list) else [],
+        shared_stream=shared_stream,
+    )
+
+
+def _resolve_status_message(payload: dict[str, Any]) -> dict[str, Any]:
+    return resolve_stream_content_envelope(payload).status_message
 
 
 def extract_stream_text_from_parts(parts: Any) -> str:
@@ -132,17 +191,7 @@ def _infer_message_block_type(parts: Any) -> str | None:
 
 
 def _resolve_stream_artifact(payload: dict[str, Any]) -> dict[str, Any]:
-    kind, body = _resolve_stream_response_body(payload)
-    if kind == "artifact-update":
-        artifact = body.get("artifact")
-        return artifact if isinstance(artifact, dict) else {}
-    if kind == "message":
-        return _build_synthetic_artifact_from_message(body)
-    if kind == "status-update":
-        return _build_synthetic_artifact_from_message(_resolve_status_message(payload))
-    if kind != "message":
-        return {}
-    return {}
+    return resolve_stream_content_envelope(payload).artifact
 
 
 def coerce_message_event_to_artifact_update(payload: dict[str, Any]) -> None:
@@ -349,17 +398,12 @@ def extract_block_base_seq(
 def extract_stream_sequence_from_serialized_event(
     payload: dict[str, Any],
 ) -> int | None:
-    root = payload
-    _, body = _resolve_stream_response_body(root)
-    artifact = _resolve_stream_artifact(root)
-    body_metadata = _dict_field(body, "metadata")
-    artifact_metadata = _dict_field(artifact, "metadata")
-    shared_stream = extract_shared_stream_metadata(root, artifact)
+    envelope = resolve_stream_content_envelope(payload)
     return pick_first_int(
         (
-            shared_stream,
-            body_metadata,
-            artifact_metadata,
+            envelope.shared_stream,
+            envelope.event_metadata,
+            envelope.artifact_metadata,
         ),
         ("seq",),
     )
@@ -368,17 +412,18 @@ def extract_stream_sequence_from_serialized_event(
 def extract_stream_chunk_from_serialized_event(
     payload: dict[str, Any],
 ) -> dict[str, Any] | None:
-    normalized_kind = _resolved_stream_event_kind(payload)
+    envelope = resolve_stream_content_envelope(payload)
+    normalized_kind = envelope.event_kind
     if normalized_kind not in ("artifact-update", "message", "status-update"):
         return None
 
-    _, body = _resolve_stream_response_body(payload)
-    artifact = _resolve_stream_artifact(payload)
+    body = envelope.event_body
+    artifact = envelope.artifact
     if not artifact:
         return None
-    artifact_metadata = _dict_field(artifact, "metadata")
-    event_metadata = _dict_field(body, "metadata")
-    shared_stream = extract_shared_stream_metadata(payload, artifact)
+    artifact_metadata = envelope.artifact_metadata
+    event_metadata = envelope.event_metadata
+    shared_stream = envelope.shared_stream
 
     block_type = extract_artifact_type(payload, artifact)
     if block_type is None:
@@ -459,14 +504,17 @@ def extract_stream_chunk_from_serialized_event(
 def analyze_stream_chunk_contract(
     payload: dict[str, Any],
 ) -> tuple[dict[str, Any] | None, str | None]:
-    normalized_kind = _resolved_stream_event_kind(payload)
+    envelope = resolve_stream_content_envelope(payload)
+    normalized_kind = envelope.event_kind
     if normalized_kind not in ("artifact-update", "message", "status-update"):
+        return None, None
+    if normalized_kind == "status-update" and envelope.content_source_kind is None:
         return None, None
     stream_block = extract_stream_chunk_from_serialized_event(payload)
     if stream_block is not None:
         return stream_block, None
 
-    artifact = _resolve_stream_artifact(payload)
+    artifact = envelope.artifact
     if not artifact:
         return None, "missing_artifact"
 

--- a/backend/tests/invoke/a2a_invoke_service_support.py
+++ b/backend/tests/invoke/a2a_invoke_service_support.py
@@ -24,7 +24,7 @@ from app.features.invoke.service_streaming import (
     a2a_invoke_streaming_runtime,
 )
 from app.features.invoke.service_types import StreamFinishReason
-from app.features.invoke.stream_diagnostics import build_artifact_update_log_sample
+from app.features.invoke.stream_diagnostics import build_stream_content_log_sample
 from app.features.invoke.stream_payloads import (
     extract_interrupt_lifecycle_from_serialized_event,
     extract_stream_chunk_from_serialized_event,
@@ -266,7 +266,7 @@ __all__ = [
     "_artifact_event",
     "a2a_invoke_service",
     "asyncio",
-    "build_artifact_update_log_sample",
+    "build_stream_content_log_sample",
     "coerce_payload_to_dict",
     "json",
     "logging",

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.features.invoke.stream_payloads import resolve_stream_content_envelope
 from tests.invoke.a2a_invoke_service_support import (
     _DumpableEvent,
     a2a_invoke_service,
@@ -8,6 +9,30 @@ from tests.invoke.a2a_invoke_service_support import (
     pytest,
     settings,
 )
+
+
+def test_resolve_stream_content_envelope_prefers_nested_status_message_content():
+    envelope = resolve_stream_content_envelope(
+        {
+            "statusUpdate": {
+                "status": {
+                    "state": "TASK_STATE_WORKING",
+                    "message": {
+                        "messageId": "msg-status-envelope",
+                        "parts": [{"text": "hello"}],
+                        "role": "ROLE_AGENT",
+                    },
+                },
+                "metadata": {"shared": {"stream": {"eventId": "evt-status-envelope"}}},
+            }
+        }
+    )
+
+    assert envelope.event_kind == "status-update"
+    assert envelope.content_source_kind == "status_message"
+    assert envelope.status_message["messageId"] == "msg-status-envelope"
+    assert envelope.artifact["parts"] == [{"text": "hello"}]
+    assert envelope.shared_stream["eventId"] == "evt-status-envelope"
 
 
 def test_extract_stream_identity_hints_from_serialized_event():

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -363,6 +363,41 @@ def test_extract_stream_chunk_inferrs_message_payloads_without_explicit_block_co
     assert chunk["source"] == "assistant_text"
 
 
+def test_extract_stream_chunk_inferrs_status_message_payloads_without_explicit_block_contract():
+    chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
+        {
+            "statusUpdate": {
+                "status": {
+                    "state": "TASK_STATE_WORKING",
+                    "message": {
+                        "messageId": "msg-status-1",
+                        "taskId": "task-status-1",
+                        "parts": [{"text": "hello from status message"}],
+                        "role": "ROLE_AGENT",
+                    },
+                },
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "eventId": "evt-status-1",
+                            "source": "assistant_text",
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    assert chunk is not None
+    assert chunk["event_id"] == "evt-status-1"
+    assert chunk["message_id"] == "msg-status-1"
+    assert chunk["artifact_id"] == "msg-status-1:text"
+    assert chunk["block_type"] == "text"
+    assert chunk["op"] == "replace"
+    assert chunk["content"] == "hello from status message"
+    assert chunk["source"] == "assistant_text"
+
+
 def test_ensure_outbound_stream_contract_adds_nested_shared_stream_metadata():
     payload = {
         "message": {
@@ -385,6 +420,36 @@ def test_ensure_outbound_stream_contract_adds_nested_shared_stream_metadata():
     assert payload["message"]["parts"] == [{"text": "render me"}]
     assert payload["message"]["role"] == "ROLE_AGENT"
     assert payload["message"]["messageId"] == "msg-root-2"
+
+
+def test_ensure_outbound_stream_contract_adds_shared_stream_metadata_for_status_message():
+    payload = {
+        "statusUpdate": {
+            "status": {
+                "state": "TASK_STATE_WORKING",
+                "message": {
+                    "messageId": "msg-status-2",
+                    "parts": [{"text": "render status message"}],
+                    "role": "ROLE_AGENT",
+                },
+            }
+        }
+    }
+
+    a2a_invoke_service._ensure_outbound_stream_contract(
+        payload,
+        event_sequence=5,
+    )
+
+    shared_stream = payload["statusUpdate"]["metadata"]["shared"]["stream"]
+    assert shared_stream["seq"] == 5
+    assert shared_stream["messageId"] == "msg-status-2"
+    assert shared_stream["eventId"] == "msg-status-2:5"
+    assert shared_stream["blockType"] == "text"
+    assert shared_stream["op"] == "replace"
+    assert payload["statusUpdate"]["status"]["message"]["parts"] == [
+        {"text": "render status message"}
+    ]
 
 
 def test_serialize_stream_event_keeps_canonical_message_payload_before_validation(

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -137,6 +137,25 @@ def test_extract_stream_identity_hints_from_status_metadata_message_id():
     assert hints["upstream_message_id"] == "msg-from-status-message"
 
 
+def test_extract_stream_identity_hints_from_nested_status_message_fields():
+    hints = a2a_invoke_service.extract_stream_identity_hints_from_serialized_event(
+        {
+            "statusUpdate": {
+                "status": {
+                    "state": "TASK_STATE_WORKING",
+                    "message": {
+                        "messageId": "msg-from-nested-status",
+                        "taskId": "task-from-nested-status",
+                        "parts": [{"text": "hello"}],
+                    },
+                }
+            }
+        }
+    )
+    assert hints["upstream_message_id"] == "msg-from-nested-status"
+    assert hints["upstream_task_id"] == "task-from-nested-status"
+
+
 def test_extract_stream_identity_hints_includes_upstream_task_id():
     hints = a2a_invoke_service.extract_stream_identity_hints_from_serialized_event(
         {
@@ -603,6 +622,38 @@ def test_extract_usage_hints_from_serialized_event_ignores_legacy_root_metadata(
         }
     )
     assert usage == {}
+
+
+def test_extract_binding_hints_from_nested_status_message_metadata():
+    context_id, metadata = (
+        a2a_invoke_service.extract_binding_hints_from_serialized_event(
+            {
+                "statusUpdate": {
+                    "status": {
+                        "state": "TASK_STATE_WORKING",
+                        "message": {
+                            "messageId": "msg-status-binding",
+                            "parts": [{"text": "hello"}],
+                            "metadata": {
+                                "contextId": "ctx-status-binding",
+                                "shared": {
+                                    "session": {
+                                        "id": "sess-status-binding",
+                                        "provider": "status-provider",
+                                    }
+                                },
+                            },
+                        },
+                    }
+                }
+            }
+        )
+    )
+    assert context_id == "ctx-status-binding"
+    assert metadata["shared"]["session"] == {
+        "id": "sess-status-binding",
+        "provider": "status-provider",
+    }
 
 
 def test_coerce_payload_to_dict_raises_exception(caplog):

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -599,7 +599,7 @@ async def test_sse_warns_non_contract_artifact_update_once_per_reason(caplog):
         record
         for record in caplog.records
         if record.levelname == "WARNING"
-        and record.message == "Dropped non-contract artifact-update event"
+        and record.message == "Dropped non-contract stream content event"
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
@@ -657,7 +657,7 @@ async def test_sse_warns_missing_text_parts_when_identity_ids_absent(caplog):
         record
         for record in caplog.records
         if record.levelname == "WARNING"
-        and record.message == "Dropped non-contract artifact-update event"
+        and record.message == "Dropped non-contract stream content event"
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
@@ -707,7 +707,7 @@ async def test_sse_accepts_tool_call_data_parts_without_non_contract_warning(cap
         record
         for record in caplog.records
         if record.levelname == "WARNING"
-        and record.message == "Dropped non-contract artifact-update event"
+        and record.message == "Dropped non-contract stream content event"
     ]
     assert warning_records == []
     payload = "".join(frames)
@@ -1316,7 +1316,7 @@ async def test_ws_warns_non_contract_artifact_update_once_per_reason(caplog):
         record
         for record in caplog.records
         if record.levelname == "WARNING"
-        and record.message == "Dropped non-contract artifact-update event"
+        and record.message == "Dropped non-contract stream content event"
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
@@ -1704,7 +1704,7 @@ async def test_consume_stream_warns_non_contract_artifact_update_once_per_reason
         record
         for record in caplog.records
         if record.levelname == "WARNING"
-        and record.message == "Dropped non-contract artifact-update event"
+        and record.message == "Dropped non-contract stream content event"
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -19,7 +19,7 @@ from tests.invoke.a2a_invoke_service_support import (
     _GatewayWithUnstructuredError,
     a2a_invoke_service,
     asyncio,
-    build_artifact_update_log_sample,
+    build_stream_content_log_sample,
     json,
     logging,
     pytest,
@@ -603,7 +603,7 @@ async def test_sse_warns_non_contract_artifact_update_once_per_reason(caplog):
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
-    warning_sample = getattr(warning_records[0], "artifact_update_sample", None)
+    warning_sample = getattr(warning_records[0], "stream_content_sample", None)
     assert isinstance(warning_sample, dict)
     assert (
         warning_sample["artifactUpdate"]["artifact"]["metadata"]["shared"]["stream"][
@@ -661,7 +661,7 @@ async def test_sse_warns_missing_text_parts_when_identity_ids_absent(caplog):
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
-    warning_sample = getattr(warning_records[0], "artifact_update_sample", None)
+    warning_sample = getattr(warning_records[0], "stream_content_sample", None)
     assert isinstance(warning_sample, dict)
     assert (
         warning_sample["artifactUpdate"]["artifact"]["metadata"]["shared"]["stream"][
@@ -1369,7 +1369,7 @@ async def test_ws_warns_non_contract_artifact_update_once_per_reason(caplog):
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
-    warning_sample = getattr(warning_records[0], "artifact_update_sample", None)
+    warning_sample = getattr(warning_records[0], "stream_content_sample", None)
     assert isinstance(warning_sample, dict)
     assert (
         warning_sample["artifactUpdate"]["artifact"]["metadata"]["shared"]["stream"][
@@ -1757,7 +1757,7 @@ async def test_consume_stream_warns_non_contract_artifact_update_once_per_reason
     ]
     assert len(warning_records) == 1
     assert getattr(warning_records[0], "drop_reason", None) == "missing_text_parts"
-    warning_sample = getattr(warning_records[0], "artifact_update_sample", None)
+    warning_sample = getattr(warning_records[0], "stream_content_sample", None)
     assert isinstance(warning_sample, dict)
     assert (
         warning_sample["artifactUpdate"]["artifact"]["metadata"]["shared"]["stream"][
@@ -1767,8 +1767,8 @@ async def test_consume_stream_warns_non_contract_artifact_update_once_per_reason
     )
 
 
-def test_build_artifact_update_log_sample_redacts_sensitive_fields_and_truncates():
-    sample = build_artifact_update_log_sample(
+def test_build_stream_content_log_sample_redacts_sensitive_fields_and_truncates():
+    sample = build_stream_content_log_sample(
         {
             "kind": "artifact-update",
             "metadata": {

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -716,6 +716,55 @@ async def test_sse_accepts_tool_call_data_parts_without_non_contract_warning(cap
 
 
 @pytest.mark.asyncio
+async def test_sse_validates_status_message_content_events(caplog):
+    caplog.set_level(logging.WARNING)
+    response = a2a_invoke_service.stream_sse(
+        gateway=_GatewayWithEvents(
+            [
+                {
+                    "statusUpdate": {
+                        "status": {
+                            "state": "TASK_STATE_WORKING",
+                            "message": {
+                                "messageId": "msg-status-invalid",
+                                "role": "ROLE_AGENT",
+                                "parts": [{"text": "hello"}],
+                            },
+                        }
+                    }
+                },
+                _status_update_event(state="TASK_STATE_COMPLETED"),
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda payload: (
+            ["invalid_status_message"]
+            if payload.get("statusUpdate", {}).get("status", {}).get("message")
+            else []
+        ),
+        logger=logging.getLogger(__name__),
+        log_extra={},
+    )
+    frames: list[str] = []
+    async for chunk in response.body_iterator:
+        frames.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    warning_records = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING"
+        and record.message == "Dropped invalid stream event"
+    ]
+    assert len(warning_records) == 1
+    payload = "".join(frames)
+    assert '"msg-status-invalid"' not in payload
+    assert '"TASK_STATE_COMPLETED"' in payload
+
+
+@pytest.mark.asyncio
 async def test_sse_cache_replays_mutated_event_payload_from_on_event():
     from app.features.invoke.stream_cache.memory_cache import global_stream_cache
 

--- a/backend/tests/invoke/test_invoke_stream_persistence.py
+++ b/backend/tests/invoke/test_invoke_stream_persistence.py
@@ -439,6 +439,108 @@ async def test_persist_local_outcome_records_upstream_task_binding(
 
 
 @pytest.mark.asyncio
+async def test_persist_stream_block_update_accepts_status_message_content(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    thread = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        title="Status Message Stream",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(thread)
+    await async_db_session.flush()
+
+    state = _FakeState(
+        local_session_id=thread.id,
+        local_source="manual",
+        context_id="ctx-status-message",
+        metadata={},
+        stream_identity={},
+        stream_usage={},
+        next_event_seq=1,
+    )
+
+    def _session_factory() -> _SessionContext:
+        return _SessionContext(async_db_session)
+
+    async def _commit(_db) -> None:
+        await async_db_session.flush()
+
+    async def _ensure_headers_adapter(**kwargs) -> None:
+        await ensure_local_message_headers(
+            **kwargs,
+            session_factory=_session_factory,
+            commit_fn=_commit,
+            session_hub=session_hub_service,
+        )
+
+    event_payload = {
+        "statusUpdate": {
+            "status": {
+                "state": "TASK_STATE_WORKING",
+                "message": {
+                    "messageId": "msg-status-stream-1",
+                    "taskId": "task-status-stream-1",
+                    "parts": [{"text": "hello from status message"}],
+                    "role": "ROLE_AGENT",
+                },
+            },
+            "metadata": {
+                "shared": {
+                    "stream": {
+                        "eventId": "evt-status-stream-1",
+                        "seq": 1,
+                        "source": "assistant_text",
+                    }
+                }
+            },
+        }
+    }
+
+    await persist_stream_block_update(
+        state=state,
+        event_payload=event_payload,
+        request=_build_request(user_id=user.id),
+        session_factory=_session_factory,
+        commit_fn=_commit,
+        session_hub=session_hub_service,
+        ensure_headers_fn=_ensure_headers_adapter,
+    )
+
+    await flush_stream_buffer(
+        state=state,
+        user_id=user.id,
+        session_factory=_session_factory,
+        commit_fn=_commit,
+        session_hub=session_hub_service,
+    )
+
+    agent_message = await async_db_session.scalar(
+        select(AgentMessage).where(
+            AgentMessage.conversation_id == thread.id,
+            AgentMessage.sender == "agent",
+        )
+    )
+    assert agent_message is not None
+
+    persisted_blocks = list(
+        (
+            await async_db_session.scalars(
+                select(AgentMessageBlock)
+                .where(AgentMessageBlock.message_id == agent_message.id)
+                .order_by(AgentMessageBlock.block_seq.asc())
+            )
+        ).all()
+    )
+    assert [block.block_type for block in persisted_blocks] == ["text"]
+    assert persisted_blocks[0].content == "hello from status message"
+
+
+@pytest.mark.asyncio
 async def test_persist_local_outcome_keeps_typed_blocks_when_upstream_reuses_artifact_id(
     async_db_session,
 ) -> None:

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -1044,6 +1044,34 @@ describe("block-based stream parser and reducer", () => {
     expect(parsed?.messageId).toBe("msg-message-9");
   });
 
+  it("infers text block type for status-update message wrappers", () => {
+    const parsed = extractStreamBlockUpdate({
+      statusUpdate: {
+        status: {
+          state: "TASK_STATE_WORKING",
+          message: {
+            messageId: "msg-status-9",
+            taskId: "task-status-9",
+            role: "ROLE_AGENT",
+            parts: [{ text: "hello from status message" }],
+          },
+        },
+        metadata: {
+          shared: {
+            stream: {
+              eventId: "evt-status-9",
+            },
+          },
+        },
+      },
+    });
+    expect(parsed?.blockType).toBe("text");
+    expect(parsed?.messageId).toBe("msg-status-9");
+    expect(parsed?.taskId).toBe("task-status-9");
+    expect(parsed?.eventId).toBe("evt-status-9");
+    expect(parsed?.delta).toBe("hello from status message");
+  });
+
   it("parses chunk when taskId is missing but messageId exists", () => {
     const parsed = extractStreamBlockUpdate({
       artifactUpdate: {

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -606,6 +606,52 @@ const resolveCanonicalStreamResponse = (
   return { kind: null, body: null };
 };
 
+const resolveCanonicalContentArtifact = (
+  kind: "artifact-update" | "message" | "status-update" | "task" | null,
+  body: Record<string, unknown> | null,
+  rootMetadata: Record<string, unknown> | null,
+) => {
+  if (kind === "artifact-update") {
+    return asRecord(body?.artifact);
+  }
+  if (kind === "message") {
+    if (!Array.isArray(body?.parts)) {
+      return null;
+    }
+    return {
+      parts: body.parts,
+      ...(rootMetadata ? { metadata: rootMetadata } : {}),
+      ...(typeof body?.messageId === "string"
+        ? { messageId: body.messageId }
+        : {}),
+      ...(typeof body?.taskId === "string" ? { taskId: body.taskId } : {}),
+      ...(typeof body?.role === "string" ? { role: body.role } : {}),
+      ...(body?.toolCall ? { toolCall: body.toolCall } : {}),
+    };
+  }
+  if (kind === "status-update") {
+    const status = asRecord(body?.status);
+    const message = asRecord(status?.message);
+    if (!Array.isArray(message?.parts)) {
+      return null;
+    }
+    const messageMetadata = asRecord(message?.metadata);
+    return {
+      parts: message.parts,
+      ...(messageMetadata ? { metadata: messageMetadata } : {}),
+      ...(typeof message?.messageId === "string"
+        ? { messageId: message.messageId }
+        : {}),
+      ...(typeof message?.taskId === "string"
+        ? { taskId: message.taskId }
+        : {}),
+      ...(typeof message?.role === "string" ? { role: message.role } : {}),
+      ...(message?.toolCall ? { toolCall: message.toolCall } : {}),
+    };
+  }
+  return null;
+};
+
 const extractToolCallView = (
   source: Record<string, unknown> | null,
 ): ToolCallView | null => {
@@ -662,19 +708,15 @@ export const extractStreamBlockUpdate = (
   data: Record<string, unknown>,
 ): StreamBlockUpdate | null => {
   const { kind, body } = resolveCanonicalStreamResponse(data);
-  if (kind !== "artifact-update" && kind !== "message") {
+  if (
+    kind !== "artifact-update" &&
+    kind !== "message" &&
+    kind !== "status-update"
+  ) {
     return null;
   }
   const rootMetadata = asRecord(body?.metadata);
-  const artifact =
-    kind === "artifact-update"
-      ? asRecord(body?.artifact)
-      : Array.isArray(body?.parts)
-        ? {
-            parts: body.parts,
-            ...(rootMetadata ? { metadata: rootMetadata } : {}),
-          }
-        : null;
+  const artifact = resolveCanonicalContentArtifact(kind, body, rootMetadata);
   const metadata = asRecord(artifact?.metadata) ?? rootMetadata;
   const sharedStream = extractSharedStreamMetadata(metadata, rootMetadata);
   const parts = Array.isArray(artifact?.parts) ? artifact.parts : [];
@@ -687,7 +729,7 @@ export const extractStreamBlockUpdate = (
   const explicitBlockType = parseBlockType(rawBlockType);
   const blockType =
     explicitBlockType ??
-    (kind === "message" && rawBlockType === null
+    ((kind === "message" || kind === "status-update") && rawBlockType === null
       ? dataFromParts
         ? "tool_call"
         : textFromParts
@@ -746,7 +788,9 @@ export const extractStreamBlockUpdate = (
     parseBlockOperation(pickString(rootMetadata, ["op", "operation"])) ??
     parseBlockOperation(pickString(artifact ?? null, ["op", "operation"])) ??
     parseBlockOperation(pickString(body ?? null, ["op", "operation"]));
-  const op = explicitOp ?? (kind === "message" ? "replace" : null);
+  const op =
+    explicitOp ??
+    (kind === "message" || kind === "status-update" ? "replace" : null);
   if (!op) {
     return null;
   }
@@ -804,6 +848,7 @@ export const extractStreamBlockUpdate = (
     pickInteger(body ?? null, ["baseSeq"]);
   const role = normalizeRole(
     pickString(body ?? null, ["role"]) ??
+      pickString(artifact ?? null, ["role"]) ??
       pickString(sharedStream, ["role"]) ??
       pickString(metadata, ["role"]) ??
       pickString(rootMetadata, ["role"]),


### PR DESCRIPTION
## 概要

本 PR 聚焦 A2A 流式内容消费链路的收敛与分层落地，完成两部分工作：

1. 落实 `#879` 的分层目标
- 明确上游协议适配、内部规范化、前端稳定契约输出三层边界
- 将上游兼容继续留在后端，不再把更多 A2A 变体解释职责扩散给前端

2. 完成 `#878` 收敛后的实现目标
- 将 `message.parts`、`artifactUpdate.artifact.parts`、`statusUpdate.status.message.parts` 三条内容源接入同一条后端消费主链
- 对齐实时流 block 解析、`final_text`、持久化 block、history fallback、identity/binding hints
- 引入显式的 stream content normalization helper，减少后端内部重复拼装
- 收尾清理 diagnostics 语义与残留冗余
- 补齐 `statusUpdate.status.message` 进入内容校验路径的残留点

## 主要改动

### 后端

- 在 `stream_payloads` 中引入统一的 `ResolvedStreamContentEnvelope`
- 统一 `artifactUpdate.artifact`、顶层 `message`、`statusUpdate.status.message` 的内容载体解析
- 扩展 `extract_stream_chunk_from_serialized_event`、`analyze_stream_chunk_contract`、`payload_analysis`、`service_streaming` 等主链路，使其共享同一套归一化结果
- 让 `statusUpdate.status.message` 进入内容类事件校验路径
- 将 diagnostics 文案从偏旧的 `artifact-update` 语义收敛为更准确的 `stream content`

### 前端

- 让前端稳定契约解析器可以消费后端规范化后的 `status-update` 内容包装
- 不新增前端对上游 provider 变体的额外适配职责

### 测试

- 补充 backend / frontend 回归，覆盖：
  - `statusUpdate.status.message` 的 block 解析
  - 持久化 block 落库
  - stream identity / binding hints
  - status message 内容的校验路径
  - diagnostics 收敛后的 warning 行为

## Issues 关系

- Closes #878
- Closes #879
- Follow-up: #880

说明：
- `#878` 与 `#879` 是本 PR 所实现并收尾的真实主 issue。
- `FilePart`、更广 multipart、block taxonomy 下一阶段支持已拆到 `#880`，不再继续塞入本 PR。

## 验证

已执行：

- `cd backend && uv run --locked pre-commit run --files app/features/invoke/stream_payloads.py app/features/invoke/payload_analysis.py app/features/invoke/service_streaming.py app/features/invoke/service_streaming_consume.py app/features/invoke/service_streaming_transport.py app/features/invoke/stream_diagnostics.py ../backend/tests/invoke/test_a2a_invoke_service_stream_contract.py ../backend/tests/invoke/test_a2a_invoke_service_streaming.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_a2a_invoke_service_contract_fallback.py tests/invoke/test_invoke_stream_persistence.py tests/invoke/test_a2a_invoke_service_streaming.py`
- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/api/chatStreamBlocks.ts lib/__tests__/streamContract.test.ts --maxWorkers=25%`

## 风险与边界

- 本 PR 不扩展新的 block taxonomy。
- 本 PR 不引入 `FilePart` 的主时间线支持。
- multipart / `FilePart` 的下一阶段设计与实现继续由 `#880` 跟进。
