### PR TITLE
fix(a2a): align canonical stream handling and extension errors

### DIFF
--- a/backend/app/features/extension_capabilities/common_router.py
+++ b/backend/app/features/extension_capabilities/common_router.py
@@ -100,13 +100,12 @@ def create_extension_capability_router(
         response: Response,
         db: AsyncSession = Depends(get_async_db),
         current_user: User = Depends(get_current_user),
-    ) -> A2AExtensionCapabilitiesResponse:
+    ) -> A2AExtensionCapabilitiesResponse | JSONResponse:
         response.headers["Cache-Control"] = "no-store"
         runtime = await _get_runtime_for_external_call(db, current_user, agent_id)
-        snapshot = await _extensions_service().resolve_capability_snapshot(
-            runtime=runtime
+        return await common_router_support.run_extension_capabilities_call(
+            _extensions_service().resolve_capability_snapshot(runtime=runtime)
         )
-        return common_router_support.build_extension_capabilities_response(snapshot)
 
     @router.post(
         "/{agent_id}/extensions/models/providers:list",

--- a/backend/app/features/extension_capabilities/common_router_support.py
+++ b/backend/app/features/extension_capabilities/common_router_support.py
@@ -556,14 +556,14 @@ def build_extension_capabilities_response(
     )
 
 
-async def run_extension_call(
-    call: Awaitable[Any],
-) -> A2AExtensionResponse | JSONResponse:
-    try:
-        result = await call
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except (A2AExtensionNotSupportedError, A2AExtensionContractError) as exc:
+def build_extension_error_response_from_exception(
+    exc: (
+        A2AExtensionNotSupportedError
+        | A2AExtensionContractError
+        | A2AExtensionUpstreamError
+    ),
+) -> JSONResponse:
+    if isinstance(exc, (A2AExtensionNotSupportedError, A2AExtensionContractError)):
         error_code = (
             "not_supported"
             if isinstance(exc, A2AExtensionNotSupportedError)
@@ -582,37 +582,80 @@ async def run_extension_call(
                 meta={},
             ),
         )
-    except A2AExtensionUpstreamError as exc:
-        response = A2AExtensionResponse(
-            success=False,
-            error_code=exc.error_code,
-            source=exc.source,
-            jsonrpc_code=exc.jsonrpc_code,
-            missing_params=exc.missing_params,
-            upstream_error=exc.upstream_error,
-            meta={},
-        )
-        status_code = status_code_for_extension_error_code(response.error_code)
-        if status_code == status.HTTP_200_OK:
-            return response
-        detail_message = (
-            str(response.upstream_error.get("message"))
-            if isinstance(response.upstream_error, dict)
-            and isinstance(response.upstream_error.get("message"), str)
-            else str(exc)
-        )
-        return build_error_response(
-            status_code=status_code,
-            detail=build_error_detail(
-                message=detail_message,
-                error_code=response.error_code,
-                source=response.source,
-                jsonrpc_code=response.jsonrpc_code,
-                missing_params=response.missing_params,
-                upstream_error=response.upstream_error,
-                meta=response.meta or {},
-            ),
-        )
+
+    response = A2AExtensionResponse(
+        success=False,
+        error_code=exc.error_code,
+        source=exc.source,
+        jsonrpc_code=exc.jsonrpc_code,
+        missing_params=exc.missing_params,
+        upstream_error=exc.upstream_error,
+        meta={},
+    )
+    detail_message = (
+        str(response.upstream_error.get("message"))
+        if isinstance(response.upstream_error, dict)
+        and isinstance(response.upstream_error.get("message"), str)
+        else str(exc)
+    )
+    return build_error_response(
+        status_code=status_code_for_extension_error_code(response.error_code),
+        detail=build_error_detail(
+            message=detail_message,
+            error_code=response.error_code,
+            source=response.source,
+            jsonrpc_code=response.jsonrpc_code,
+            missing_params=response.missing_params,
+            upstream_error=response.upstream_error,
+            meta=response.meta or {},
+        ),
+    )
+
+
+async def run_extension_capabilities_call(
+    call: Awaitable[Any],
+) -> A2AExtensionCapabilitiesResponse | JSONResponse:
+    try:
+        snapshot = await call
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (
+        A2AExtensionNotSupportedError,
+        A2AExtensionContractError,
+        A2AExtensionUpstreamError,
+    ) as exc:
+        return build_extension_error_response_from_exception(exc)
+    return build_extension_capabilities_response(snapshot)
+
+
+async def run_extension_call(
+    call: Awaitable[Any],
+) -> A2AExtensionResponse | JSONResponse:
+    try:
+        result = await call
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except (
+        A2AExtensionNotSupportedError,
+        A2AExtensionContractError,
+        A2AExtensionUpstreamError,
+    ) as exc:
+        if isinstance(exc, A2AExtensionUpstreamError):
+            response = A2AExtensionResponse(
+                success=False,
+                error_code=exc.error_code,
+                source=exc.source,
+                jsonrpc_code=exc.jsonrpc_code,
+                missing_params=exc.missing_params,
+                upstream_error=exc.upstream_error,
+                meta={},
+            )
+            if (
+                status_code_for_extension_error_code(response.error_code)
+                == status.HTTP_200_OK
+            ):
+                return response
+        return build_extension_error_response_from_exception(exc)
     response = A2AExtensionResponse(
         success=result.success,
         result=result.result,

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -264,6 +264,59 @@ def extract_artifact_id(
     return None
 
 
+def _infer_task_id_from_artifact_id(artifact_id: str | None) -> str | None:
+    if not isinstance(artifact_id, str):
+        return None
+    normalized = artifact_id.strip()
+    if not normalized:
+        return None
+    task_id, _, _ = normalized.partition(":")
+    task_id = task_id.strip()
+    return task_id or None
+
+
+def extract_message_id(
+    payload: dict[str, Any], artifact: dict[str, Any], *, artifact_id: str | None = None
+) -> str | None:
+    artifact_metadata = _dict_field(artifact, "metadata")
+    event_metadata = _event_metadata(payload)
+    shared_stream = extract_shared_stream_metadata(payload, artifact)
+    kind, body = _resolve_stream_response_body(payload)
+
+    message_id = pick_first_non_empty_str(
+        (
+            artifact,
+            artifact_metadata,
+            event_metadata,
+            shared_stream,
+            body,
+        ),
+        ("messageId",),
+    )
+    if message_id is not None:
+        return message_id
+    if kind != "artifact-update":
+        return None
+
+    task_id = pick_first_non_empty_str(
+        (
+            body,
+            artifact,
+            artifact_metadata,
+            event_metadata,
+            shared_stream,
+        ),
+        ("taskId",),
+    ) or _infer_task_id_from_artifact_id(
+        artifact_id
+        if artifact_id is not None
+        else extract_artifact_id(payload, artifact)
+    )
+    if task_id is None:
+        return None
+    return f"task:{task_id}"
+
+
 def _default_lane_id(block_type: str) -> str:
     return "primary_text" if block_type == "text" else block_type
 
@@ -324,21 +377,12 @@ def extract_block_id(
         return block_id
 
     lane_id = extract_lane_id(payload, artifact, block_type=block_type)
-    message_id = pick_first_non_empty_str(
-        (
-            artifact,
-            artifact_metadata,
-            event_metadata,
-            shared_stream,
-            body,
-        ),
-        ("messageId",),
-    )
+    artifact_id = extract_artifact_id(payload, artifact)
+    message_id = extract_message_id(payload, artifact, artifact_id=artifact_id)
     if message_id is not None:
         return f"{message_id}:{lane_id}"
 
-    artifact_id = extract_artifact_id(payload, artifact) or "stream"
-    return f"{artifact_id}:{lane_id}"
+    return f"{artifact_id or 'stream'}:{lane_id}"
 
 
 def extract_lane_id(
@@ -414,17 +458,6 @@ def extract_stream_chunk_from_serialized_event(
         ),
         ("eventId",),
     )
-    message_id = pick_first_non_empty_str(
-        (
-            artifact,
-            artifact_metadata,
-            event_metadata,
-            shared_stream,
-            body,
-        ),
-        ("messageId",),
-    )
-
     delta = extract_stream_content_from_parts(
         artifact.get("parts"), block_type=block_type
     )
@@ -446,6 +479,7 @@ def extract_stream_chunk_from_serialized_event(
     )
     source = extract_artifact_source(payload, artifact)
     artifact_id = extract_artifact_id(payload, artifact)
+    message_id = extract_message_id(payload, artifact, artifact_id=artifact_id)
     if artifact_id is None and message_id is not None:
         artifact_id = f"{message_id}:{block_type}"
     stream_chunk: dict[str, Any] = {

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -171,7 +171,7 @@ def extract_stream_data_from_parts(parts: Any) -> str:
     return "\n".join(collected)
 
 
-def _infer_message_block_type(parts: Any) -> str | None:
+def _infer_canonical_block_type(parts: Any) -> str | None:
     if extract_stream_data_from_parts(parts):
         return "tool_call"
     if extract_stream_text_from_parts(parts):
@@ -217,8 +217,8 @@ def extract_artifact_type(
         raw = event_metadata.get("blockType")
 
     if not isinstance(raw, str) or not raw.strip():
-        if kind in {"message", "status-update"}:
-            return _infer_message_block_type(artifact.get("parts"))
+        if kind in {"artifact-update", "message", "status-update"}:
+            return _infer_canonical_block_type(artifact.get("parts"))
         return None
 
     normalized = raw.strip().lower()
@@ -292,9 +292,14 @@ def extract_block_operation(
             return normalized
     if (
         kind in {"message", "status-update"}
-        and _infer_message_block_type(artifact.get("parts")) is not None
+        and _infer_canonical_block_type(artifact.get("parts")) is not None
     ):
         return "replace"
+    if (
+        kind == "artifact-update"
+        and _infer_canonical_block_type(artifact.get("parts")) is not None
+    ):
+        return "append" if body.get("append") is True else "replace"
     return None
 
 

--- a/backend/tests/agents/shared/test_hub_a2a_extension_capabilities_routes.py
+++ b/backend/tests/agents/shared/test_hub_a2a_extension_capabilities_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.integrations.a2a_extensions.errors import A2AExtensionUpstreamError
 from tests.agents.shared import hub_a2a_extensions_routes_support as support
 from tests.agents.shared.hub_a2a_extensions_routes_support import (
     SimpleNamespace,
@@ -989,6 +990,67 @@ async def test_hub_extension_capabilities_closes_read_only_transaction_before_up
     assert response.status_code == 200
     assert call_order == ["prepare_external_call", "resolve_capability_snapshot"]
     assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_hub_extension_capabilities_route_maps_upstream_timeout_to_structured_error(
+    async_session_maker, async_db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "a2a_proxy_allowed_hosts", ["example.com"])
+
+    agent_id, user = await _create_allowlisted_hub_agent(
+        async_session_maker=async_session_maker,
+        async_db_session=async_db_session,
+        admin_email="admin_opencode_cap_timeout@example.com",
+        user_email="alice_opencode_cap_timeout@example.com",
+        token="secret-token-opencode-capability-timeout",
+    )
+
+    fake_extensions = _FakeExtensionsService()
+
+    async def fake_resolve_capability_snapshot(*, runtime):
+        raise A2AExtensionUpstreamError(
+            message="A2A agent 'https://commons.kalos.art' timed out while fetching metadata",
+            error_code="agent_unavailable",
+            source="hub_gateway",
+            upstream_error={
+                "message": "A2A agent 'https://commons.kalos.art' timed out while fetching metadata",
+                "type": "A2AAgentUnavailableError",
+            },
+        )
+
+    monkeypatch.setattr(
+        fake_extensions,
+        "resolve_capability_snapshot",
+        fake_resolve_capability_snapshot,
+    )
+    monkeypatch.setattr(
+        extension_router_common,
+        "get_a2a_extensions_service",
+        lambda: fake_extensions,
+    )
+
+    async with create_test_client(
+        hub_extension_router.router,
+        async_session_maker=async_session_maker,
+        current_user=user,
+        base_prefix=settings.api_v1_prefix,
+    ) as user_client:
+        response = await user_client.get(
+            f"{settings.api_v1_prefix}/a2a/agents/{agent_id}/extensions/capabilities"
+        )
+
+    assert response.status_code == 503
+    detail = response.json()["detail"]
+    assert detail["message"] == (
+        "A2A agent 'https://commons.kalos.art' timed out while fetching metadata"
+    )
+    assert detail["error_code"] == "agent_unavailable"
+    assert detail["source"] == "hub_gateway"
+    assert detail["upstream_error"] == {
+        "message": "A2A agent 'https://commons.kalos.art' timed out while fetching metadata",
+        "type": "A2AAgentUnavailableError",
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/invoke/test_a2a_invoke_service_contract_fallback.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_contract_fallback.py
@@ -154,6 +154,52 @@ def test_extract_stream_chunk_reads_tool_call_content_from_data_parts():
     }
 
 
+def test_extract_stream_chunk_inferrs_tool_call_from_canonical_data_parts():
+    chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
+        {
+            "artifactUpdate": {
+                "taskId": "task-data-1",
+                "append": True,
+                "artifact": {
+                    "artifactId": "task-data-1:stream:data",
+                    "parts": [
+                        {
+                            "data": {
+                                "call_id": "call-2",
+                                "tool": "read",
+                                "status": "pending",
+                                "input": {"path": "README.md"},
+                            }
+                        }
+                    ],
+                },
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "eventId": "stream:data:1",
+                            "seq": 5,
+                        }
+                    }
+                },
+            }
+        }
+    )
+    assert chunk is not None
+    assert chunk["block_type"] == "tool_call"
+    assert chunk["op"] == "append"
+    assert chunk["content"] == (
+        '{"call_id":"call-2","input":{"path":"README.md"},"status":"pending","tool":"read"}'
+    )
+    assert chunk["tool_call"] == {
+        "name": "read",
+        "status": "running",
+        "callId": "call-2",
+        "arguments": {"path": "README.md"},
+        "result": None,
+        "error": None,
+    }
+
+
 def test_extract_stream_chunk_uses_message_lane_identity_when_artifact_id_is_shared():
     reasoning = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
         {

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -442,6 +442,41 @@ def test_extract_stream_chunk_inferrs_status_message_payloads_without_explicit_b
     assert chunk["source"] == "assistant_text"
 
 
+def test_extract_stream_chunk_inferrs_artifact_text_payloads_without_explicit_block_contract():
+    chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
+        {
+            "artifactUpdate": {
+                "taskId": "task-artifact-1",
+                "append": True,
+                "lastChunk": False,
+                "artifact": {
+                    "artifactId": "task-artifact-1:stream:text",
+                    "parts": [{"text": "hello from artifact"}],
+                },
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "eventId": "stream:4",
+                            "seq": 4,
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    assert chunk is not None
+    assert chunk["event_id"] == "stream:4"
+    assert chunk["seq"] == 4
+    assert chunk["message_id"] is None
+    assert chunk["artifact_id"] == "task-artifact-1:stream:text"
+    assert chunk["block_type"] == "text"
+    assert chunk["op"] == "append"
+    assert chunk["append"] is True
+    assert chunk["content"] == "hello from artifact"
+    assert chunk["is_finished"] is False
+
+
 def test_ensure_outbound_stream_contract_adds_nested_shared_stream_metadata():
     payload = {
         "message": {

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -468,8 +468,9 @@ def test_extract_stream_chunk_inferrs_artifact_text_payloads_without_explicit_bl
     assert chunk is not None
     assert chunk["event_id"] == "stream:4"
     assert chunk["seq"] == 4
-    assert chunk["message_id"] is None
+    assert chunk["message_id"] == "task:task-artifact-1"
     assert chunk["artifact_id"] == "task-artifact-1:stream:text"
+    assert chunk["block_id"] == "task:task-artifact-1:primary_text"
     assert chunk["block_type"] == "text"
     assert chunk["op"] == "append"
     assert chunk["append"] is True

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -410,7 +410,7 @@ async def test_sse_on_complete_supports_block_type():
 
 
 @pytest.mark.asyncio
-async def test_sse_on_complete_rejects_artifact_updates_without_block_type():
+async def test_sse_on_complete_accepts_artifact_updates_without_block_type():
     completed: list[str] = []
 
     async def _on_complete(text: str):
@@ -437,7 +437,7 @@ async def test_sse_on_complete_rejects_artifact_updates_without_block_type():
     async for _ in response.body_iterator:
         pass
 
-    assert completed == [""]
+    assert completed == ["Hello generic"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/invoke/test_invoke_route_runner_streaming.py
+++ b/backend/tests/invoke/test_invoke_route_runner_streaming.py
@@ -511,6 +511,102 @@ async def test_persist_stream_block_update_rewrites_when_only_agent_message_id_i
 
 
 @pytest.mark.asyncio
+async def test_persist_stream_block_update_inferrs_canonical_artifact_text_without_private_block_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+    agent_message_id = str(uuid4())
+
+    class _DummySession:
+        async def scalar(self, *_args, **_kwargs):
+            return object()
+
+    class _DummySessionContext:
+        async def __aenter__(self) -> _DummySession:
+            return _DummySession()
+
+        async def __aexit__(self, _exc_type, _exc, _tb) -> None:
+            return None
+
+    async def fake_append_agent_message_block_updates(_db, **kwargs):
+        captured.update(kwargs)
+        return [object()]
+
+    async def fake_commit_safely(_db):
+        return None
+
+    async def fake_ensure_local_message_headers(**_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "AsyncSessionLocal",
+        lambda: _DummySessionContext(),
+    )
+    monkeypatch.setattr(
+        invoke_route_runner,
+        "_ensure_local_message_headers",
+        fake_ensure_local_message_headers,
+    )
+    monkeypatch.setattr(
+        invoke_route_runner.session_hub_service,
+        "append_agent_message_block_updates",
+        fake_append_agent_message_block_updates,
+    )
+    monkeypatch.setattr(invoke_route_runner, "commit_safely", fake_commit_safely)
+
+    state = invoke_route_runner._InvokeState(
+        local_session_id=uuid4(),
+        local_source="manual",
+        context_id=None,
+        metadata={},
+        stream_identity={},
+        stream_usage={},
+        user_message_id=str(uuid4()),
+        agent_message_id=agent_message_id,
+        message_refs=None,
+        next_event_seq=1,
+        persisted_block_count=0,
+    )
+
+    event_payload = {
+        "artifactUpdate": {
+            "taskId": "task-raw-1",
+            "append": True,
+            "lastChunk": True,
+            "artifact": {
+                "artifactId": "task-raw-1:stream:text",
+                "parts": [{"text": "Code"}],
+            },
+            "metadata": {
+                "shared": {
+                    "stream": {
+                        "eventId": "stream:4",
+                        "seq": 4,
+                    }
+                }
+            },
+        }
+    }
+
+    await invoke_route_runner._persist_stream_block_update(
+        state=state,
+        event_payload=event_payload,
+        request=_build_persistence_request(transport="ws"),
+    )
+
+    shared_stream = event_payload["artifactUpdate"]["metadata"]["shared"]["stream"]
+    assert shared_stream["messageId"] == agent_message_id
+    assert shared_stream["eventId"] == "stream:4"
+    assert shared_stream["seq"] == 1
+    updates = captured["updates"]
+    assert isinstance(updates, list)
+    assert len(updates) == 1
+    assert updates[0]["content"] == "Code"
+    assert updates[0]["append"] is True
+
+
+@pytest.mark.asyncio
 async def test_persist_stream_block_update_consumes_and_persists_optional_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docs/contracts/stream-block-operation-canonical-cases.json
+++ b/docs/contracts/stream-block-operation-canonical-cases.json
@@ -125,6 +125,46 @@
     }
   },
   {
+    "name": "artifact_update_inferrs_text_append_from_canonical_fields",
+    "payload": {
+      "artifactUpdate": {
+        "taskId": "task-raw-1",
+        "append": true,
+        "lastChunk": false,
+        "artifact": {
+          "artifactId": "task-raw-1:stream:text",
+          "parts": [
+            {
+              "text": "Code"
+            }
+          ]
+        },
+        "metadata": {
+          "shared": {
+            "stream": {
+              "eventId": "stream:4",
+              "seq": 4
+            }
+          }
+        }
+      }
+    },
+    "expected": {
+      "eventId": "stream:4",
+      "seq": 4,
+      "messageId": null,
+      "artifactId": "task-raw-1:stream:text",
+      "blockId": "task-raw-1:stream:text:primary_text",
+      "laneId": "primary_text",
+      "blockType": "text",
+      "op": "append",
+      "content": "Code",
+      "baseSeq": null,
+      "isFinished": false,
+      "source": null
+    }
+  },
+  {
     "name": "message_wrapper_inferrs_text_replace_without_artifact_update_compat",
     "payload": {
       "message": {

--- a/docs/contracts/stream-block-operation-canonical-cases.json
+++ b/docs/contracts/stream-block-operation-canonical-cases.json
@@ -152,9 +152,9 @@
     "expected": {
       "eventId": "stream:4",
       "seq": 4,
-      "messageId": null,
+      "messageId": "task:task-raw-1",
       "artifactId": "task-raw-1:stream:text",
-      "blockId": "task-raw-1:stream:text:primary_text",
+      "blockId": "task:task-raw-1:primary_text",
       "laneId": "primary_text",
       "blockType": "text",
       "op": "append",

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -630,6 +630,7 @@ describe("block-based stream parser and reducer", () => {
     blocks = applyStreamBlockUpdate(blocks, {
       eventId: "evt-tool-late-success",
       eventIdSource: "upstream",
+      messageIdSource: "upstream",
       seq: 3,
       taskId: "task-tools",
       artifactId: "task-tools:stream:tool-late-success",
@@ -1134,6 +1135,40 @@ describe("block-based stream parser and reducer", () => {
     ).artifact?.metadata?.shared?.stream?.messageId;
     const parsed = extractStreamBlockUpdate(payload);
     expect(parsed?.messageId).toBe("task:task-1");
+    expect(parsed?.messageIdSource).toBe("task_fallback");
+  });
+
+  it("accepts raw A2A artifact text chunks without custom block metadata", () => {
+    const payload = {
+      artifactUpdate: {
+        taskId: "task-raw-1",
+        contextId: "ctx-raw-1",
+        append: true,
+        lastChunk: false,
+        artifact: {
+          artifactId: "task-raw-1:stream:text",
+          parts: [{ text: "Code" }],
+        },
+        metadata: {
+          shared: {
+            stream: {
+              seq: 4,
+              eventId: "stream:4",
+            },
+          },
+        },
+      },
+    };
+
+    const parsed = extractStreamBlockUpdate(payload);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.blockType).toBe("text");
+    expect(parsed?.op).toBe("append");
+    expect(parsed?.delta).toBe("Code");
+    expect(parsed?.messageId).toBe("task:task-raw-1");
+    expect(parsed?.messageIdSource).toBe("task_fallback");
+    expect(parsed?.eventId).toBe("stream:4");
   });
 
   it("uses seq-based fallback when eventId is missing", () => {

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -81,6 +81,7 @@ export type ChatMessage = {
 export type StreamBlockUpdate = {
   eventId: string;
   eventIdSource: "upstream" | "fallback_seq" | "fallback_chunk";
+  messageIdSource: "upstream" | "task_fallback" | "artifact_fallback";
   seq: number | null;
   taskId: string;
   artifactId: string;
@@ -450,6 +451,7 @@ export const buildInterruptEventBlockUpdate = ({
   return {
     eventId,
     eventIdSource: "upstream",
+    messageIdSource: "upstream",
     seq: null,
     taskId: `interrupt:${normalizedMessageId}`,
     artifactId: `${normalizedMessageId}:interrupt:${interrupt.requestId}:${interrupt.phase}`,
@@ -729,7 +731,10 @@ export const extractStreamBlockUpdate = (
   const explicitBlockType = parseBlockType(rawBlockType);
   const blockType =
     explicitBlockType ??
-    ((kind === "message" || kind === "status-update") && rawBlockType === null
+    ((kind === "artifact-update" ||
+      kind === "message" ||
+      kind === "status-update") &&
+    rawBlockType === null
       ? dataFromParts
         ? "tool_call"
         : textFromParts
@@ -760,6 +765,12 @@ export const extractStreamBlockUpdate = (
     pickString(artifact ?? null, ["messageId"]) ??
     pickString(metadata, ["messageId"]) ??
     pickString(rootMetadata, ["messageId"]);
+  const messageIdSource: StreamBlockUpdate["messageIdSource"] =
+    upstreamMessageId !== null
+      ? "upstream"
+      : taskIdHint
+        ? "task_fallback"
+        : "artifact_fallback";
   const resolvedMessageId =
     upstreamMessageId ?? (taskIdHint ? `task:${taskIdHint}` : null);
   const resolvedArtifactId =
@@ -790,7 +801,13 @@ export const extractStreamBlockUpdate = (
     parseBlockOperation(pickString(body ?? null, ["op", "operation"]));
   const op =
     explicitOp ??
-    (kind === "message" || kind === "status-update" ? "replace" : null);
+    (kind === "message" || kind === "status-update"
+      ? "replace"
+      : kind === "artifact-update"
+        ? body?.append === true
+          ? "append"
+          : "replace"
+        : null);
   if (!op) {
     return null;
   }
@@ -867,6 +884,7 @@ export const extractStreamBlockUpdate = (
   return {
     eventId,
     eventIdSource,
+    messageIdSource,
     seq: seq ?? null,
     taskId,
     artifactId: resolvedArtifactId,

--- a/frontend/store/__tests__/chatRuntime.recovery.test.ts
+++ b/frontend/store/__tests__/chatRuntime.recovery.test.ts
@@ -71,6 +71,41 @@ const buildArtifactUpdate = ({
   },
 });
 
+const buildRawCompatArtifactUpdate = ({
+  taskId,
+  text,
+  eventId,
+  seq,
+  append = true,
+  lastChunk = false,
+}: {
+  taskId: string;
+  text: string;
+  eventId: string;
+  seq: number;
+  append?: boolean;
+  lastChunk?: boolean;
+}) => ({
+  artifactUpdate: {
+    taskId,
+    contextId: "ctx-1",
+    append,
+    lastChunk,
+    artifact: {
+      artifactId: `${taskId}:stream:text`,
+      parts: [{ text }],
+    },
+    metadata: {
+      shared: {
+        stream: {
+          eventId,
+          seq,
+        },
+      },
+    },
+  },
+});
+
 describe("executeChatRuntime empty-content recovery", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -207,6 +242,123 @@ describe("executeChatRuntime empty-content recovery", () => {
     );
     expect(agentMessage?.status).toBe("done");
     expect(agentMessage?.content).toBe("Recovered response");
+  });
+
+  it("renders raw A2A artifact text chunks without rekeying the placeholder message", async () => {
+    const conversationId = "conv-raw-artifact-1";
+    const agentId = "agent-raw-artifact-1";
+    const userMessageId = "user-raw-artifact-1";
+    const agentMessageId = "agent-raw-artifact-1";
+    const taskId = "task-raw-artifact-1";
+
+    addConversationMessage(conversationId, {
+      id: userMessageId,
+      role: "user",
+      content: "hello",
+      createdAt: "2026-03-12T05:10:00.000Z",
+      status: "done",
+    });
+    addConversationMessage(conversationId, {
+      id: agentMessageId,
+      role: "agent",
+      content: "",
+      blocks: [],
+      createdAt: "2026-03-12T05:10:01.000Z",
+      status: "streaming",
+    });
+
+    let state: ChatRuntimeState = {
+      sessions: {
+        [conversationId]: {
+          ...createAgentSession(agentId),
+          streamState: "streaming",
+          lastUserMessageId: userMessageId,
+          lastAgentMessageId: agentMessageId,
+        },
+      },
+    };
+
+    const get = () => state;
+    const set: ChatRuntimeSetState<ChatRuntimeState> = (partial) => {
+      const next =
+        typeof partial === "function"
+          ? partial(state as ChatRuntimeState)
+          : partial;
+      state = {
+        ...state,
+        ...(next as Partial<ChatRuntimeState>),
+      };
+    };
+
+    mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
+      async (params: {
+        callbacks: {
+          onData: (data: Record<string, unknown>) => boolean | void;
+        };
+      }) => {
+        params.callbacks.onData(
+          buildStatusUpdate({ state: "TASK_STATE_WORKING" }),
+        );
+        params.callbacks.onData(
+          buildRawCompatArtifactUpdate({
+            taskId,
+            text: "Code",
+            eventId: "stream:4",
+            seq: 4,
+          }),
+        );
+        params.callbacks.onData(
+          buildRawCompatArtifactUpdate({
+            taskId,
+            text: "，你",
+            eventId: "stream:5",
+            seq: 5,
+          }),
+        );
+        params.callbacks.onData(
+          buildStatusUpdate({
+            state: "TASK_STATE_COMPLETED",
+            completionPhase: "persisted",
+          }),
+        );
+        return true;
+      },
+    );
+
+    await executeChatRuntime(
+      conversationId,
+      agentId,
+      "personal",
+      {
+        query: "hello",
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      },
+      agentMessageId,
+      get,
+      set,
+    );
+
+    await flushPromises();
+
+    expect(mockedListSessionMessagesPage).not.toHaveBeenCalled();
+    expect(state.sessions[conversationId]?.lastAgentMessageId).toBe(
+      agentMessageId,
+    );
+    expect(state.sessions[conversationId]?.streamState).toBe("idle");
+
+    const messages = getConversationMessages(conversationId);
+    expect(messages.find((message) => message.id === `task:${taskId}`)).toBe(
+      undefined,
+    );
+
+    const agentMessage = messages.find(
+      (message) => message.id === agentMessageId,
+    );
+    expect(agentMessage?.status).toBe("done");
+    expect(agentMessage?.content).toBe("Code，你");
+    expect(agentMessage?.blocks?.map((block) => block.type)).toEqual(["text"]);
   });
 
   it("marks the stream recoverable when terminal status is not followed by a persisted completion ack", async () => {

--- a/frontend/store/chatRuntime.ts
+++ b/frontend/store/chatRuntime.ts
@@ -518,6 +518,11 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
         (message) => message.id === placeholderId,
       );
       if (hasActivePlaceholder) {
+        if (chunk.messageIdSource !== "upstream") {
+          streamMessageIdMap.set(chunk.messageId, placeholderId);
+          markActiveMessage(placeholderId);
+          return placeholderId;
+        }
         // Before rekeying, ensure we flush any pending chunks for the placeholder
         flushChunkBuffer();
         rekeyConversationMessage(


### PR DESCRIPTION
## 关联 Issues

Closes #884
Closes #887
Closes #890

Related #888
Related #889
Related #891

## 背景

本 PR 聚焦两类相互关联的问题：

1. 合法的原生 A2A `artifactUpdate` 文本/数据分片在前后端解析链路里被当作缺少私有 `blockType` / `op` 而丢弃，导致会话渲染为 `Content unavailable`，或在不同层出现共享 contract 不一致。
2. `GET /extensions/capabilities` 在上游 card 拉取超时时没有统一走扩展错误映射，导致 traceback 和 `500` 暴露到接口层。

## 变更说明

### 1. 前端按 A2A canonical 语义消费 artifact 流

- 允许 `artifactUpdate.artifact.parts[].text` 在缺少私有 `blockType` 时仍按 `text` 解析。
- 允许 `artifactUpdate.artifact.parts[].data` 在缺少私有 `blockType` 时按 `tool_call` 解析。
- 将 A2A `append: true|false` 映射为 `append` / `replace`。
- 当上游没有提供 `messageId` 时，保留当前占位消息，不再错误 rekey 到新的本地消息。

### 2. 后端补齐 canonical artifact stream block 推断

- 后端 stream payload 解析不再把私有 `blockType` / `op` 当作 `artifactUpdate` 的硬门槛。
- 共享 stream contract 中，对于无 upstream `messageId` 的 canonical artifact 更新，统一回退到 `task:<taskId>` 语义，保证前后端 contract 一致。
- 修正受新行为影响的陈旧测试断言与 contract fixture。

### 3. 扩展能力查询统一错误映射

- `GET /extensions/capabilities` 现在复用统一扩展错误响应逻辑。
- 当上游 card 拉取超时或失败时，接口返回受控结构化错误，而不是未处理异常 traceback。

## 审查结论

- 当前实现相较旧逻辑更符合 A2A 通用原则：不再把私有 `blockType` / `op` 作为合法 `artifactUpdate` 的消费前提。
- 本次审查里发现的两处真实问题，均已在本 PR 内补齐：
  - 前后端共享 `stream-block-operation` contract 对 artifact fallback `messageId` 语义不一致。
  - backend / frontend CI 中存在基于旧行为的陈旧测试断言。
- 仍存在一个非阻断的后续优化点：聊天页默认预探测扩展能力过于激进，已单独跟踪到 #891，不在本 PR 内处理。

## 验证

### Backend

- `cd backend && uv run --locked pre-commit run --files app/features/invoke/stream_payloads.py tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_a2a_invoke_service_streaming.py tests/invoke/test_stream_block_operation_contract.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_a2a_invoke_service_streaming.py tests/invoke/test_stream_block_operation_contract.py tests/invoke/test_a2a_invoke_service_contract_fallback.py tests/invoke/test_invoke_route_runner_streaming.py tests/agents/shared/test_hub_a2a_extension_capabilities_routes.py`

结果：`102 passed`

### Frontend

- `cd frontend && npm run lint`
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
- `cd frontend && npm test -- --findRelatedTests lib/api/chatStreamBlocks.ts store/chatRuntime.ts lib/__tests__/streamContract.test.ts store/__tests__/chatRuntime.recovery.test.ts lib/__tests__/streamBlockOperationContract.test.ts --maxWorkers=25%`

结果：`61 passed, 365 tests`

## 备注

- 推送 `505ae610 fix(invoke): align artifact fallback stream contract (#887)` 后，GitHub Actions 已重新触发，等待远端检查完成。
