### PR TITLE
fix(a2a): consume stream contracts through hub envelope (#892)

### DIFF
--- a/backend/app/features/invoke/hub_stream_contract.py
+++ b/backend/app/features/invoke/hub_stream_contract.py
@@ -1,0 +1,422 @@
+"""Stable backend-to-frontend stream contract for Hub clients."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from app.features.invoke.payload_analysis import analyze_payload
+from app.features.invoke.payload_helpers import dict_field as _dict_field
+from app.features.invoke.payload_helpers import (
+    pick_first_int,
+    pick_first_non_empty_str,
+)
+from app.features.invoke.stream_field_aliases import (
+    EVENT_ID_KEYS,
+    MESSAGE_ID_KEYS,
+    SEQ_KEYS,
+    TASK_ID_KEYS,
+)
+from app.features.invoke.stream_payloads import (
+    extract_interrupt_lifecycle_from_serialized_event,
+    extract_stream_chunk_from_serialized_event,
+    resolve_stream_content_envelope,
+)
+from app.integrations.a2a_runtime_status_contract import (
+    TERMINAL_STREAM_RUNTIME_STATES,
+    normalize_runtime_state,
+)
+from app.utils.payload_extract import extract_provider_and_external_session_id
+
+_HUB_STREAM_VERSION = "v1"
+_VALID_EVENT_KINDS = frozenset({"artifact-update", "message", "status-update", "task"})
+
+
+def _coerce_string_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    normalized = [
+        item.strip() for item in value if isinstance(item, str) and item.strip()
+    ]
+    return normalized or None
+
+
+def _infer_task_id_from_artifact_id(artifact_id: str | None) -> str | None:
+    if not isinstance(artifact_id, str):
+        return None
+    normalized = artifact_id.strip()
+    if not normalized:
+        return None
+    task_id, _, _ = normalized.partition(":")
+    task_id = task_id.strip()
+    return task_id or None
+
+
+def _infer_task_id_from_message_id(message_id: str | None) -> str | None:
+    if not isinstance(message_id, str):
+        return None
+    normalized = message_id.strip()
+    if not normalized.startswith("task:"):
+        return None
+    task_id = normalized[len("task:") :].strip()
+    return task_id or None
+
+
+def _build_fallback_event_id(
+    *,
+    message_id: str,
+    artifact_id: str,
+    seq: int | None,
+) -> str:
+    if seq is not None:
+        return f"seq:{message_id}:{seq}"
+    return f"chunk:{message_id}:{artifact_id}"
+
+
+def _build_interrupt_details(
+    interrupt_type: str,
+    details: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    resolved = dict(details or {})
+    display_message = resolved.get("display_message")
+    if interrupt_type == "permission":
+        return {
+            "permission": resolved.get("permission"),
+            "patterns": (
+                resolved.get("patterns")
+                if isinstance(resolved.get("patterns"), list)
+                else []
+            ),
+            "displayMessage": display_message,
+        }
+    if interrupt_type == "permissions":
+        permissions = resolved.get("permissions")
+        return {
+            "permissions": (
+                dict(permissions) if isinstance(permissions, Mapping) else None
+            ),
+            "displayMessage": display_message,
+        }
+    if interrupt_type == "elicitation":
+        meta = resolved.get("meta")
+        return {
+            "displayMessage": display_message,
+            "serverName": resolved.get("server_name"),
+            "mode": resolved.get("mode"),
+            "requestedSchema": resolved.get("requested_schema"),
+            "url": resolved.get("url"),
+            "elicitationId": resolved.get("elicitation_id"),
+            "meta": dict(meta) if isinstance(meta, Mapping) else None,
+        }
+    return {
+        "displayMessage": display_message,
+        "questions": (
+            resolved.get("questions")
+            if isinstance(resolved.get("questions"), list)
+            else []
+        ),
+    }
+
+
+def _build_runtime_interrupt(payload: dict[str, Any]) -> dict[str, Any] | None:
+    raw_interrupt = extract_interrupt_lifecycle_from_serialized_event(payload)
+    if not raw_interrupt:
+        return None
+
+    request_id = raw_interrupt.get("request_id")
+    interrupt_type = raw_interrupt.get("type")
+    phase = raw_interrupt.get("phase")
+    if not isinstance(request_id, str) or not isinstance(interrupt_type, str):
+        return None
+    if phase == "resolved":
+        resolution = raw_interrupt.get("resolution")
+        if not isinstance(resolution, str):
+            return None
+        return {
+            "requestId": request_id,
+            "type": interrupt_type,
+            "phase": "resolved",
+            "resolution": resolution,
+            "source": "stream",
+        }
+    if phase != "asked":
+        return None
+    details = raw_interrupt.get("details")
+    return {
+        "requestId": request_id,
+        "type": interrupt_type,
+        "phase": "asked",
+        "source": "stream",
+        "details": _build_interrupt_details(
+            interrupt_type,
+            details if isinstance(details, Mapping) else None,
+        ),
+    }
+
+
+def _build_runtime_status(payload: dict[str, Any]) -> dict[str, Any] | None:
+    envelope = resolve_stream_content_envelope(payload)
+    if envelope.event_kind != "status-update" or not envelope.status:
+        return None
+
+    raw_state = envelope.status.get("state")
+    if not isinstance(raw_state, str) or not raw_state.strip():
+        return None
+
+    state = normalize_runtime_state(raw_state)
+    if state is None:
+        return None
+
+    message_id = pick_first_non_empty_str(
+        (
+            envelope.shared_stream,
+            envelope.event_metadata,
+            envelope.status_message,
+            envelope.status,
+            envelope.event_body,
+        ),
+        MESSAGE_ID_KEYS,
+    )
+    seq = pick_first_int(
+        (
+            envelope.shared_stream,
+            envelope.event_metadata,
+            envelope.status_message,
+            envelope.status,
+            envelope.event_body,
+        ),
+        SEQ_KEYS,
+    )
+    raw_completion_phase = envelope.shared_stream.get("completionPhase")
+    completion_phase = (
+        "persisted"
+        if isinstance(raw_completion_phase, str)
+        and raw_completion_phase.strip().lower() == "persisted"
+        else None
+    )
+    result = {
+        "state": state,
+        "isFinal": state in TERMINAL_STREAM_RUNTIME_STATES,
+        "interrupt": _build_runtime_interrupt(payload),
+        "seq": seq,
+        "completionPhase": completion_phase,
+        "messageId": message_id,
+    }
+    return result
+
+
+def _normalize_role(value: Any) -> str:
+    if not isinstance(value, str):
+        return "agent"
+    normalized = value.strip().lower()
+    if normalized.startswith("role_"):
+        normalized = normalized[len("role_") :]
+    if normalized in {"user", "agent", "system"}:
+        return normalized
+    return "agent"
+
+
+def _build_stream_block(
+    payload: dict[str, Any],
+    *,
+    upstream_shared_stream: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    stream_chunk = extract_stream_chunk_from_serialized_event(payload)
+    if not stream_chunk:
+        return None
+
+    envelope = resolve_stream_content_envelope(payload)
+    body = envelope.event_body
+    artifact = envelope.artifact
+    artifact_metadata = envelope.artifact_metadata
+    event_metadata = envelope.event_metadata
+    shared_stream = envelope.shared_stream
+    source_shared_stream = (
+        dict(upstream_shared_stream)
+        if isinstance(upstream_shared_stream, Mapping)
+        else shared_stream
+    )
+
+    block_type = stream_chunk.get("block_type")
+    content = stream_chunk.get("content")
+    operation = stream_chunk.get("op")
+    if (
+        not isinstance(block_type, str)
+        or not isinstance(content, str)
+        or not isinstance(operation, str)
+    ):
+        return None
+
+    seq = stream_chunk.get("seq")
+    resolved_seq = seq if isinstance(seq, int) else None
+
+    artifact_id = stream_chunk.get("artifact_id")
+    resolved_artifact_id = artifact_id if isinstance(artifact_id, str) else None
+    task_id_hint = pick_first_non_empty_str(
+        (body, artifact, event_metadata, source_shared_stream),
+        TASK_ID_KEYS,
+    ) or _infer_task_id_from_artifact_id(resolved_artifact_id)
+
+    upstream_message_id = pick_first_non_empty_str(
+        (
+            source_shared_stream,
+            body,
+            artifact,
+            artifact_metadata,
+            event_metadata,
+        ),
+        MESSAGE_ID_KEYS,
+    )
+    message_id_source = (
+        "upstream"
+        if upstream_message_id is not None
+        else "task_fallback" if task_id_hint else "artifact_fallback"
+    )
+    resolved_message_id = upstream_message_id or (
+        f"task:{task_id_hint}" if task_id_hint else None
+    )
+    if resolved_artifact_id is None:
+        resolved_artifact_id = f"{resolved_message_id or 'stream'}:{block_type}"
+    task_id = (
+        task_id_hint
+        or _infer_task_id_from_artifact_id(resolved_artifact_id)
+        or _infer_task_id_from_message_id(resolved_message_id)
+        or resolved_message_id
+        or resolved_artifact_id
+    )
+    message_id = resolved_message_id or f"artifact:{resolved_artifact_id}"
+
+    upstream_event_id = pick_first_non_empty_str(
+        (
+            source_shared_stream,
+            body,
+            artifact,
+            artifact_metadata,
+            event_metadata,
+        ),
+        EVENT_ID_KEYS,
+    )
+    event_id = upstream_event_id or _build_fallback_event_id(
+        message_id=message_id,
+        artifact_id=resolved_artifact_id,
+        seq=resolved_seq,
+    )
+    event_id_source = (
+        "upstream"
+        if upstream_event_id
+        else "fallback_seq" if resolved_seq is not None else "fallback_chunk"
+    )
+
+    lane_id = stream_chunk.get("lane_id")
+    block_id = stream_chunk.get("block_id")
+    source = stream_chunk.get("source")
+    base_seq = stream_chunk.get("base_seq")
+
+    payload_result: dict[str, Any] = {
+        "eventId": event_id,
+        "eventIdSource": event_id_source,
+        "messageIdSource": message_id_source,
+        "seq": resolved_seq,
+        "taskId": task_id,
+        "artifactId": resolved_artifact_id,
+        "blockId": (
+            block_id if isinstance(block_id, str) else f"{message_id}:{block_type}"
+        ),
+        "laneId": lane_id if isinstance(lane_id, str) else block_type,
+        "blockType": block_type,
+        "op": operation,
+        "baseSeq": base_seq if isinstance(base_seq, int) else None,
+        "source": source if isinstance(source, str) else None,
+        "messageId": message_id,
+        "role": _normalize_role(
+            pick_first_non_empty_str(
+                (
+                    body,
+                    artifact,
+                    source_shared_stream,
+                    artifact_metadata,
+                    event_metadata,
+                ),
+                ("role",),
+            )
+        ),
+        "delta": content,
+        "append": bool(stream_chunk.get("append")),
+        "done": bool(stream_chunk.get("is_finished")),
+    }
+    tool_call = stream_chunk.get("tool_call")
+    if isinstance(tool_call, Mapping):
+        payload_result["toolCall"] = dict(tool_call)
+    return payload_result
+
+
+def _build_session_meta(payload: dict[str, Any]) -> dict[str, Any] | None:
+    envelope = resolve_stream_content_envelope(payload)
+    body = envelope.event_body
+    if not body:
+        return None
+
+    properties = _dict_field(body, "properties")
+    analysis = analyze_payload(payload)
+    provider, external_session_id = extract_provider_and_external_session_id(
+        {"metadata": analysis.binding_metadata or {}}
+    )
+
+    stream_thread_id = pick_first_non_empty_str(
+        (properties, envelope.shared_stream, body),
+        ("threadId",),
+    )
+    stream_turn_id = pick_first_non_empty_str(
+        (properties, envelope.shared_stream, body),
+        ("turnId",),
+    )
+
+    transport = body.get("transport")
+    input_modes = _coerce_string_list(body.get("inputModes")) or _coerce_string_list(
+        payload.get("inputModes")
+    )
+    output_modes = _coerce_string_list(body.get("outputModes")) or _coerce_string_list(
+        payload.get("outputModes")
+    )
+
+    session_meta = {
+        "provider": provider,
+        "externalSessionId": external_session_id,
+        "streamThreadId": stream_thread_id,
+        "streamTurnId": stream_turn_id,
+        "transport": transport if isinstance(transport, str) else None,
+        "inputModes": input_modes,
+        "outputModes": output_modes,
+    }
+    if any(value is not None for value in session_meta.values()):
+        return session_meta
+    return None
+
+
+def attach_hub_stream_contract(
+    payload: dict[str, Any],
+    *,
+    upstream_shared_stream: Mapping[str, Any] | None = None,
+) -> None:
+    envelope = resolve_stream_content_envelope(payload)
+    kind = envelope.event_kind
+    if kind not in _VALID_EVENT_KINDS:
+        return
+
+    hub_payload: dict[str, Any] = {
+        "version": _HUB_STREAM_VERSION,
+        "eventKind": kind,
+    }
+    stream_block = _build_stream_block(
+        payload,
+        upstream_shared_stream=upstream_shared_stream,
+    )
+    if stream_block is not None:
+        hub_payload["streamBlock"] = stream_block
+    runtime_status = _build_runtime_status(payload)
+    if runtime_status is not None:
+        hub_payload["runtimeStatus"] = runtime_status
+    session_meta = _build_session_meta(payload)
+    if session_meta is not None:
+        hub_payload["sessionMeta"] = session_meta
+    payload["hub"] = hub_payload

--- a/backend/app/features/invoke/hub_stream_contract.py
+++ b/backend/app/features/invoke/hub_stream_contract.py
@@ -19,7 +19,7 @@ from app.features.invoke.stream_field_aliases import (
 )
 from app.features.invoke.stream_payloads import (
     extract_interrupt_lifecycle_from_serialized_event,
-    extract_stream_chunk_from_serialized_event,
+    extract_raw_stream_chunk_from_serialized_event,
     resolve_stream_content_envelope,
 )
 from app.integrations.a2a_runtime_status_contract import (
@@ -227,7 +227,7 @@ def _build_stream_block(
     upstream_shared_stream: Mapping[str, Any] | None = None,
     local_event_sequence: int,
 ) -> dict[str, Any] | None:
-    stream_chunk = extract_stream_chunk_from_serialized_event(payload)
+    stream_chunk = extract_raw_stream_chunk_from_serialized_event(payload)
     if not stream_chunk:
         return None
 

--- a/backend/app/features/invoke/hub_stream_contract.py
+++ b/backend/app/features/invoke/hub_stream_contract.py
@@ -225,6 +225,7 @@ def _build_stream_block(
     payload: dict[str, Any],
     *,
     upstream_shared_stream: Mapping[str, Any] | None = None,
+    local_stream_context: Mapping[str, Any] | None = None,
     local_event_sequence: int,
 ) -> dict[str, Any] | None:
     stream_chunk = extract_raw_stream_chunk_from_serialized_event(payload)
@@ -237,6 +238,9 @@ def _build_stream_block(
     artifact_metadata = envelope.artifact_metadata
     event_metadata = envelope.event_metadata
     shared_stream = envelope.shared_stream
+    local_context_candidates = (
+        (local_stream_context,) if isinstance(local_stream_context, Mapping) else ()
+    )
     source_shared_stream = (
         dict(upstream_shared_stream)
         if isinstance(upstream_shared_stream, Mapping)
@@ -255,6 +259,9 @@ def _build_stream_block(
 
     seq = stream_chunk.get("seq")
     resolved_seq = seq if isinstance(seq, int) else local_event_sequence
+    local_seq = pick_first_int(local_context_candidates, ("seq",))
+    if isinstance(local_seq, int):
+        resolved_seq = local_seq
 
     artifact_id = stream_chunk.get("artifact_id")
     resolved_artifact_id = artifact_id if isinstance(artifact_id, str) else None
@@ -263,6 +270,9 @@ def _build_stream_block(
         TASK_ID_KEYS,
     ) or _infer_task_id_from_artifact_id(resolved_artifact_id)
 
+    local_message_id = pick_first_non_empty_str(
+        local_context_candidates, ("message_id",)
+    )
     upstream_message_id = pick_first_non_empty_str(
         (
             source_shared_stream,
@@ -274,12 +284,18 @@ def _build_stream_block(
         MESSAGE_ID_KEYS,
     )
     message_id_source = (
-        "upstream"
-        if upstream_message_id is not None
-        else "task_fallback" if task_id_hint else "artifact_fallback"
+        "local_persistence"
+        if local_message_id is not None
+        else (
+            "upstream"
+            if upstream_message_id is not None
+            else "task_fallback" if task_id_hint else "artifact_fallback"
+        )
     )
-    resolved_message_id = upstream_message_id or (
-        f"task:{task_id_hint}" if task_id_hint else None
+    resolved_message_id = (
+        local_message_id
+        or upstream_message_id
+        or (f"task:{task_id_hint}" if task_id_hint else None)
     )
     if resolved_artifact_id is None:
         resolved_artifact_id = f"{resolved_message_id or 'stream'}:{block_type}"
@@ -292,6 +308,7 @@ def _build_stream_block(
     )
     message_id = resolved_message_id or f"artifact:{resolved_artifact_id}"
 
+    local_event_id = pick_first_non_empty_str(local_context_candidates, ("event_id",))
     upstream_event_id = pick_first_non_empty_str(
         (
             source_shared_stream,
@@ -302,21 +319,41 @@ def _build_stream_block(
         ),
         EVENT_ID_KEYS,
     )
-    event_id = upstream_event_id or _build_fallback_event_id(
-        message_id=message_id,
-        artifact_id=resolved_artifact_id,
-        seq=resolved_seq,
+    event_id = (
+        local_event_id
+        or upstream_event_id
+        or _build_fallback_event_id(
+            message_id=message_id,
+            artifact_id=resolved_artifact_id,
+            seq=resolved_seq,
+        )
     )
     event_id_source = (
-        "upstream"
-        if upstream_event_id
-        else "fallback_seq" if resolved_seq is not None else "fallback_chunk"
+        "local_persistence"
+        if local_event_id
+        else (
+            "upstream"
+            if upstream_event_id
+            else "fallback_seq" if resolved_seq is not None else "fallback_chunk"
+        )
     )
 
     lane_id = stream_chunk.get("lane_id")
     block_id = stream_chunk.get("block_id")
     source = stream_chunk.get("source")
     base_seq = stream_chunk.get("base_seq")
+    local_block_id = pick_first_non_empty_str(local_context_candidates, ("block_id",))
+    local_lane_id = pick_first_non_empty_str(local_context_candidates, ("lane_id",))
+    local_operation = pick_first_non_empty_str(local_context_candidates, ("op",))
+    local_base_seq = pick_first_int(local_context_candidates, ("base_seq",))
+    if local_block_id is not None:
+        block_id = local_block_id
+    if local_lane_id is not None:
+        lane_id = local_lane_id
+    if local_operation is not None:
+        operation = local_operation
+    if isinstance(local_base_seq, int):
+        base_seq = local_base_seq
 
     payload_result: dict[str, Any] = {
         "eventId": event_id,
@@ -403,6 +440,7 @@ def attach_hub_stream_contract(
     payload: dict[str, Any],
     *,
     upstream_shared_stream: Mapping[str, Any] | None = None,
+    local_stream_context: Mapping[str, Any] | None = None,
     local_event_sequence: int,
 ) -> None:
     envelope = resolve_stream_content_envelope(payload)
@@ -417,6 +455,7 @@ def attach_hub_stream_contract(
     stream_block = _build_stream_block(
         payload,
         upstream_shared_stream=upstream_shared_stream,
+        local_stream_context=local_stream_context,
         local_event_sequence=local_event_sequence,
     )
     if stream_block is not None:

--- a/backend/app/features/invoke/hub_stream_contract.py
+++ b/backend/app/features/invoke/hub_stream_contract.py
@@ -154,7 +154,11 @@ def _build_runtime_interrupt(payload: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
-def _build_runtime_status(payload: dict[str, Any]) -> dict[str, Any] | None:
+def _build_runtime_status(
+    payload: dict[str, Any],
+    *,
+    local_event_sequence: int,
+) -> dict[str, Any] | None:
     envelope = resolve_stream_content_envelope(payload)
     if envelope.event_kind != "status-update" or not envelope.status:
         return None
@@ -187,6 +191,7 @@ def _build_runtime_status(payload: dict[str, Any]) -> dict[str, Any] | None:
         ),
         SEQ_KEYS,
     )
+    resolved_seq = seq if isinstance(seq, int) else local_event_sequence
     raw_completion_phase = envelope.shared_stream.get("completionPhase")
     completion_phase = (
         "persisted"
@@ -198,7 +203,7 @@ def _build_runtime_status(payload: dict[str, Any]) -> dict[str, Any] | None:
         "state": state,
         "isFinal": state in TERMINAL_STREAM_RUNTIME_STATES,
         "interrupt": _build_runtime_interrupt(payload),
-        "seq": seq,
+        "seq": resolved_seq,
         "completionPhase": completion_phase,
         "messageId": message_id,
     }
@@ -220,6 +225,7 @@ def _build_stream_block(
     payload: dict[str, Any],
     *,
     upstream_shared_stream: Mapping[str, Any] | None = None,
+    local_event_sequence: int,
 ) -> dict[str, Any] | None:
     stream_chunk = extract_stream_chunk_from_serialized_event(payload)
     if not stream_chunk:
@@ -248,7 +254,7 @@ def _build_stream_block(
         return None
 
     seq = stream_chunk.get("seq")
-    resolved_seq = seq if isinstance(seq, int) else None
+    resolved_seq = seq if isinstance(seq, int) else local_event_sequence
 
     artifact_id = stream_chunk.get("artifact_id")
     resolved_artifact_id = artifact_id if isinstance(artifact_id, str) else None
@@ -397,6 +403,7 @@ def attach_hub_stream_contract(
     payload: dict[str, Any],
     *,
     upstream_shared_stream: Mapping[str, Any] | None = None,
+    local_event_sequence: int,
 ) -> None:
     envelope = resolve_stream_content_envelope(payload)
     kind = envelope.event_kind
@@ -410,10 +417,14 @@ def attach_hub_stream_contract(
     stream_block = _build_stream_block(
         payload,
         upstream_shared_stream=upstream_shared_stream,
+        local_event_sequence=local_event_sequence,
     )
     if stream_block is not None:
         hub_payload["streamBlock"] = stream_block
-    runtime_status = _build_runtime_status(payload)
+    runtime_status = _build_runtime_status(
+        payload,
+        local_event_sequence=local_event_sequence,
+    )
     if runtime_status is not None:
         hub_payload["runtimeStatus"] = runtime_status
     session_meta = _build_session_meta(payload)

--- a/backend/app/features/invoke/hub_stream_local_context.py
+++ b/backend/app/features/invoke/hub_stream_local_context.py
@@ -1,0 +1,43 @@
+"""Internal local stream identity overlay for Hub stream normalization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_LOCAL_STREAM_CONTEXT_KEY = "__hub_local_stream"
+
+
+def attach_local_stream_context(
+    payload: dict[str, Any],
+    *,
+    local_message_id: str,
+    event_id: str,
+    seq: int | None,
+    stream_block: dict[str, Any] | None = None,
+) -> None:
+    context: dict[str, Any] = {
+        "message_id": local_message_id,
+        "event_id": event_id,
+        "seq": seq if isinstance(seq, int) and seq > 0 else None,
+    }
+    if isinstance(stream_block, Mapping):
+        for source_name in ("block_id", "lane_id", "op", "base_seq"):
+            value = stream_block.get(source_name)
+            if value is not None:
+                context[source_name] = value
+    payload[_LOCAL_STREAM_CONTEXT_KEY] = context
+
+
+def consume_local_stream_context(payload: dict[str, Any]) -> dict[str, Any] | None:
+    candidate = payload.pop(_LOCAL_STREAM_CONTEXT_KEY, None)
+    if not isinstance(candidate, Mapping):
+        return None
+    resolved = dict(candidate)
+    message_id = resolved.get("message_id")
+    event_id = resolved.get("event_id")
+    if not isinstance(message_id, str) or not message_id.strip():
+        return None
+    if not isinstance(event_id, str) or not event_id.strip():
+        return None
+    return resolved

--- a/backend/app/features/invoke/payload_analysis.py
+++ b/backend/app/features/invoke/payload_analysis.py
@@ -25,6 +25,11 @@ from app.utils.payload_extract import (
 
 logger = logging.getLogger(__name__)
 
+_MESSAGE_ID_KEYS = ("messageId", "message_id")
+_EVENT_ID_KEYS = ("eventId", "event_id")
+_SEQ_KEYS = ("seq", "sequence")
+_TASK_ID_KEYS = ("taskId", "task_id", "id")
+
 
 @dataclass(frozen=True)
 class PayloadAnalysis:
@@ -145,8 +150,8 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
         root_metadata,
         stream_body,
     )
-    msg_id = pick_first_non_empty_str(identity_candidates, ("messageId",))
-    evt_id = pick_first_non_empty_str(identity_candidates, ("eventId",))
+    msg_id = pick_first_non_empty_str(identity_candidates, _MESSAGE_ID_KEYS)
+    evt_id = pick_first_non_empty_str(identity_candidates, _EVENT_ID_KEYS)
 
     task_id = pick_first_non_empty_str(
         (
@@ -156,7 +161,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
             _dict_field(status, "task"),
             _dict_field(result, "task"),
         ),
-        ("taskId", "id"),
+        _TASK_ID_KEYS,
     )
 
     seq = pick_first_int(
@@ -167,7 +172,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
             root_metadata,
             artifact_shared_stream,
         ),
-        ("seq",),
+        _SEQ_KEYS,
     )
 
     usage: dict[str, Any] = {}

--- a/backend/app/features/invoke/payload_analysis.py
+++ b/backend/app/features/invoke/payload_analysis.py
@@ -15,6 +15,12 @@ from app.features.invoke.shared_metadata import (
     extract_preferred_usage_metadata,
     merge_preferred_session_binding_metadata,
 )
+from app.features.invoke.stream_field_aliases import (
+    EVENT_ID_KEYS,
+    MESSAGE_ID_KEYS,
+    SEQ_KEYS,
+    TASK_ID_KEYS,
+)
 from app.integrations.a2a_client.protobuf import (
     to_protojson_object,
 )
@@ -25,10 +31,7 @@ from app.utils.payload_extract import (
 
 logger = logging.getLogger(__name__)
 
-_MESSAGE_ID_KEYS = ("messageId", "message_id")
-_EVENT_ID_KEYS = ("eventId", "event_id")
-_SEQ_KEYS = ("seq", "sequence")
-_TASK_ID_KEYS = ("taskId", "task_id", "id")
+_TASK_ANALYSIS_KEYS = (*TASK_ID_KEYS, "id")
 
 
 @dataclass(frozen=True)
@@ -150,8 +153,8 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
         root_metadata,
         stream_body,
     )
-    msg_id = pick_first_non_empty_str(identity_candidates, _MESSAGE_ID_KEYS)
-    evt_id = pick_first_non_empty_str(identity_candidates, _EVENT_ID_KEYS)
+    msg_id = pick_first_non_empty_str(identity_candidates, MESSAGE_ID_KEYS)
+    evt_id = pick_first_non_empty_str(identity_candidates, EVENT_ID_KEYS)
 
     task_id = pick_first_non_empty_str(
         (
@@ -161,7 +164,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
             _dict_field(status, "task"),
             _dict_field(result, "task"),
         ),
-        _TASK_ID_KEYS,
+        _TASK_ANALYSIS_KEYS,
     )
 
     seq = pick_first_int(
@@ -172,7 +175,7 @@ def analyze_payload(payload: dict[str, Any]) -> PayloadAnalysis:
             root_metadata,
             artifact_shared_stream,
         ),
-        _SEQ_KEYS,
+        SEQ_KEYS,
     )
 
     usage: dict[str, Any] = {}

--- a/backend/app/features/invoke/route_runner.py
+++ b/backend/app/features/invoke/route_runner.py
@@ -57,9 +57,6 @@ from app.features.invoke.stream_persistence import (
     InvokePersistenceRequest,
 )
 from app.features.invoke.stream_persistence import (
-    ensure_local_message_headers as ensure_local_message_headers_impl,
-)
-from app.features.invoke.stream_persistence import (
     flush_stream_buffer as flush_stream_buffer_impl,
 )
 from app.features.invoke.stream_persistence import (
@@ -73,9 +70,6 @@ from app.features.invoke.stream_persistence import (
 )
 from app.features.invoke.stream_persistence import (
     persist_stream_block_update as persist_stream_block_update_impl,
-)
-from app.features.invoke.stream_persistence import (
-    persist_synthetic_final_block_if_needed as persist_synthetic_final_block_if_needed_impl,
 )
 from app.features.sessions.common import serialize_interrupt_event_block_content
 from app.features.sessions.service import session_hub_service
@@ -271,20 +265,6 @@ def _build_invoke_metadata_error_response(
     )
 
 
-async def _ensure_local_message_headers(
-    *,
-    state: InvokeState,
-    request: InvokePersistenceRequest,
-) -> None:
-    await ensure_local_message_headers_impl(
-        state=state,
-        request=request,
-        session_factory=AsyncSessionLocal,
-        commit_fn=commit_safely,
-        session_hub=session_hub_service,
-    )
-
-
 async def _flush_stream_buffer(
     *,
     state: InvokeState,
@@ -305,18 +285,6 @@ async def _persist_stream_block_update(
     event_payload: dict[str, Any],
     request: InvokePersistenceRequest,
 ) -> None:
-    async def _ensure_headers_adapter(**kwargs: Any) -> None:
-        await _ensure_local_message_headers(
-            state=kwargs["state"],
-            request=kwargs["request"],
-        )
-
-    async def _flush_buffer_adapter(**kwargs: Any) -> None:
-        await _flush_stream_buffer(
-            state=kwargs["state"],
-            user_id=kwargs["user_id"],
-        )
-
     await persist_stream_block_update_impl(
         state=state,
         event_payload=event_payload,
@@ -324,8 +292,6 @@ async def _persist_stream_block_update(
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,
-        ensure_headers_fn=_ensure_headers_adapter,
-        flush_buffer_fn=_flush_buffer_adapter,
     )
 
 
@@ -335,41 +301,11 @@ async def _persist_interrupt_lifecycle_event(
     event_payload: dict[str, Any],
     request: InvokePersistenceRequest,
 ) -> None:
-    async def _ensure_headers_adapter(**kwargs: Any) -> None:
-        await _ensure_local_message_headers(
-            state=kwargs["state"],
-            request=kwargs["request"],
-        )
-
-    async def _flush_buffer_adapter(**kwargs: Any) -> None:
-        await _flush_stream_buffer(
-            state=kwargs["state"],
-            user_id=kwargs["user_id"],
-        )
-
     await persist_interrupt_lifecycle_event_impl(
         state=state,
         event_payload=event_payload,
         request=request,
         build_interrupt_message_content=serialize_interrupt_event_block_content,
-        session_factory=AsyncSessionLocal,
-        commit_fn=commit_safely,
-        session_hub=session_hub_service,
-        ensure_headers_fn=_ensure_headers_adapter,
-        flush_buffer_fn=_flush_buffer_adapter,
-    )
-
-
-async def _persist_synthetic_final_block_if_needed(
-    *,
-    state: InvokeState,
-    outcome: StreamOutcome,
-    user_id: UUID,
-) -> None:
-    await persist_synthetic_final_block_if_needed_impl(
-        state=state,
-        outcome=outcome,
-        user_id=user_id,
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,
@@ -383,19 +319,6 @@ async def _persist_local_outcome(
     request: InvokePersistenceRequest,
     response_metadata: dict[str, Any] | None = None,
 ) -> None:
-    async def _ensure_headers_adapter(**kwargs: Any) -> None:
-        await _ensure_local_message_headers(
-            state=kwargs["state"],
-            request=kwargs["request"],
-        )
-
-    async def _persist_final_block_adapter(**kwargs: Any) -> None:
-        await _persist_synthetic_final_block_if_needed(
-            state=kwargs["state"],
-            outcome=kwargs["outcome"],
-            user_id=kwargs["user_id"],
-        )
-
     await persist_local_outcome_impl(
         state=state,
         outcome=outcome,
@@ -404,8 +327,6 @@ async def _persist_local_outcome(
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,
-        ensure_headers_fn=_ensure_headers_adapter,
-        persist_final_block_fn=_persist_final_block_adapter,
     )
 
 

--- a/backend/app/features/invoke/route_runner_streaming.py
+++ b/backend/app/features/invoke/route_runner_streaming.py
@@ -33,9 +33,6 @@ from app.features.invoke.stream_persistence import (
     coerce_uuid,
 )
 from app.features.invoke.stream_persistence import (
-    ensure_local_message_headers as ensure_local_message_headers_impl,
-)
-from app.features.invoke.stream_persistence import (
     flush_stream_buffer as flush_stream_buffer_impl,
 )
 from app.features.invoke.stream_persistence import (
@@ -46,9 +43,6 @@ from app.features.invoke.stream_persistence import (
 )
 from app.features.invoke.stream_persistence import (
     persist_stream_block_update as persist_stream_block_update_impl,
-)
-from app.features.invoke.stream_persistence import (
-    persist_synthetic_final_block_if_needed as persist_synthetic_final_block_if_needed_impl,
 )
 from app.features.sessions.common import serialize_interrupt_event_block_content
 from app.features.sessions.service import session_hub_service
@@ -408,20 +402,6 @@ def build_persisted_finalization_ack_event(
     }
 
 
-async def ensure_local_message_headers(
-    *,
-    state: InvokeState,
-    request: InvokePersistenceRequest,
-) -> None:
-    await ensure_local_message_headers_impl(
-        state=state,
-        request=request,
-        session_factory=AsyncSessionLocal,
-        commit_fn=commit_safely,
-        session_hub=session_hub_service,
-    )
-
-
 async def flush_stream_buffer(
     *,
     state: InvokeState,
@@ -442,18 +422,6 @@ async def persist_stream_block_update(
     event_payload: dict[str, Any],
     request: InvokePersistenceRequest,
 ) -> None:
-    async def _ensure_headers_adapter(**kwargs: Any) -> None:
-        await ensure_local_message_headers(
-            state=kwargs["state"],
-            request=kwargs["request"],
-        )
-
-    async def _flush_buffer_adapter(**kwargs: Any) -> None:
-        await flush_stream_buffer(
-            state=kwargs["state"],
-            user_id=kwargs["user_id"],
-        )
-
     await persist_stream_block_update_impl(
         state=state,
         event_payload=event_payload,
@@ -461,8 +429,6 @@ async def persist_stream_block_update(
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,
-        ensure_headers_fn=_ensure_headers_adapter,
-        flush_buffer_fn=_flush_buffer_adapter,
     )
 
 
@@ -472,41 +438,11 @@ async def persist_interrupt_lifecycle_event(
     event_payload: dict[str, Any],
     request: InvokePersistenceRequest,
 ) -> None:
-    async def _ensure_headers_adapter(**kwargs: Any) -> None:
-        await ensure_local_message_headers(
-            state=kwargs["state"],
-            request=kwargs["request"],
-        )
-
-    async def _flush_buffer_adapter(**kwargs: Any) -> None:
-        await flush_stream_buffer(
-            state=kwargs["state"],
-            user_id=kwargs["user_id"],
-        )
-
     await persist_interrupt_lifecycle_event_impl(
         state=state,
         event_payload=event_payload,
         request=request,
         build_interrupt_message_content=serialize_interrupt_event_block_content,
-        session_factory=AsyncSessionLocal,
-        commit_fn=commit_safely,
-        session_hub=session_hub_service,
-        ensure_headers_fn=_ensure_headers_adapter,
-        flush_buffer_fn=_flush_buffer_adapter,
-    )
-
-
-async def persist_synthetic_final_block_if_needed(
-    *,
-    state: InvokeState,
-    outcome: StreamOutcome,
-    user_id: UUID,
-) -> None:
-    await persist_synthetic_final_block_if_needed_impl(
-        state=state,
-        outcome=outcome,
-        user_id=user_id,
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,
@@ -520,19 +456,6 @@ async def persist_local_outcome(
     request: InvokePersistenceRequest,
     response_metadata: dict[str, Any] | None = None,
 ) -> None:
-    async def _ensure_headers_adapter(**kwargs: Any) -> None:
-        await ensure_local_message_headers(
-            state=kwargs["state"],
-            request=kwargs["request"],
-        )
-
-    async def _persist_final_block_adapter(**kwargs: Any) -> None:
-        await persist_synthetic_final_block_if_needed(
-            state=kwargs["state"],
-            outcome=kwargs["outcome"],
-            user_id=kwargs["user_id"],
-        )
-
     await persist_local_outcome_impl(
         state=state,
         outcome=outcome,
@@ -541,8 +464,6 @@ async def persist_local_outcome(
         session_factory=AsyncSessionLocal,
         commit_fn=commit_safely,
         session_hub=session_hub_service,
-        ensure_headers_fn=_ensure_headers_adapter,
-        persist_final_block_fn=_persist_final_block_adapter,
     )
 
 

--- a/backend/app/features/invoke/service_streaming.py
+++ b/backend/app/features/invoke/service_streaming.py
@@ -19,6 +19,7 @@ from app.features.invoke import (
     service_streaming_transport,
     stream_payloads,
 )
+from app.features.invoke.hub_stream_local_context import consume_local_stream_context
 from app.features.invoke.service_types import (
     StreamErrorMetadataCallbackFn,
     StreamErrorPayload,
@@ -443,10 +444,12 @@ class A2AInvokeStreamingRuntime:
         if not body:
             return
         upstream_shared_stream = dict(content_envelope.shared_stream)
+        local_stream_context = consume_local_stream_context(payload)
 
         hub_stream_contract.attach_hub_stream_contract(
             payload,
             upstream_shared_stream=upstream_shared_stream,
+            local_stream_context=local_stream_context,
             local_event_sequence=event_sequence,
         )
 

--- a/backend/app/features/invoke/service_streaming.py
+++ b/backend/app/features/invoke/service_streaming.py
@@ -19,10 +19,6 @@ from app.features.invoke import (
     service_streaming_transport,
     stream_payloads,
 )
-from app.features.invoke.payload_helpers import (
-    pick_first_non_empty_str,
-    pick_non_empty_str,
-)
 from app.features.invoke.service_types import (
     StreamErrorMetadataCallbackFn,
     StreamErrorPayload,
@@ -34,11 +30,6 @@ from app.features.invoke.service_types import (
     StreamSessionStartedCallbackFn,
     StreamTextCallbackFn,
     ValidateMessageFn,
-)
-from app.features.invoke.stream_field_aliases import (
-    BLOCK_TYPE_KEYS,
-    EVENT_ID_KEYS,
-    MESSAGE_ID_KEYS,
 )
 from app.integrations.a2a_client.errors import A2APeerProtocolError
 from app.integrations.a2a_client.invoke_session import AgentResolutionPolicy
@@ -451,86 +442,12 @@ class A2AInvokeStreamingRuntime:
         body = content_envelope.event_body
         if not body:
             return
-
-        metadata = body.get("metadata")
-        if not isinstance(metadata, dict):
-            metadata = {}
-            body["metadata"] = metadata
-
-        shared = metadata.get("shared")
-        if not isinstance(shared, dict):
-            shared = {}
-            metadata["shared"] = shared
-
-        shared_stream = shared.get("stream")
-        if not isinstance(shared_stream, dict):
-            shared_stream = {}
-            shared["stream"] = shared_stream
-        upstream_shared_stream = dict(shared_stream)
-
-        shared_stream["seq"] = event_sequence
-
-        artifact = content_envelope.artifact
-        artifact_metadata = content_envelope.artifact_metadata
-        artifact_shared_stream = content_envelope.shared_stream
-        message_id = pick_first_non_empty_str(
-            (
-                body,
-                artifact_shared_stream,
-                artifact,
-                artifact_metadata,
-                metadata,
-                shared_stream,
-            ),
-            MESSAGE_ID_KEYS,
-        )
-
-        event_id = pick_first_non_empty_str(
-            (
-                body,
-                artifact_shared_stream,
-                artifact,
-                artifact_metadata,
-                metadata,
-            ),
-            EVENT_ID_KEYS,
-        )
-
-        fallback_event_id = (
-            f"{message_id}:{event_sequence}"
-            if message_id
-            else f"stream:{event_sequence}"
-        )
-        if event_id == f"stream:{event_sequence}" and message_id is not None:
-            event_id = None
-        shared_event_id = pick_non_empty_str(shared_stream, EVENT_ID_KEYS)
-        if event_id is None and shared_event_id not in (
-            None,
-            "",
-            fallback_event_id,
-            f"stream:{event_sequence}",
-        ):
-            event_id = shared_event_id
-
-        if message_id is not None:
-            shared_stream["messageId"] = message_id
-        shared_stream["eventId"] = event_id or fallback_event_id
-        if kind in {"message", "status-update"}:
-            if pick_non_empty_str(shared_stream, BLOCK_TYPE_KEYS) is None:
-                parts = artifact.get("parts")
-                if stream_payloads.extract_stream_data_from_parts(parts):
-                    shared_stream["blockType"] = "tool_call"
-                elif stream_payloads.extract_stream_text_from_parts(parts):
-                    shared_stream["blockType"] = "text"
-            if (
-                not isinstance(shared_stream.get("op"), str)
-                or not str(shared_stream.get("op")).strip()
-            ):
-                shared_stream["op"] = "replace"
+        upstream_shared_stream = dict(content_envelope.shared_stream)
 
         hub_stream_contract.attach_hub_stream_contract(
             payload,
             upstream_shared_stream=upstream_shared_stream,
+            local_event_sequence=event_sequence,
         )
 
     @classmethod

--- a/backend/app/features/invoke/service_streaming.py
+++ b/backend/app/features/invoke/service_streaming.py
@@ -34,6 +34,11 @@ from app.features.invoke.service_types import (
     StreamTextCallbackFn,
     ValidateMessageFn,
 )
+from app.features.invoke.stream_field_aliases import (
+    BLOCK_TYPE_KEYS,
+    EVENT_ID_KEYS,
+    MESSAGE_ID_KEYS,
+)
 from app.integrations.a2a_client.errors import A2APeerProtocolError
 from app.integrations.a2a_client.invoke_session import AgentResolutionPolicy
 from app.integrations.a2a_client.protobuf import (
@@ -475,7 +480,7 @@ class A2AInvokeStreamingRuntime:
                 metadata,
                 shared_stream,
             ),
-            ("messageId",),
+            MESSAGE_ID_KEYS,
         )
 
         event_id = pick_first_non_empty_str(
@@ -486,7 +491,7 @@ class A2AInvokeStreamingRuntime:
                 artifact_metadata,
                 metadata,
             ),
-            ("eventId",),
+            EVENT_ID_KEYS,
         )
 
         fallback_event_id = (
@@ -496,7 +501,7 @@ class A2AInvokeStreamingRuntime:
         )
         if event_id == f"stream:{event_sequence}" and message_id is not None:
             event_id = None
-        shared_event_id = pick_non_empty_str(shared_stream, ("eventId",))
+        shared_event_id = pick_non_empty_str(shared_stream, EVENT_ID_KEYS)
         if event_id is None and shared_event_id not in (
             None,
             "",
@@ -509,10 +514,7 @@ class A2AInvokeStreamingRuntime:
             shared_stream["messageId"] = message_id
         shared_stream["eventId"] = event_id or fallback_event_id
         if kind in {"message", "status-update"}:
-            if (
-                not isinstance(shared_stream.get("blockType"), str)
-                or not str(shared_stream.get("blockType")).strip()
-            ):
+            if pick_non_empty_str(shared_stream, BLOCK_TYPE_KEYS) is None:
                 parts = artifact.get("parts")
                 if stream_payloads.extract_stream_data_from_parts(parts):
                     shared_stream["blockType"] = "tool_call"

--- a/backend/app/features/invoke/service_streaming.py
+++ b/backend/app/features/invoke/service_streaming.py
@@ -14,6 +14,7 @@ from fastapi import WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
 
 from app.features.invoke import (
+    hub_stream_contract,
     service_streaming_consume,
     service_streaming_transport,
     stream_payloads,
@@ -465,6 +466,7 @@ class A2AInvokeStreamingRuntime:
         if not isinstance(shared_stream, dict):
             shared_stream = {}
             shared["stream"] = shared_stream
+        upstream_shared_stream = dict(shared_stream)
 
         shared_stream["seq"] = event_sequence
 
@@ -525,6 +527,11 @@ class A2AInvokeStreamingRuntime:
                 or not str(shared_stream.get("op")).strip()
             ):
                 shared_stream["op"] = "replace"
+
+        hub_stream_contract.attach_hub_stream_contract(
+            payload,
+            upstream_shared_stream=upstream_shared_stream,
+        )
 
     @classmethod
     def _extract_error_code_from_exception(cls, exc: BaseException) -> str | None:

--- a/backend/app/features/invoke/service_streaming_consume.py
+++ b/backend/app/features/invoke/service_streaming_consume.py
@@ -183,9 +183,6 @@ async def consume_stream(
                 event, validate_message=validate_message
             )
             event_sequence += 1
-            runtime._ensure_outbound_stream_contract(
-                serialized, event_sequence=event_sequence
-            )
             validation_errors = extract_stream_content_validation_errors(
                 serialized,
                 validate_message=validate_message,
@@ -212,6 +209,9 @@ async def consume_stream(
                         extra=warning_payload,
                     )
                 continue
+            runtime._ensure_outbound_stream_contract(
+                serialized, event_sequence=event_sequence
+            )
             stream_block, non_contract_reason = (
                 stream_payloads.analyze_stream_chunk_contract(serialized)
             )

--- a/backend/app/features/invoke/service_streaming_consume.py
+++ b/backend/app/features/invoke/service_streaming_consume.py
@@ -209,6 +209,8 @@ async def consume_stream(
                         extra=warning_payload,
                     )
                 continue
+            last_event_at = time.monotonic()
+            await runtime._call_callback(on_event, serialized)
             runtime._ensure_outbound_stream_contract(
                 serialized, event_sequence=event_sequence
             )
@@ -222,12 +224,6 @@ async def consume_stream(
                 log_warning=log_warning,
                 log_info=log_info,
                 log_extra=log_extra,
-            )
-
-            last_event_at = time.monotonic()
-            await runtime._call_callback(on_event, serialized)
-            runtime._ensure_outbound_stream_contract(
-                serialized, event_sequence=event_sequence
             )
             stream_text_accumulator.consume(serialized, stream_block=stream_block)
             if runtime._is_terminal_status_event(serialized):

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -28,6 +28,7 @@ from app.features.invoke.stream_diagnostics import (
     extract_stream_content_validation_errors,
     warn_non_contract_stream_content_once,
 )
+from app.features.invoke.stream_field_aliases import SEQ_KEYS
 from app.utils.json_encoder import json_dumps
 
 
@@ -85,7 +86,7 @@ def stream_sse(
                         envelope.event_metadata,
                         envelope.artifact_metadata,
                     ),
-                    ("seq",),
+                    SEQ_KEYS,
                 )
                 if parsed_sequence is not None:
                     seq_counter = max(seq_counter, parsed_sequence)
@@ -307,7 +308,7 @@ async def stream_ws(
                     envelope.event_metadata,
                     envelope.artifact_metadata,
                 ),
-                ("seq",),
+                SEQ_KEYS,
             )
             if parsed_sequence is not None:
                 seq_counter = max(seq_counter, parsed_sequence)

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -144,10 +144,11 @@ def stream_sse(
                     and event_sequence <= resume_from_sequence
                 ):
                     continue
-                seq_counter = max(seq_counter, event_sequence)
+                await runtime._call_callback(on_event, serialized)
                 runtime._ensure_outbound_stream_contract(
                     serialized, event_sequence=event_sequence
                 )
+                seq_counter = max(seq_counter, event_sequence)
                 stream_block, non_contract_reason = (
                     stream_payloads.analyze_stream_chunk_contract(serialized)
                 )
@@ -158,11 +159,6 @@ def stream_sse(
                     log_warning=log_warning,
                     log_info=log_info,
                     log_extra=log_extra,
-                )
-
-                await runtime._call_callback(on_event, serialized)
-                runtime._ensure_outbound_stream_contract(
-                    serialized, event_sequence=event_sequence
                 )
                 if cache_key:
                     await global_stream_cache.append_event(
@@ -372,10 +368,11 @@ async def stream_ws(
                 and event_sequence <= resume_from_sequence
             ):
                 continue
-            seq_counter = max(seq_counter, event_sequence)
+            await runtime._call_callback(on_event, serialized)
             runtime._ensure_outbound_stream_contract(
                 serialized, event_sequence=event_sequence
             )
+            seq_counter = max(seq_counter, event_sequence)
             stream_block, non_contract_reason = (
                 stream_payloads.analyze_stream_chunk_contract(serialized)
             )
@@ -386,11 +383,6 @@ async def stream_ws(
                 log_warning=log_warning,
                 log_info=log_info,
                 log_extra=log_extra,
-            )
-
-            await runtime._call_callback(on_event, serialized)
-            runtime._ensure_outbound_stream_contract(
-                serialized, event_sequence=event_sequence
             )
             if cache_key:
                 await global_stream_cache.append_event(

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -239,6 +239,10 @@ def stream_sse(
                 if isinstance(finalized_callback_result, dict):
                     finalization_event = finalized_callback_result
             if finalization_event is not None and not client_disconnected:
+                runtime._ensure_outbound_stream_contract(
+                    finalization_event,
+                    event_sequence=seq_counter + 1,
+                )
                 yield f"data: {json_dumps(finalization_event, ensure_ascii=False)}\n\n"
             if not client_disconnected:
                 yield "event: stream_end\ndata: {}\n\n"
@@ -481,6 +485,10 @@ async def stream_ws(
             if isinstance(finalized_callback_result, dict):
                 finalization_event = finalized_callback_result
         if finalization_event is not None and not client_disconnected:
+            runtime._ensure_outbound_stream_contract(
+                finalization_event,
+                event_sequence=seq_counter + 1,
+            )
             await websocket.send_text(
                 json_dumps(finalization_event, ensure_ascii=False)
             )

--- a/backend/app/features/invoke/stream_field_aliases.py
+++ b/backend/app/features/invoke/stream_field_aliases.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+BLOCK_TYPE_KEYS = ("blockType", "block_type")
+MESSAGE_ID_KEYS = ("messageId", "message_id")
+EVENT_ID_KEYS = ("eventId", "event_id")
+SEQ_KEYS = ("seq", "sequence")
+TASK_ID_KEYS = ("taskId", "task_id")
+BLOCK_ID_KEYS = ("blockId", "block_id")
+LANE_ID_KEYS = ("laneId", "lane_id")
+BASE_SEQ_KEYS = ("baseSeq", "base_seq")

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -487,13 +487,9 @@ def extract_block_base_seq(
     )
 
 
-def extract_stream_chunk_from_serialized_event(
+def extract_raw_stream_chunk_from_serialized_event(
     payload: dict[str, Any],
 ) -> dict[str, Any] | None:
-    hub_stream_chunk = _extract_stream_chunk_from_hub_envelope(payload)
-    if hub_stream_chunk is not None:
-        return hub_stream_chunk
-
     envelope = resolve_stream_content_envelope(payload)
     normalized_kind = envelope.event_kind
     if normalized_kind not in ("artifact-update", "message", "status-update"):
@@ -571,6 +567,15 @@ def extract_stream_chunk_from_serialized_event(
         if tool_call is not None:
             stream_chunk["tool_call"] = tool_call
     return stream_chunk
+
+
+def extract_stream_chunk_from_serialized_event(
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    hub_stream_chunk = _extract_stream_chunk_from_hub_envelope(payload)
+    if hub_stream_chunk is not None:
+        return hub_stream_chunk
+    return extract_raw_stream_chunk_from_serialized_event(payload)
 
 
 def analyze_stream_chunk_contract(

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -22,6 +22,16 @@ from app.features.invoke.shared_metadata import (
     extract_preferred_interrupt_metadata,
     merge_shared_metadata_sections,
 )
+from app.features.invoke.stream_field_aliases import (
+    BASE_SEQ_KEYS,
+    BLOCK_ID_KEYS,
+    BLOCK_TYPE_KEYS,
+    EVENT_ID_KEYS,
+    LANE_ID_KEYS,
+    MESSAGE_ID_KEYS,
+    SEQ_KEYS,
+    TASK_ID_KEYS,
+)
 from app.features.invoke.tool_call_view import build_tool_call_view
 from app.integrations.a2a_extensions.shared_contract import SHARED_STREAM_KEY
 from app.integrations.a2a_runtime_status_contract import (
@@ -35,14 +45,6 @@ _STREAM_RESPONSE_FIELD_TO_KIND = (
     ("message", "message"),
     ("task", "task"),
 )
-_BLOCK_TYPE_KEYS = ("blockType", "block_type")
-_MESSAGE_ID_KEYS = ("messageId", "message_id")
-_EVENT_ID_KEYS = ("eventId", "event_id")
-_SEQ_KEYS = ("seq", "sequence")
-_TASK_ID_KEYS = ("taskId", "task_id")
-_BLOCK_ID_KEYS = ("blockId", "block_id")
-_LANE_ID_KEYS = ("laneId", "lane_id")
-_BASE_SEQ_KEYS = ("baseSeq", "base_seq")
 
 
 @dataclass(frozen=True)
@@ -220,7 +222,7 @@ def extract_artifact_type(
 
     raw = pick_first_non_empty_str(
         (shared_stream, metadata, event_metadata),
-        _BLOCK_TYPE_KEYS,
+        BLOCK_TYPE_KEYS,
     )
 
     if raw is None:
@@ -298,7 +300,7 @@ def extract_message_id(
             shared_stream,
             body,
         ),
-        _MESSAGE_ID_KEYS,
+        MESSAGE_ID_KEYS,
     )
     if message_id is not None:
         return message_id
@@ -313,7 +315,7 @@ def extract_message_id(
             event_metadata,
             shared_stream,
         ),
-        _TASK_ID_KEYS,
+        TASK_ID_KEYS,
     ) or _infer_task_id_from_artifact_id(
         artifact_id
         if artifact_id is not None
@@ -378,7 +380,7 @@ def extract_block_id(
             event_metadata,
             artifact,
         ),
-        _BLOCK_ID_KEYS,
+        BLOCK_ID_KEYS,
     )
     if block_id is not None:
         return block_id
@@ -406,7 +408,7 @@ def extract_lane_id(
             event_metadata,
             artifact,
         ),
-        _LANE_ID_KEYS,
+        LANE_ID_KEYS,
     )
     if lane_id is not None:
         return lane_id
@@ -428,7 +430,7 @@ def extract_block_base_seq(
             event_metadata,
             artifact,
         ),
-        _BASE_SEQ_KEYS,
+        BASE_SEQ_KEYS,
     )
 
 
@@ -463,7 +465,7 @@ def extract_stream_chunk_from_serialized_event(
             shared_stream,
             body,
         ),
-        _EVENT_ID_KEYS,
+        EVENT_ID_KEYS,
     )
     delta = extract_stream_content_from_parts(
         artifact.get("parts"), block_type=block_type
@@ -482,7 +484,7 @@ def extract_stream_chunk_from_serialized_event(
             event_metadata,
             shared_stream,
         ),
-        _SEQ_KEYS,
+        SEQ_KEYS,
     )
     source = extract_artifact_source(payload, artifact)
     artifact_id = extract_artifact_id(payload, artifact)

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -45,6 +45,8 @@ _STREAM_RESPONSE_FIELD_TO_KIND = (
     ("message", "message"),
     ("task", "task"),
 )
+_HUB_STREAM_BLOCK_TYPES = frozenset({"text", "reasoning", "tool_call"})
+_HUB_STREAM_OPERATIONS = frozenset({"append", "replace", "finalize"})
 
 
 @dataclass(frozen=True)
@@ -137,6 +139,57 @@ def resolve_stream_content_envelope(
         parts=list(parts) if isinstance(parts, list) else [],
         shared_stream=shared_stream,
     )
+
+
+def _extract_stream_chunk_from_hub_envelope(
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    hub = _dict_field(payload, "hub")
+    if hub.get("version") != "v1":
+        return None
+    stream_block = _dict_field(hub, "streamBlock")
+    if not stream_block:
+        return None
+
+    block_type = _pick_non_empty_str(stream_block, ("blockType",))
+    operation = _pick_non_empty_str(stream_block, ("op",))
+    delta = stream_block.get("delta")
+    if (
+        block_type not in _HUB_STREAM_BLOCK_TYPES
+        or operation not in _HUB_STREAM_OPERATIONS
+        or not isinstance(delta, str)
+    ):
+        return None
+    if not delta and operation != "finalize":
+        return None
+
+    stream_chunk: dict[str, Any] = {
+        "event_id": _pick_non_empty_str(stream_block, ("eventId",)),
+        "seq": pick_first_int((stream_block,), ("seq",)),
+        "message_id": _pick_non_empty_str(stream_block, ("messageId",)),
+        "artifact_id": _pick_non_empty_str(stream_block, ("artifactId",)),
+        "block_id": _pick_non_empty_str(stream_block, ("blockId",)),
+        "lane_id": _pick_non_empty_str(stream_block, ("laneId",)),
+        "block_type": block_type,
+        "op": operation,
+        "content": delta,
+        "base_seq": pick_first_int((stream_block,), ("baseSeq",)),
+        "append": (
+            bool(stream_block.get("append"))
+            if isinstance(stream_block.get("append"), bool)
+            else operation == "append"
+        ),
+        "is_finished": (
+            bool(stream_block.get("done"))
+            if isinstance(stream_block.get("done"), bool)
+            else operation == "finalize"
+        ),
+        "source": _pick_non_empty_str(stream_block, ("source",)),
+    }
+    tool_call = _dict_field(stream_block, "toolCall")
+    if tool_call:
+        stream_chunk["tool_call"] = tool_call
+    return stream_chunk
 
 
 def extract_stream_text_from_parts(parts: Any) -> str:
@@ -437,6 +490,10 @@ def extract_block_base_seq(
 def extract_stream_chunk_from_serialized_event(
     payload: dict[str, Any],
 ) -> dict[str, Any] | None:
+    hub_stream_chunk = _extract_stream_chunk_from_hub_envelope(payload)
+    if hub_stream_chunk is not None:
+        return hub_stream_chunk
+
     envelope = resolve_stream_content_envelope(payload)
     normalized_kind = envelope.event_kind
     if normalized_kind not in ("artifact-update", "message", "status-update"):

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -35,6 +35,14 @@ _STREAM_RESPONSE_FIELD_TO_KIND = (
     ("message", "message"),
     ("task", "task"),
 )
+_BLOCK_TYPE_KEYS = ("blockType", "block_type")
+_MESSAGE_ID_KEYS = ("messageId", "message_id")
+_EVENT_ID_KEYS = ("eventId", "event_id")
+_SEQ_KEYS = ("seq", "sequence")
+_TASK_ID_KEYS = ("taskId", "task_id")
+_BLOCK_ID_KEYS = ("blockId", "block_id")
+_LANE_ID_KEYS = ("laneId", "lane_id")
+_BASE_SEQ_KEYS = ("baseSeq", "base_seq")
 
 
 @dataclass(frozen=True)
@@ -210,18 +218,17 @@ def extract_artifact_type(
     event_metadata = _event_metadata(payload)
     shared_stream = extract_shared_stream_metadata(payload, artifact)
 
-    raw = shared_stream.get("blockType")
-    if not isinstance(raw, str) or not raw.strip():
-        raw = metadata.get("blockType")
-    if not isinstance(raw, str) or not raw.strip():
-        raw = event_metadata.get("blockType")
+    raw = pick_first_non_empty_str(
+        (shared_stream, metadata, event_metadata),
+        _BLOCK_TYPE_KEYS,
+    )
 
-    if not isinstance(raw, str) or not raw.strip():
+    if raw is None:
         if kind in {"artifact-update", "message", "status-update"}:
             return _infer_canonical_block_type(artifact.get("parts"))
         return None
 
-    normalized = raw.strip().lower()
+    normalized = raw.lower()
     if normalized in {"text", "reasoning", "tool_call"}:
         return normalized
     return None
@@ -258,7 +265,7 @@ def extract_artifact_id(
         event_metadata,
         shared_stream,
     ):
-        artifact_id = _pick_non_empty_str(candidate, ("artifactId",))
+        artifact_id = _pick_non_empty_str(candidate, ("artifactId", "artifact_id"))
         if artifact_id is not None:
             return artifact_id
     return None
@@ -291,7 +298,7 @@ def extract_message_id(
             shared_stream,
             body,
         ),
-        ("messageId",),
+        _MESSAGE_ID_KEYS,
     )
     if message_id is not None:
         return message_id
@@ -306,7 +313,7 @@ def extract_message_id(
             event_metadata,
             shared_stream,
         ),
-        ("taskId",),
+        _TASK_ID_KEYS,
     ) or _infer_task_id_from_artifact_id(
         artifact_id
         if artifact_id is not None
@@ -371,7 +378,7 @@ def extract_block_id(
             event_metadata,
             artifact,
         ),
-        ("blockId",),
+        _BLOCK_ID_KEYS,
     )
     if block_id is not None:
         return block_id
@@ -399,7 +406,7 @@ def extract_lane_id(
             event_metadata,
             artifact,
         ),
-        ("laneId",),
+        _LANE_ID_KEYS,
     )
     if lane_id is not None:
         return lane_id
@@ -421,7 +428,7 @@ def extract_block_base_seq(
             event_metadata,
             artifact,
         ),
-        ("baseSeq",),
+        _BASE_SEQ_KEYS,
     )
 
 
@@ -456,7 +463,7 @@ def extract_stream_chunk_from_serialized_event(
             shared_stream,
             body,
         ),
-        ("eventId",),
+        _EVENT_ID_KEYS,
     )
     delta = extract_stream_content_from_parts(
         artifact.get("parts"), block_type=block_type
@@ -475,7 +482,7 @@ def extract_stream_chunk_from_serialized_event(
             event_metadata,
             shared_stream,
         ),
-        ("seq",),
+        _SEQ_KEYS,
     )
     source = extract_artifact_source(payload, artifact)
     artifact_id = extract_artifact_id(payload, artifact)

--- a/backend/app/features/invoke/stream_persistence.py
+++ b/backend/app/features/invoke/stream_persistence.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Protocol
 from uuid import UUID
 
 from app.db.models.agent_message import AgentMessage
+from app.features.invoke.hub_stream_local_context import attach_local_stream_context
 from app.features.invoke.service_types import StreamOutcome
 from app.features.invoke.session_binding import resolve_invoke_session_control_intent
 from app.features.invoke.stream_payloads import (
@@ -168,7 +169,7 @@ def resolve_agent_status_from_outcome(outcome: StreamOutcome) -> str:
     return "error"
 
 
-def rewrite_stream_event_contract(
+def attach_local_stream_contract_context(
     event_payload: dict[str, Any],
     *,
     local_message_id: str,
@@ -176,25 +177,13 @@ def rewrite_stream_event_contract(
     seq: int | None,
     stream_block: dict[str, Any] | None = None,
 ) -> None:
-    shared_stream = _ensure_shared_stream_metadata(event_payload)
-    if shared_stream is None:
-        return
-    shared_stream["messageId"] = local_message_id
-    if event_id:
-        shared_stream["eventId"] = event_id
-    if isinstance(seq, int) and seq > 0:
-        shared_stream["seq"] = seq
-    if isinstance(stream_block, dict):
-        field_map = {
-            "block_id": "blockId",
-            "lane_id": "laneId",
-            "op": "op",
-            "base_seq": "baseSeq",
-        }
-        for source_name, target_name in field_map.items():
-            value = stream_block.get(source_name)
-            if value is not None:
-                shared_stream[target_name] = value
+    attach_local_stream_context(
+        event_payload,
+        local_message_id=local_message_id,
+        event_id=event_id,
+        seq=seq,
+        stream_block=stream_block,
+    )
 
 
 def resolve_stream_event_id(
@@ -305,7 +294,7 @@ async def persist_stream_block_update(
         local_message_id=local_message_id,
         seq=persist_seq,
     )
-    rewrite_stream_event_contract(
+    attach_local_stream_contract_context(
         event_payload,
         local_message_id=local_message_id,
         event_id=resolved_event_id,
@@ -354,36 +343,6 @@ async def persist_stream_block_update(
             commit_fn=commit_fn,
             session_hub=session_hub,
         )
-
-
-def _ensure_shared_stream_metadata(
-    event_payload: dict[str, Any],
-) -> dict[str, Any] | None:
-    event_body = None
-    for field_name in ("artifactUpdate", "message", "statusUpdate", "task"):
-        candidate = event_payload.get(field_name)
-        if isinstance(candidate, dict):
-            event_body = candidate
-            break
-    if event_body is None:
-        return None
-
-    metadata = event_body.get("metadata")
-    if not isinstance(metadata, dict):
-        metadata = {}
-        event_body["metadata"] = metadata
-
-    shared = metadata.get("shared")
-    if not isinstance(shared, dict):
-        shared = {}
-        metadata["shared"] = shared
-
-    shared_stream = shared.get("stream")
-    if not isinstance(shared_stream, dict):
-        shared_stream = {}
-        shared["stream"] = shared_stream
-
-    return shared_stream
 
 
 async def persist_interrupt_lifecycle_event(

--- a/backend/app/features/invoke/stream_persistence.py
+++ b/backend/app/features/invoke/stream_persistence.py
@@ -44,6 +44,34 @@ class InvokePersistenceState(Protocol):
     current_block_type: str | None
 
 
+class EnsureHeadersFn(Protocol):
+    async def __call__(
+        self,
+        *,
+        state: InvokePersistenceState,
+        request: "InvokePersistenceRequest",
+    ) -> None: ...
+
+
+class FlushStreamBufferFn(Protocol):
+    async def __call__(
+        self,
+        *,
+        state: InvokePersistenceState,
+        user_id: UUID,
+    ) -> None: ...
+
+
+class PersistFinalBlockFn(Protocol):
+    async def __call__(
+        self,
+        *,
+        state: InvokePersistenceState,
+        outcome: StreamOutcome,
+        user_id: UUID,
+    ) -> None: ...
+
+
 @dataclass(frozen=True)
 class InvokePersistenceRequest:
     user_id: UUID
@@ -169,23 +197,6 @@ def resolve_agent_status_from_outcome(outcome: StreamOutcome) -> str:
     return "error"
 
 
-def attach_local_stream_contract_context(
-    event_payload: dict[str, Any],
-    *,
-    local_message_id: str,
-    event_id: str,
-    seq: int | None,
-    stream_block: dict[str, Any] | None = None,
-) -> None:
-    attach_local_stream_context(
-        event_payload,
-        local_message_id=local_message_id,
-        event_id=event_id,
-        seq=seq,
-        stream_block=stream_block,
-    )
-
-
 def resolve_stream_event_id(
     *,
     stream_block: dict[str, Any],
@@ -271,18 +282,46 @@ async def persist_stream_block_update(
     session_factory: Any,
     commit_fn: Any,
     session_hub: Any,
-    ensure_headers_fn: Any = ensure_local_message_headers,
-    flush_buffer_fn: Any = None,
+    ensure_headers_fn: EnsureHeadersFn | None = None,
+    flush_buffer_fn: FlushStreamBufferFn | None = None,
 ) -> None:
     stream_block = extract_stream_chunk_from_serialized_event(event_payload)
     if stream_block is None:
         return
+    if ensure_headers_fn is None:
+
+        async def ensure_headers_fn(
+            *,
+            state: InvokePersistenceState,
+            request: InvokePersistenceRequest,
+        ) -> None:
+            await ensure_local_message_headers(
+                state=state,
+                request=request,
+                session_factory=session_factory,
+                commit_fn=commit_fn,
+                session_hub=session_hub,
+            )
+
+    if flush_buffer_fn is None:
+
+        async def flush_buffer_fn(
+            *,
+            state: InvokePersistenceState,
+            user_id: UUID,
+        ) -> None:
+            await flush_stream_buffer(
+                state=state,
+                user_id=user_id,
+                session_factory=session_factory,
+                commit_fn=commit_fn,
+                session_hub=session_hub,
+            )
+
     await ensure_headers_fn(
         state=state,
         request=request,
     )
-    if flush_buffer_fn is None:
-        flush_buffer_fn = flush_stream_buffer
     agent_message_id = resolve_agent_message_id(state)
     if agent_message_id is None:
         return
@@ -294,7 +333,7 @@ async def persist_stream_block_update(
         local_message_id=local_message_id,
         seq=persist_seq,
     )
-    attach_local_stream_contract_context(
+    attach_local_stream_context(
         event_payload,
         local_message_id=local_message_id,
         event_id=resolved_event_id,
@@ -309,9 +348,6 @@ async def persist_stream_block_update(
         await flush_buffer_fn(
             state=state,
             user_id=request.user_id,
-            session_factory=session_factory,
-            commit_fn=commit_fn,
-            session_hub=session_hub,
         )
 
     state.current_block_type = block_type
@@ -339,9 +375,6 @@ async def persist_stream_block_update(
         await flush_buffer_fn(
             state=state,
             user_id=request.user_id,
-            session_factory=session_factory,
-            commit_fn=commit_fn,
-            session_hub=session_hub,
         )
 
 
@@ -354,29 +387,54 @@ async def persist_interrupt_lifecycle_event(
     session_factory: Any,
     commit_fn: Any,
     session_hub: Any,
-    ensure_headers_fn: Any = ensure_local_message_headers,
-    flush_buffer_fn: Any = None,
+    ensure_headers_fn: EnsureHeadersFn | None = None,
+    flush_buffer_fn: FlushStreamBufferFn | None = None,
 ) -> None:
     if state.local_session_id is None:
         return
     interrupt_event = extract_interrupt_lifecycle_from_serialized_event(event_payload)
     if interrupt_event is None:
         return
+    if ensure_headers_fn is None:
+
+        async def ensure_headers_fn(
+            *,
+            state: InvokePersistenceState,
+            request: InvokePersistenceRequest,
+        ) -> None:
+            await ensure_local_message_headers(
+                state=state,
+                request=request,
+                session_factory=session_factory,
+                commit_fn=commit_fn,
+                session_hub=session_hub,
+            )
+
+    if flush_buffer_fn is None:
+
+        async def flush_buffer_fn(
+            *,
+            state: InvokePersistenceState,
+            user_id: UUID,
+        ) -> None:
+            await flush_stream_buffer(
+                state=state,
+                user_id=user_id,
+                session_factory=session_factory,
+                commit_fn=commit_fn,
+                session_hub=session_hub,
+            )
+
     await ensure_headers_fn(
         state=state,
         request=request,
     )
-    if flush_buffer_fn is None:
-        flush_buffer_fn = flush_stream_buffer
     agent_message_id = resolve_agent_message_id(state)
     if agent_message_id is None:
         return
     await flush_buffer_fn(
         state=state,
         user_id=request.user_id,
-        session_factory=session_factory,
-        commit_fn=commit_fn,
-        session_hub=session_hub,
     )
     persist_seq = state.next_event_seq if state.next_event_seq > 0 else 1
     interrupt_event_id = (
@@ -465,24 +523,51 @@ async def persist_local_outcome(
     session_factory: Any,
     commit_fn: Any,
     session_hub: Any,
-    ensure_headers_fn: Any = ensure_local_message_headers,
-    persist_final_block_fn: Any = None,
+    ensure_headers_fn: EnsureHeadersFn | None = None,
+    persist_final_block_fn: PersistFinalBlockFn | None = None,
 ) -> None:
     if state.local_session_id is None or state.local_source is None:
         return
+    if ensure_headers_fn is None:
+
+        async def ensure_headers_fn(
+            *,
+            state: InvokePersistenceState,
+            request: InvokePersistenceRequest,
+        ) -> None:
+            await ensure_local_message_headers(
+                state=state,
+                request=request,
+                session_factory=session_factory,
+                commit_fn=commit_fn,
+                session_hub=session_hub,
+            )
+
+    if persist_final_block_fn is None:
+
+        async def persist_final_block_fn(
+            *,
+            state: InvokePersistenceState,
+            outcome: StreamOutcome,
+            user_id: UUID,
+        ) -> None:
+            await persist_synthetic_final_block_if_needed(
+                state=state,
+                outcome=outcome,
+                user_id=user_id,
+                session_factory=session_factory,
+                commit_fn=commit_fn,
+                session_hub=session_hub,
+            )
+
     await ensure_headers_fn(
         state=state,
         request=request,
     )
-    if persist_final_block_fn is None:
-        persist_final_block_fn = persist_synthetic_final_block_if_needed
     await persist_final_block_fn(
         state=state,
         outcome=outcome,
         user_id=request.user_id,
-        session_factory=session_factory,
-        commit_fn=commit_fn,
-        session_hub=session_hub,
     )
     persisted_content = outcome.final_text or str(outcome.error_message or "")
     metadata_payload = build_stream_metadata_from_outcome(

--- a/backend/tests/invoke/test_a2a_invoke_service_contract_fallback.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_contract_fallback.py
@@ -105,6 +105,36 @@ def test_extract_stream_chunk_prefers_shared_stream_block_type_over_text_part_ki
     assert chunk["source"] == "tool_part_update"
 
 
+def test_extract_stream_chunk_reads_snake_case_stream_hint_fields():
+    chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
+        {
+            "artifactUpdate": {
+                "artifact": {
+                    "parts": [{"text": "thinking"}],
+                    "metadata": {
+                        "shared": {
+                            "stream": {
+                                "block_type": "reasoning",
+                                "op": "append",
+                                "source": "reasoning_part_update",
+                                "message_id": "msg-snake",
+                                "event_id": "evt-snake",
+                                "sequence": 11,
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    )
+    assert chunk is not None
+    assert chunk["block_type"] == "reasoning"
+    assert chunk["message_id"] == "msg-snake"
+    assert chunk["event_id"] == "evt-snake"
+    assert chunk["seq"] == 11
+    assert chunk["source"] == "reasoning_part_update"
+
+
 def test_extract_stream_chunk_reads_tool_call_content_from_data_parts():
     chunk = a2a_invoke_service.extract_stream_chunk_from_serialized_event(
         {

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -502,7 +502,7 @@ def test_extract_stream_chunk_inferrs_artifact_text_payloads_without_explicit_bl
     assert chunk["is_finished"] is False
 
 
-def test_ensure_outbound_stream_contract_adds_nested_shared_stream_metadata():
+def test_ensure_outbound_stream_contract_attaches_hub_message_contract_only():
     payload = {
         "message": {
             "messageId": "msg-root-2",
@@ -516,22 +516,20 @@ def test_ensure_outbound_stream_contract_adds_nested_shared_stream_metadata():
         event_sequence=4,
     )
 
-    shared_stream = payload["message"]["metadata"]["shared"]["stream"]
-    assert shared_stream["seq"] == 4
-    assert shared_stream["eventId"] == "msg-root-2:4"
-    assert shared_stream["blockType"] == "text"
-    assert shared_stream["op"] == "replace"
+    assert "metadata" not in payload["message"]
     assert payload["message"]["parts"] == [{"text": "render me"}]
     assert payload["message"]["role"] == "ROLE_AGENT"
     assert payload["message"]["messageId"] == "msg-root-2"
     assert payload["hub"]["version"] == "v1"
     assert payload["hub"]["eventKind"] == "message"
+    assert payload["hub"]["streamBlock"]["seq"] == 4
+    assert payload["hub"]["streamBlock"]["eventId"] == "seq:msg-root-2:4"
     assert payload["hub"]["streamBlock"]["messageId"] == "msg-root-2"
     assert payload["hub"]["streamBlock"]["blockType"] == "text"
     assert payload["hub"]["streamBlock"]["op"] == "replace"
 
 
-def test_ensure_outbound_stream_contract_adds_shared_stream_metadata_for_status_message():
+def test_ensure_outbound_stream_contract_attaches_hub_status_contract_only():
     payload = {
         "statusUpdate": {
             "status": {
@@ -550,20 +548,19 @@ def test_ensure_outbound_stream_contract_adds_shared_stream_metadata_for_status_
         event_sequence=5,
     )
 
-    shared_stream = payload["statusUpdate"]["metadata"]["shared"]["stream"]
-    assert shared_stream["seq"] == 5
-    assert shared_stream["messageId"] == "msg-status-2"
-    assert shared_stream["eventId"] == "msg-status-2:5"
-    assert shared_stream["blockType"] == "text"
-    assert shared_stream["op"] == "replace"
+    assert "metadata" not in payload["statusUpdate"]
     assert payload["statusUpdate"]["status"]["message"]["parts"] == [
         {"text": "render status message"}
     ]
     assert payload["hub"]["version"] == "v1"
     assert payload["hub"]["eventKind"] == "status-update"
+    assert payload["hub"]["streamBlock"]["seq"] == 5
+    assert payload["hub"]["streamBlock"]["eventId"] == "seq:msg-status-2:5"
     assert payload["hub"]["streamBlock"]["messageId"] == "msg-status-2"
     assert payload["hub"]["runtimeStatus"]["state"] == "working"
     assert payload["hub"]["runtimeStatus"]["isFinal"] is False
+    assert payload["hub"]["runtimeStatus"]["seq"] == 5
+    assert payload["hub"]["runtimeStatus"]["messageId"] == "msg-status-2"
 
 
 def test_ensure_outbound_stream_contract_exposes_fallback_message_identity_in_hub():
@@ -586,6 +583,8 @@ def test_ensure_outbound_stream_contract_exposes_fallback_message_identity_in_hu
     assert payload["hub"]["streamBlock"]["messageId"] == "task:task-fallback-1"
     assert payload["hub"]["streamBlock"]["messageIdSource"] == "task_fallback"
     assert payload["hub"]["streamBlock"]["eventIdSource"] == "fallback_seq"
+    assert payload["hub"]["streamBlock"]["seq"] == 6
+    assert payload["hub"]["streamBlock"]["eventId"] == "seq:task:task-fallback-1:6"
 
 
 def test_serialize_stream_event_keeps_canonical_message_payload_before_validation(

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -524,6 +524,11 @@ def test_ensure_outbound_stream_contract_adds_nested_shared_stream_metadata():
     assert payload["message"]["parts"] == [{"text": "render me"}]
     assert payload["message"]["role"] == "ROLE_AGENT"
     assert payload["message"]["messageId"] == "msg-root-2"
+    assert payload["hub"]["version"] == "v1"
+    assert payload["hub"]["eventKind"] == "message"
+    assert payload["hub"]["streamBlock"]["messageId"] == "msg-root-2"
+    assert payload["hub"]["streamBlock"]["blockType"] == "text"
+    assert payload["hub"]["streamBlock"]["op"] == "replace"
 
 
 def test_ensure_outbound_stream_contract_adds_shared_stream_metadata_for_status_message():
@@ -554,6 +559,33 @@ def test_ensure_outbound_stream_contract_adds_shared_stream_metadata_for_status_
     assert payload["statusUpdate"]["status"]["message"]["parts"] == [
         {"text": "render status message"}
     ]
+    assert payload["hub"]["version"] == "v1"
+    assert payload["hub"]["eventKind"] == "status-update"
+    assert payload["hub"]["streamBlock"]["messageId"] == "msg-status-2"
+    assert payload["hub"]["runtimeStatus"]["state"] == "working"
+    assert payload["hub"]["runtimeStatus"]["isFinal"] is False
+
+
+def test_ensure_outbound_stream_contract_exposes_fallback_message_identity_in_hub():
+    payload = {
+        "artifactUpdate": {
+            "taskId": "task-fallback-1",
+            "append": True,
+            "artifact": {
+                "artifactId": "task-fallback-1:stream:text",
+                "parts": [{"text": "hello"}],
+            },
+        }
+    }
+
+    a2a_invoke_service._ensure_outbound_stream_contract(
+        payload,
+        event_sequence=6,
+    )
+
+    assert payload["hub"]["streamBlock"]["messageId"] == "task:task-fallback-1"
+    assert payload["hub"]["streamBlock"]["messageIdSource"] == "task_fallback"
+    assert payload["hub"]["streamBlock"]["eventIdSource"] == "fallback_seq"
 
 
 def test_serialize_stream_event_keeps_canonical_message_payload_before_validation(

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -59,6 +59,30 @@ def test_extract_stream_identity_hints_from_serialized_event():
     }
 
 
+def test_extract_stream_identity_hints_accepts_snake_case_stream_fields():
+    hints = a2a_invoke_service.extract_stream_identity_hints_from_serialized_event(
+        {
+            "artifactUpdate": {
+                "artifact": {"parts": [{"text": "noop"}]},
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "message_id": "msg-snake-1",
+                            "event_id": "evt-snake-1",
+                            "sequence": 13,
+                        }
+                    }
+                },
+            }
+        }
+    )
+    assert hints == {
+        "upstream_message_id": "msg-snake-1",
+        "upstream_event_id": "evt-snake-1",
+        "upstream_event_seq": 13,
+    }
+
+
 def test_extract_stream_identity_hints_reads_seq_and_task_id_from_analysis():
     hints = a2a_invoke_service.extract_stream_identity_hints_from_serialized_event(
         {
@@ -249,7 +273,7 @@ def test_extract_stream_identity_hints_reads_shared_stream_metadata():
     assert hints["upstream_event_seq"] == 12
 
 
-def test_extract_stream_identity_hints_ignores_legacy_sequence_alias():
+def test_extract_stream_identity_hints_accepts_sequence_alias():
     hints = a2a_invoke_service.extract_stream_identity_hints_from_serialized_event(
         {
             "artifactUpdate": {
@@ -269,7 +293,7 @@ def test_extract_stream_identity_hints_ignores_legacy_sequence_alias():
 
     assert hints["upstream_message_id"] == "msg-legacy-sequence"
     assert hints["upstream_event_id"] == "evt-legacy-sequence"
-    assert "upstream_event_seq" not in hints
+    assert hints["upstream_event_seq"] == 12
 
 
 def test_extract_stream_chunk_reads_canonical_event_and_message_ids():

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.features.invoke.hub_stream_local_context import attach_local_stream_context
 from app.features.invoke.stream_payloads import resolve_stream_content_envelope
 from tests.invoke.a2a_invoke_service_support import (
     _DumpableEvent,
@@ -585,6 +586,61 @@ def test_ensure_outbound_stream_contract_exposes_fallback_message_identity_in_hu
     assert payload["hub"]["streamBlock"]["eventIdSource"] == "fallback_seq"
     assert payload["hub"]["streamBlock"]["seq"] == 6
     assert payload["hub"]["streamBlock"]["eventId"] == "seq:task:task-fallback-1:6"
+
+
+def test_ensure_outbound_stream_contract_consumes_local_stream_overlay():
+    payload = {
+        "artifactUpdate": {
+            "append": True,
+            "artifact": {
+                "artifactId": "task-local-1:stream:text",
+                "parts": [{"text": "hello"}],
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "blockType": "text",
+                            "messageId": "msg-upstream-local-1",
+                            "eventId": "evt-upstream-local-1",
+                            "seq": 9,
+                        }
+                    }
+                },
+            },
+        }
+    }
+    attach_local_stream_context(
+        payload,
+        local_message_id="msg-local-1",
+        event_id="evt-local-1",
+        seq=3,
+        stream_block={
+            "block_id": "block-local-1",
+            "lane_id": "primary_text",
+            "op": "replace",
+            "base_seq": 2,
+        },
+    )
+
+    a2a_invoke_service._ensure_outbound_stream_contract(
+        payload,
+        event_sequence=11,
+    )
+
+    assert "__hub_local_stream" not in payload
+    assert payload["artifactUpdate"]["artifact"]["metadata"]["shared"]["stream"] == {
+        "blockType": "text",
+        "messageId": "msg-upstream-local-1",
+        "eventId": "evt-upstream-local-1",
+        "seq": 9,
+    }
+    assert payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
+    assert payload["hub"]["streamBlock"]["messageIdSource"] == "local_persistence"
+    assert payload["hub"]["streamBlock"]["eventId"] == "evt-local-1"
+    assert payload["hub"]["streamBlock"]["eventIdSource"] == "local_persistence"
+    assert payload["hub"]["streamBlock"]["seq"] == 3
+    assert payload["hub"]["streamBlock"]["blockId"] == "block-local-1"
+    assert payload["hub"]["streamBlock"]["baseSeq"] == 2
+    assert payload["hub"]["streamBlock"]["op"] == "replace"
 
 
 def test_serialize_stream_event_keeps_canonical_message_payload_before_validation(

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -813,12 +813,14 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
         for payload in _extract_stream_payloads(initial_frames)
         if "artifactUpdate" in payload
     )
-    initial_shared_stream = initial_payload["artifactUpdate"]["metadata"]["shared"][
-        "stream"
-    ]
+    initial_shared_stream = initial_payload["artifactUpdate"]["artifact"]["metadata"][
+        "shared"
+    ]["stream"]
     assert initial_shared_stream["messageId"] == "msg-local-1"
-    assert initial_shared_stream["seq"] == 1
     assert initial_shared_stream["eventId"] == "evt-cache-1"
+    assert "seq" not in initial_shared_stream
+    assert initial_payload["hub"]["streamBlock"]["seq"] == 1
+    assert initial_payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
 
     replay = a2a_invoke_service.stream_sse(
         gateway=_GatewayWithEvents([]),
@@ -841,12 +843,14 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
         for payload in _extract_stream_payloads(replay_frames)
         if "artifactUpdate" in payload
     )
-    replay_shared_stream = replay_payload["artifactUpdate"]["metadata"]["shared"][
-        "stream"
-    ]
+    replay_shared_stream = replay_payload["artifactUpdate"]["artifact"]["metadata"][
+        "shared"
+    ]["stream"]
     assert replay_shared_stream["messageId"] == "msg-local-1"
-    assert replay_shared_stream["seq"] == 1
     assert replay_shared_stream["eventId"] == "evt-cache-1"
+    assert "seq" not in replay_shared_stream
+    assert replay_payload["hub"]["streamBlock"]["seq"] == 1
+    assert replay_payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
 
     await global_stream_cache.mark_completed(cache_key)
 
@@ -877,7 +881,7 @@ async def test_iter_gateway_stream_passes_requested_extensions_to_gateway():
 
 
 @pytest.mark.asyncio
-async def test_sse_normalizes_outbound_seq_to_monotonic_event_cursor():
+async def test_sse_preserves_upstream_seq_in_hub_stream_blocks():
     response = a2a_invoke_service.stream_sse(
         gateway=_GatewayWithEvents(
             [
@@ -934,11 +938,11 @@ async def test_sse_normalizes_outbound_seq_to_monotonic_event_cursor():
 
     payloads = _extract_stream_payloads(frames)
     artifact_payloads = [payload for payload in payloads if "artifactUpdate" in payload]
-    assert [
-        payload["artifactUpdate"]["metadata"]["shared"]["stream"]["seq"]
-        for payload in artifact_payloads
-    ] == [1, 2]
-    assert payloads[-1]["statusUpdate"]["metadata"]["shared"]["stream"]["seq"] == 3
+    assert [payload["hub"]["streamBlock"]["seq"] for payload in artifact_payloads] == [
+        9,
+        12,
+    ]
+    assert payloads[-1]["hub"]["runtimeStatus"]["seq"] == 3
 
 
 @pytest.mark.asyncio
@@ -970,13 +974,14 @@ async def test_sse_preserves_canonical_message_payload_for_upstream_message_even
     assert message_payload["message"]["messageId"] == "msg-upstream-sse-1"
     assert message_payload["message"]["role"] == "ROLE_AGENT"
     assert message_payload["message"]["parts"] == [{"text": "hello from raw message"}]
-    assert message_payload["message"]["metadata"]["shared"]["stream"] == {
-        "seq": 1,
-        "messageId": "msg-upstream-sse-1",
-        "eventId": "msg-upstream-sse-1:1",
-        "blockType": "text",
-        "op": "replace",
-    }
+    assert "metadata" not in message_payload["message"]
+    assert message_payload["hub"]["streamBlock"]["seq"] == 1
+    assert message_payload["hub"]["streamBlock"]["messageId"] == "msg-upstream-sse-1"
+    assert (
+        message_payload["hub"]["streamBlock"]["eventId"] == "seq:msg-upstream-sse-1:1"
+    )
+    assert message_payload["hub"]["streamBlock"]["blockType"] == "text"
+    assert message_payload["hub"]["streamBlock"]["op"] == "replace"
 
 
 @pytest.mark.asyncio
@@ -1120,13 +1125,12 @@ async def test_ws_preserves_canonical_message_payload_for_upstream_message_event
     assert message_payload["message"]["messageId"] == "msg-upstream-ws-1"
     assert message_payload["message"]["role"] == "ROLE_AGENT"
     assert message_payload["message"]["parts"] == [{"text": "hello from raw message"}]
-    assert message_payload["message"]["metadata"]["shared"]["stream"] == {
-        "seq": 1,
-        "messageId": "msg-upstream-ws-1",
-        "eventId": "msg-upstream-ws-1:1",
-        "blockType": "text",
-        "op": "replace",
-    }
+    assert "metadata" not in message_payload["message"]
+    assert message_payload["hub"]["streamBlock"]["seq"] == 1
+    assert message_payload["hub"]["streamBlock"]["messageId"] == "msg-upstream-ws-1"
+    assert message_payload["hub"]["streamBlock"]["eventId"] == "seq:msg-upstream-ws-1:1"
+    assert message_payload["hub"]["streamBlock"]["blockType"] == "text"
+    assert message_payload["hub"]["streamBlock"]["op"] == "replace"
 
 
 @pytest.mark.asyncio
@@ -1232,15 +1236,19 @@ async def test_ws_assigns_fallback_seq_and_event_id_after_on_event_mutation():
         if item.startswith("{") and '"artifactUpdate"' in item
     ]
     assert payloads
-    assert payloads[0]["artifactUpdate"]["metadata"]["shared"]["stream"] == {
-        "seq": 1,
+    assert payloads[0]["artifactUpdate"]["artifact"]["metadata"]["shared"][
+        "stream"
+    ] == {
+        "blockType": "text",
         "messageId": "msg-local-ws-1",
-        "eventId": "msg-local-ws-1:1",
     }
+    assert payloads[0]["hub"]["streamBlock"]["seq"] == 1
+    assert payloads[0]["hub"]["streamBlock"]["messageId"] == "msg-local-ws-1"
+    assert payloads[0]["hub"]["streamBlock"]["eventId"] == "seq:msg-local-ws-1:1"
 
 
 @pytest.mark.asyncio
-async def test_ws_normalizes_outbound_seq_to_monotonic_event_cursor():
+async def test_ws_preserves_upstream_seq_in_hub_stream_blocks():
     websocket = _DummyWebSocket()
 
     await a2a_invoke_service.stream_ws(
@@ -1302,11 +1310,11 @@ async def test_ws_normalizes_outbound_seq_to_monotonic_event_cursor():
         and ('"artifactUpdate"' in item or '"statusUpdate"' in item)
     ]
     artifact_payloads = [payload for payload in payloads if "artifactUpdate" in payload]
-    assert [
-        payload["artifactUpdate"]["metadata"]["shared"]["stream"]["seq"]
-        for payload in artifact_payloads
-    ] == [1, 2]
-    assert payloads[-1]["statusUpdate"]["metadata"]["shared"]["stream"]["seq"] == 3
+    assert [payload["hub"]["streamBlock"]["seq"] for payload in artifact_payloads] == [
+        9,
+        12,
+    ]
+    assert payloads[-1]["hub"]["runtimeStatus"]["seq"] == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -856,6 +856,53 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
 
 
 @pytest.mark.asyncio
+async def test_sse_rebuilds_hub_stream_block_after_on_event_text_mutation():
+    completed: list[str] = []
+
+    async def _on_complete(text: str):
+        completed.append(text)
+
+    async def _rewrite_text(payload: dict[str, object]) -> None:
+        if "artifactUpdate" not in payload:
+            return
+        payload["artifactUpdate"]["artifact"]["parts"][0]["text"] = "rewritten"
+
+    response = a2a_invoke_service.stream_sse(
+        gateway=_GatewayWithEvents(
+            [
+                _artifact_event(
+                    artifact_id="task-rewrite-sse:stream:text",
+                    text="hello",
+                    block_type="text",
+                )
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+        on_complete=_on_complete,
+        on_event=_rewrite_text,
+    )
+    frames: list[str] = []
+    async for chunk in response.body_iterator:
+        frames.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+
+    payloads = _extract_stream_payloads(frames)
+    artifact_payload = next(
+        payload for payload in payloads if "artifactUpdate" in payload
+    )
+    assert artifact_payload["artifactUpdate"]["artifact"]["parts"] == [
+        {"text": "rewritten"}
+    ]
+    assert artifact_payload["hub"]["streamBlock"]["delta"] == "rewritten"
+    assert completed == ["rewritten"]
+
+
+@pytest.mark.asyncio
 async def test_iter_gateway_stream_passes_requested_extensions_to_gateway():
     captured: dict[str, object] = {}
 
@@ -1245,6 +1292,46 @@ async def test_ws_assigns_fallback_seq_and_event_id_after_on_event_mutation():
     assert payloads[0]["hub"]["streamBlock"]["seq"] == 1
     assert payloads[0]["hub"]["streamBlock"]["messageId"] == "msg-local-ws-1"
     assert payloads[0]["hub"]["streamBlock"]["eventId"] == "seq:msg-local-ws-1:1"
+
+
+@pytest.mark.asyncio
+async def test_ws_rebuilds_hub_stream_block_after_on_event_text_mutation():
+    websocket = _DummyWebSocket()
+
+    async def _rewrite_text(payload: dict[str, object]) -> None:
+        if "artifactUpdate" not in payload:
+            return
+        payload["artifactUpdate"]["artifact"]["parts"][0]["text"] = "rewritten"
+
+    await a2a_invoke_service.stream_ws(
+        websocket=websocket,
+        gateway=_GatewayWithEvents(
+            [
+                _artifact_event(
+                    artifact_id="task-rewrite-ws:stream:text",
+                    text="hello",
+                    block_type="text",
+                )
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+        on_event=_rewrite_text,
+    )
+
+    payloads = [
+        json.loads(item)
+        for item in websocket.sent
+        if item.startswith("{") and '"artifactUpdate"' in item
+    ]
+    assert payloads
+    assert payloads[0]["artifactUpdate"]["artifact"]["parts"] == [{"text": "rewritten"}]
+    assert payloads[0]["hub"]["streamBlock"]["delta"] == "rewritten"
 
 
 @pytest.mark.asyncio
@@ -1662,6 +1749,48 @@ async def test_consume_stream_accepts_single_blocking_message_payload() -> None:
     assert result.finish_reason == StreamFinishReason.SUCCESS
     assert result.final_text == "blocking-result"
     assert result.terminal_event_seen is False
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_uses_post_on_event_text_mutation_for_final_result():
+    async def _rewrite_text(payload: dict[str, object]) -> None:
+        if "message" not in payload:
+            return
+        payload["message"]["parts"][0]["text"] = "rewritten"
+
+    result = await a2a_invoke_service.consume_stream(
+        gateway=_GatewayWithEvents(
+            [
+                {
+                    "message": {
+                        "messageId": "msg-blocking-rewrite-1",
+                        "taskId": "task-blocking-rewrite-1",
+                        "role": "ROLE_AGENT",
+                        "parts": [{"type": "text", "text": "blocking-result"}],
+                        "metadata": {
+                            "shared": {
+                                "stream": {
+                                    "eventId": "evt-blocking-rewrite-1",
+                                    "blockType": "text",
+                                }
+                            }
+                        },
+                    }
+                }
+            ]
+        ),
+        resolved=object(),
+        query="hello",
+        context_id=None,
+        metadata=None,
+        validate_message=lambda _: [],
+        logger=logging.getLogger(__name__),
+        log_extra={},
+        on_event=_rewrite_text,
+    )
+
+    assert result.success is True
+    assert result.final_text == "rewritten"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/invoke/test_invoke_route_runner_streaming.py
+++ b/backend/tests/invoke/test_invoke_route_runner_streaming.py
@@ -449,18 +449,10 @@ async def test_persist_stream_block_update_rewrites_when_only_agent_message_id_i
     async def fake_commit_safely(_db):
         return None
 
-    async def fake_ensure_local_message_headers(**_kwargs):
-        return None
-
     monkeypatch.setattr(
         invoke_route_runner,
         "AsyncSessionLocal",
         lambda: _DummySessionContext(),
-    )
-    monkeypatch.setattr(
-        invoke_route_runner,
-        "_ensure_local_message_headers",
-        fake_ensure_local_message_headers,
     )
     monkeypatch.setattr(
         invoke_route_runner.session_hub_service,
@@ -478,7 +470,10 @@ async def test_persist_stream_block_update_rewrites_when_only_agent_message_id_i
         stream_usage={},
         user_message_id=str(uuid4()),
         agent_message_id=agent_message_id,
-        message_refs=None,
+        message_refs={
+            "user_message_id": str(uuid4()),
+            "agent_message_id": agent_message_id,
+        },
         next_event_seq=1,
         persisted_block_count=0,
     )
@@ -538,18 +533,10 @@ async def test_persist_stream_block_update_inferrs_canonical_artifact_text_witho
     async def fake_commit_safely(_db):
         return None
 
-    async def fake_ensure_local_message_headers(**_kwargs):
-        return None
-
     monkeypatch.setattr(
         invoke_route_runner,
         "AsyncSessionLocal",
         lambda: _DummySessionContext(),
-    )
-    monkeypatch.setattr(
-        invoke_route_runner,
-        "_ensure_local_message_headers",
-        fake_ensure_local_message_headers,
     )
     monkeypatch.setattr(
         invoke_route_runner.session_hub_service,
@@ -567,7 +554,10 @@ async def test_persist_stream_block_update_inferrs_canonical_artifact_text_witho
         stream_usage={},
         user_message_id=str(uuid4()),
         agent_message_id=agent_message_id,
-        message_refs=None,
+        message_refs={
+            "user_message_id": str(uuid4()),
+            "agent_message_id": agent_message_id,
+        },
         next_event_seq=1,
         persisted_block_count=0,
     )

--- a/backend/tests/invoke/test_invoke_route_runner_streaming.py
+++ b/backend/tests/invoke/test_invoke_route_runner_streaming.py
@@ -500,10 +500,13 @@ async def test_persist_stream_block_update_rewrites_when_only_agent_message_id_i
         request=_build_persistence_request(transport="ws"),
     )
 
-    shared_stream = event_payload["artifactUpdate"]["metadata"]["shared"]["stream"]
-    assert shared_stream["messageId"] == agent_message_id
-    assert isinstance(shared_stream.get("eventId"), str)
-    assert shared_stream["seq"] == 1
+    assert event_payload["artifactUpdate"]["artifact"]["metadata"]["shared"][
+        "stream"
+    ] == {"blockType": "text"}
+    local_stream_context = event_payload["__hub_local_stream"]
+    assert local_stream_context["message_id"] == agent_message_id
+    assert isinstance(local_stream_context.get("event_id"), str)
+    assert local_stream_context["seq"] == 1
     updates = captured["updates"]
     assert isinstance(updates, list)
     assert len(updates) == 1
@@ -595,10 +598,14 @@ async def test_persist_stream_block_update_inferrs_canonical_artifact_text_witho
         request=_build_persistence_request(transport="ws"),
     )
 
-    shared_stream = event_payload["artifactUpdate"]["metadata"]["shared"]["stream"]
-    assert shared_stream["messageId"] == agent_message_id
-    assert shared_stream["eventId"] == "stream:4"
-    assert shared_stream["seq"] == 1
+    assert event_payload["artifactUpdate"]["metadata"]["shared"]["stream"] == {
+        "eventId": "stream:4",
+        "seq": 4,
+    }
+    local_stream_context = event_payload["__hub_local_stream"]
+    assert local_stream_context["message_id"] == agent_message_id
+    assert local_stream_context["event_id"] == "stream:4"
+    assert local_stream_context["seq"] == 1
     updates = captured["updates"]
     assert isinstance(updates, list)
     assert len(updates) == 1
@@ -693,10 +700,19 @@ async def test_persist_stream_block_update_consumes_and_persists_optional_fields
     assert state.next_event_seq == 4
     assert state.persisted_block_count == 1
     assert state.chunk_buffer == []
-    shared_stream = event_payload["artifactUpdate"]["metadata"]["shared"]["stream"]
-    assert shared_stream["messageId"] == str(state.message_refs["agent_message_id"])
-    assert shared_stream["eventId"] == "evt-opt"
-    assert shared_stream["seq"] == 3
+    assert event_payload["artifactUpdate"]["artifact"]["metadata"]["shared"][
+        "stream"
+    ] == {
+        "blockType": "text",
+        "messageId": "msg-opt",
+        "eventId": "evt-opt",
+    }
+    local_stream_context = event_payload["__hub_local_stream"]
+    assert local_stream_context["message_id"] == str(
+        state.message_refs["agent_message_id"]
+    )
+    assert local_stream_context["event_id"] == "evt-opt"
+    assert local_stream_context["seq"] == 3
 
 
 @pytest.mark.asyncio
@@ -774,12 +790,15 @@ async def test_persist_stream_block_update_preserves_canonical_message_events(
     assert "message" in event_payload
     assert event_payload["message"]["parts"] == [{"text": "root text"}]
     assert event_payload["message"]["metadata"]["shared"]["stream"] == {
-        "messageId": refs["agent_message_id"],
-        "eventId": f"{refs['agent_message_id']}:5",
-        "seq": 5,
         "blockType": "text",
-        "blockId": "msg-upstream-root:primary_text",
-        "laneId": "primary_text",
+        "op": "replace",
+    }
+    assert event_payload["__hub_local_stream"] == {
+        "message_id": refs["agent_message_id"],
+        "event_id": f"{refs['agent_message_id']}:5",
+        "seq": 5,
+        "block_id": "msg-upstream-root:primary_text",
+        "lane_id": "primary_text",
         "op": "replace",
     }
 
@@ -971,12 +990,17 @@ async def test_persist_stream_block_update_generates_local_event_id_when_missing
     assert len(updates) == 1
     assert updates[0]["event_id"] == expected_event_id
     assert updates[0]["seq"] == 4
-    assert event_payload["artifactUpdate"]["metadata"]["shared"]["stream"] == {
-        "messageId": refs["agent_message_id"],
-        "eventId": expected_event_id,
+    assert event_payload["artifactUpdate"]["artifact"]["metadata"]["shared"][
+        "stream"
+    ] == {
+        "blockType": "text",
+    }
+    assert event_payload["__hub_local_stream"] == {
+        "message_id": refs["agent_message_id"],
+        "event_id": expected_event_id,
         "seq": 4,
-        "blockId": "stream:primary_text",
-        "laneId": "primary_text",
+        "block_id": "stream:primary_text",
+        "lane_id": "primary_text",
         "op": "append",
     }
     assert state.next_event_seq == 5

--- a/backend/tests/invoke/test_invoke_stream_persistence.py
+++ b/backend/tests/invoke/test_invoke_stream_persistence.py
@@ -541,6 +541,105 @@ async def test_persist_stream_block_update_accepts_status_message_content(
 
 
 @pytest.mark.asyncio
+async def test_persist_stream_block_update_accepts_snake_case_stream_hints(
+    async_db_session,
+) -> None:
+    user = await create_user(async_db_session, skip_onboarding_defaults=True)
+    thread = ConversationThread(
+        id=uuid4(),
+        user_id=user.id,
+        source=ConversationThread.SOURCE_MANUAL,
+        title="Snake Case Stream Hints",
+        last_active_at=utc_now(),
+        status=ConversationThread.STATUS_ACTIVE,
+    )
+    async_db_session.add(thread)
+    await async_db_session.flush()
+
+    state = _FakeState(
+        local_session_id=thread.id,
+        local_source="manual",
+        context_id="ctx-stream-snake",
+        metadata={},
+        stream_identity={},
+        stream_usage={},
+        next_event_seq=1,
+    )
+
+    def _session_factory() -> _SessionContext:
+        return _SessionContext(async_db_session)
+
+    async def _commit(_db) -> None:
+        await async_db_session.flush()
+
+    async def _ensure_headers_adapter(**kwargs) -> None:
+        await ensure_local_message_headers(
+            **kwargs,
+            session_factory=_session_factory,
+            commit_fn=_commit,
+            session_hub=session_hub_service,
+        )
+
+    event_payload = {
+        "artifactUpdate": {
+            "artifact": {
+                "parts": [{"text": "thinking"}],
+                "metadata": {
+                    "shared": {
+                        "stream": {
+                            "block_type": "reasoning",
+                            "message_id": "msg-stream-snake-1",
+                            "event_id": "evt-stream-snake-1",
+                            "sequence": 1,
+                            "op": "append",
+                            "source": "reasoning_part_update",
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    await persist_stream_block_update(
+        state=state,
+        event_payload=event_payload,
+        request=_build_request(user_id=user.id),
+        session_factory=_session_factory,
+        commit_fn=_commit,
+        session_hub=session_hub_service,
+        ensure_headers_fn=_ensure_headers_adapter,
+    )
+
+    await flush_stream_buffer(
+        state=state,
+        user_id=user.id,
+        session_factory=_session_factory,
+        commit_fn=_commit,
+        session_hub=session_hub_service,
+    )
+
+    agent_message = await async_db_session.scalar(
+        select(AgentMessage).where(
+            AgentMessage.conversation_id == thread.id,
+            AgentMessage.sender == "agent",
+        )
+    )
+    assert agent_message is not None
+
+    persisted_blocks = list(
+        (
+            await async_db_session.scalars(
+                select(AgentMessageBlock)
+                .where(AgentMessageBlock.message_id == agent_message.id)
+                .order_by(AgentMessageBlock.block_seq.asc())
+            )
+        ).all()
+    )
+    assert [block.block_type for block in persisted_blocks] == ["reasoning"]
+    assert persisted_blocks[0].content == "thinking"
+
+
+@pytest.mark.asyncio
 async def test_persist_local_outcome_keeps_typed_blocks_when_upstream_reuses_artifact_id(
     async_db_session,
 ) -> None:

--- a/backend/tests/invoke/test_invoke_stream_persistence.py
+++ b/backend/tests/invoke/test_invoke_stream_persistence.py
@@ -9,10 +9,10 @@ from app.db.models.agent_message import AgentMessage
 from app.db.models.agent_message_block import AgentMessageBlock
 from app.db.models.conversation_thread import ConversationThread
 from app.db.models.conversation_upstream_task import ConversationUpstreamTask
+from app.features.invoke.hub_stream_local_context import attach_local_stream_context
 from app.features.invoke.service_types import StreamFinishReason, StreamOutcome
 from app.features.invoke.stream_persistence import (
     InvokePersistenceRequest,
-    attach_local_stream_contract_context,
     build_stream_metadata_from_outcome,
     ensure_local_message_headers,
     flush_stream_buffer,
@@ -92,14 +92,14 @@ def test_build_stream_metadata_from_outcome_keeps_identity_and_usage() -> None:
     }
 
 
-def test_attach_local_stream_contract_context_stores_internal_overlay() -> None:
+def test_attach_local_stream_context_stores_internal_overlay() -> None:
     payload = {
         "artifactUpdate": {
             "artifact": {"metadata": {}, "parts": [{"text": "draft"}]},
         }
     }
 
-    attach_local_stream_contract_context(
+    attach_local_stream_context(
         payload,
         local_message_id="msg-local-1",
         event_id="evt-local-1",

--- a/backend/tests/invoke/test_invoke_stream_persistence.py
+++ b/backend/tests/invoke/test_invoke_stream_persistence.py
@@ -12,13 +12,13 @@ from app.db.models.conversation_upstream_task import ConversationUpstreamTask
 from app.features.invoke.service_types import StreamFinishReason, StreamOutcome
 from app.features.invoke.stream_persistence import (
     InvokePersistenceRequest,
+    attach_local_stream_contract_context,
     build_stream_metadata_from_outcome,
     ensure_local_message_headers,
     flush_stream_buffer,
     persist_local_outcome,
     persist_stream_block_update,
     resolve_invoke_idempotency_key,
-    rewrite_stream_event_contract,
 )
 from app.features.sessions.service import session_hub_service
 from app.utils.idempotency_key import IDEMPOTENCY_KEY_MAX_LENGTH
@@ -92,14 +92,14 @@ def test_build_stream_metadata_from_outcome_keeps_identity_and_usage() -> None:
     }
 
 
-def test_rewrite_stream_event_contract_copies_canonical_block_fields() -> None:
+def test_attach_local_stream_contract_context_stores_internal_overlay() -> None:
     payload = {
         "artifactUpdate": {
             "artifact": {"metadata": {}, "parts": [{"text": "draft"}]},
         }
     }
 
-    rewrite_stream_event_contract(
+    attach_local_stream_contract_context(
         payload,
         local_message_id="msg-local-1",
         event_id="evt-local-1",
@@ -112,14 +112,17 @@ def test_rewrite_stream_event_contract_copies_canonical_block_fields() -> None:
         },
     )
 
-    assert payload["artifactUpdate"]["metadata"]["shared"]["stream"] == {
-        "messageId": "msg-local-1",
-        "eventId": "evt-local-1",
+    assert payload["artifactUpdate"] == {
+        "artifact": {"metadata": {}, "parts": [{"text": "draft"}]},
+    }
+    assert payload["__hub_local_stream"] == {
+        "message_id": "msg-local-1",
+        "event_id": "evt-local-1",
         "seq": 7,
-        "blockId": "block-text-main",
-        "laneId": "primary_text",
+        "block_id": "block-text-main",
+        "lane_id": "primary_text",
         "op": "replace",
-        "baseSeq": 6,
+        "base_seq": 6,
     }
 
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -119,7 +119,7 @@ Message id contract:
 - Structured command results may be persisted as `data` blocks and should render as first-class canonical history blocks rather than overlay text fallbacks.
 - `blocks:query` detail items include `messageId` and must match the target message before cache patching.
 - `tool_call` blocks may include a normalized `toolCall` view from backend (`name`, `status`, `callId`, `arguments`, `result`, `error`); frontend should render that stable field instead of parsing provider-private raw payloads.
-- Upstream A2A stream wrappers are consumed via canonical `messageId` / `eventId` / `seq` metadata only; the hub then emits stable local `message_id` / `event_id` / `seq` identities for frontend state and duplicate suppression.
+- Frontend stream rendering reads only the backend `hub` envelope (`hub.version`, `hub.streamBlock`, `hub.runtimeStatus`, `hub.sessionMeta`); upstream A2A `artifactUpdate` / `statusUpdate` payloads remain available for diagnostics but are no longer parsed on the client.
 - Invoke payloads should carry both `userMessageId` and `agentMessageId` (UUID).
 - Message status semantics are preserved from history payloads (`streaming`, `done`, `error`, `interrupted`).
 - The Hub Assistant is injected into the normal agent catalog and reuses the existing permission interrupt card: read-only runs can return a `permission` interrupt, and the same UI resolves it through the dedicated hub-assistant reply endpoint.

--- a/frontend/lib/__tests__/streamBlockOperationContract.test.ts
+++ b/frontend/lib/__tests__/streamBlockOperationContract.test.ts
@@ -7,8 +7,39 @@ const canonicalCases =
     expected: Record<string, unknown>;
   }[];
 
-const normalizeParsedUpdate = (payload: Record<string, unknown>) => {
-  const parsed = extractStreamBlockUpdate(payload);
+const normalizeParsedUpdate = (
+  payload: Record<string, unknown>,
+  expected: Record<string, unknown>,
+) => {
+  const parsed = extractStreamBlockUpdate({
+    ...payload,
+    hub: {
+      version: "v1",
+      eventKind: "artifact-update",
+      streamBlock: {
+        eventId: expected.eventId,
+        eventIdSource: "upstream",
+        messageIdSource: "upstream",
+        seq: expected.seq,
+        taskId:
+          typeof expected.artifactId === "string"
+            ? expected.artifactId.split(":")[0]
+            : "task-1",
+        artifactId: expected.artifactId,
+        blockId: expected.blockId,
+        laneId: expected.laneId,
+        blockType: expected.blockType,
+        op: expected.op,
+        baseSeq: expected.baseSeq,
+        source: expected.source,
+        messageId: expected.messageId,
+        role: "agent",
+        delta: expected.content,
+        append: expected.op === "append",
+        done: expected.isFinished,
+      },
+    },
+  });
   expect(parsed).not.toBeNull();
   return {
     eventId: parsed?.eventId ?? null,
@@ -29,9 +60,9 @@ const normalizeParsedUpdate = (payload: Record<string, unknown>) => {
 describe("stream block operation contract", () => {
   it("matches the shared canonical cases", () => {
     canonicalCases.forEach((testCase) => {
-      expect(normalizeParsedUpdate(testCase.payload)).toEqual(
-        testCase.expected,
-      );
+      expect(
+        normalizeParsedUpdate(testCase.payload, testCase.expected),
+      ).toEqual(testCase.expected);
     });
   });
 });

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -1646,6 +1646,27 @@ describe("block-based stream parser and reducer", () => {
     expect(parsed?.eventIdSource).toBe("fallback_seq");
   });
 
+  it("accepts local persistence identity sources from hub stream blocks", () => {
+    const payload = buildBlockUpdatePayload({
+      blockType: "text",
+      delta: "hello",
+      artifactId: "task-1:stream",
+    }) as Record<string, unknown>;
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).messageIdSource = "local_persistence";
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).eventIdSource = "local_persistence";
+
+    const parsed = extractStreamBlockUpdate(payload);
+
+    expect(parsed?.messageIdSource).toBe("local_persistence");
+    expect(parsed?.eventIdSource).toBe("local_persistence");
+  });
+
   it("accepts chunks using camelCase message/event fields", () => {
     const payload = withHubStreamBlock(
       {

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -58,21 +58,48 @@ const buildBlockUpdatePayload = (input: {
   laneId?: string;
   op?: "append" | "replace" | "finalize";
   baseSeq?: number;
+  useSnakeCaseStreamHints?: boolean;
 }) => {
+  const streamIdentity = input.useSnakeCaseStreamHints
+    ? {
+        ...(input.messageId !== undefined
+          ? { message_id: input.messageId }
+          : { message_id: "msg-1" }),
+        ...(input.eventId !== undefined
+          ? { event_id: input.eventId }
+          : { event_id: "evt-1" }),
+        ...(input.seq !== undefined ? { sequence: input.seq } : {}),
+        block_type: input.blockType,
+      }
+    : {
+        ...(input.messageId !== undefined
+          ? { messageId: input.messageId }
+          : { messageId: "msg-1" }),
+        ...(input.eventId !== undefined
+          ? { eventId: input.eventId }
+          : { eventId: "evt-1" }),
+        ...(input.seq !== undefined ? { seq: input.seq } : {}),
+      };
   const artifactMetadata: Record<string, unknown> = {
-    blockType: input.blockType,
-    op: input.op ?? (input.append === false ? "replace" : "append"),
     source: input.source ?? "stream",
   };
+  if (!input.useSnakeCaseStreamHints) {
+    artifactMetadata.blockType = input.blockType;
+  }
   if (input.blockId !== undefined) {
-    artifactMetadata.blockId = input.blockId;
+    artifactMetadata[input.useSnakeCaseStreamHints ? "block_id" : "blockId"] =
+      input.blockId;
   }
   if (input.laneId !== undefined) {
-    artifactMetadata.laneId = input.laneId;
+    artifactMetadata[input.useSnakeCaseStreamHints ? "lane_id" : "laneId"] =
+      input.laneId;
   }
   if (input.baseSeq !== undefined) {
-    artifactMetadata.baseSeq = input.baseSeq;
+    artifactMetadata[input.useSnakeCaseStreamHints ? "base_seq" : "baseSeq"] =
+      input.baseSeq;
   }
+  artifactMetadata.op =
+    input.op ?? (input.append === false ? "replace" : "append");
   const payload: Record<string, unknown> = {
     artifactUpdate: {
       append: input.append ?? true,
@@ -84,15 +111,7 @@ const buildBlockUpdatePayload = (input: {
         metadata: {
           ...artifactMetadata,
           shared: {
-            stream: {
-              ...(input.messageId !== undefined
-                ? { messageId: input.messageId }
-                : { messageId: "msg-1" }),
-              ...(input.eventId !== undefined
-                ? { eventId: input.eventId }
-                : { eventId: "evt-1" }),
-              ...(input.seq !== undefined ? { seq: input.seq } : {}),
-            },
+            stream: streamIdentity,
           },
         },
       },
@@ -198,6 +217,25 @@ describe("block-based stream parser and reducer", () => {
     expect(blocks).toHaveLength(2);
     expect(blocks?.[0]?.type).toBe("reasoning");
     expect(blocks?.[1]?.type).toBe("text");
+  });
+
+  it("parses snake_case stream-hints fields from shared stream metadata", () => {
+    const parsed = mustParse(
+      buildBlockUpdatePayload({
+        blockType: "reasoning",
+        delta: "thinking",
+        artifactId: "task-1:stream:reasoning",
+        messageId: "msg-snake-1",
+        eventId: "evt-snake-1",
+        seq: 9,
+        useSnakeCaseStreamHints: true,
+      }),
+    );
+
+    expect(parsed.blockType).toBe("reasoning");
+    expect(parsed.messageId).toBe("msg-snake-1");
+    expect(parsed.eventId).toBe("evt-snake-1");
+    expect(parsed.seq).toBe(9);
   });
 
   it("projects only text blocks into message content", () => {

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_RUNTIME_STATUS_CONTRACT,
   applyLoadedBlockDetail,
   applyStreamBlockUpdate,
   buildInterruptEventBlockUpdate,
@@ -6,6 +7,7 @@ import {
   extractRuntimeStatusEvent,
   extractStreamBlockUpdate,
   finalizeMessageBlocks,
+  normalizeRuntimeState,
   projectPrimaryTextContent,
   type MessageBlock,
   type StreamBlockUpdate,
@@ -25,21 +27,246 @@ const buildStatusUpdatePayload = (input: {
   messageId?: string;
   completionPhase?: string;
   interrupt?: Record<string, unknown>;
-}) => ({
-  statusUpdate: {
-    status: { state: input.state },
-    metadata: {
-      shared: {
-        ...(input.interrupt ? { interrupt: input.interrupt } : {}),
-        stream: {
-          ...(input.seq !== undefined ? { seq: input.seq } : {}),
-          ...(input.messageId ? { messageId: input.messageId } : {}),
-          ...(input.completionPhase
-            ? { completionPhase: input.completionPhase }
-            : {}),
+}) => {
+  const canonicalInterrupt = buildCanonicalInterrupt(input.interrupt);
+  return {
+    statusUpdate: {
+      status: { state: input.state },
+      metadata: {
+        shared: {
+          ...(input.interrupt ? { interrupt: input.interrupt } : {}),
+          stream: {
+            ...(input.seq !== undefined ? { seq: input.seq } : {}),
+            ...(input.messageId ? { messageId: input.messageId } : {}),
+            ...(input.completionPhase
+              ? { completionPhase: input.completionPhase }
+              : {}),
+          },
         },
       },
     },
+    hub: {
+      version: "v1",
+      eventKind: "status-update",
+      runtimeStatus: {
+        state: normalizeRuntimeState(input.state),
+        isFinal: DEFAULT_RUNTIME_STATUS_CONTRACT.terminalStates
+          .map((item) => normalizeRuntimeState(item))
+          .includes(normalizeRuntimeState(input.state)),
+        interrupt: canonicalInterrupt,
+        seq: input.seq ?? null,
+        completionPhase:
+          input.completionPhase?.trim().toLowerCase() === "persisted"
+            ? "persisted"
+            : null,
+        messageId: input.messageId ?? null,
+      },
+    },
+  };
+};
+
+const buildToolCallViewFromDelta = (delta: string | undefined) => {
+  if (!delta) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(delta) as Record<string, unknown>;
+    const status = typeof parsed.status === "string" ? parsed.status : null;
+    if (!status) {
+      return null;
+    }
+    return {
+      name:
+        typeof parsed.name === "string"
+          ? parsed.name
+          : typeof parsed.tool === "string"
+            ? parsed.tool
+            : null,
+      status,
+      callId:
+        typeof parsed.callId === "string"
+          ? parsed.callId
+          : typeof parsed.call_id === "string"
+            ? parsed.call_id
+            : null,
+      arguments: parsed.arguments ?? parsed.input ?? null,
+      result: parsed.result ?? parsed.output ?? null,
+      error: parsed.error ?? null,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const pickDisplayMessage = (
+  details: Record<string, unknown> | null | undefined,
+): string | null =>
+  (typeof details?.displayMessage === "string" && details.displayMessage) ||
+  (typeof details?.display_message === "string" && details.display_message) ||
+  (typeof details?.description === "string" && details.description) ||
+  (typeof (details?.request as { description?: unknown } | undefined)
+    ?.description === "string" &&
+    (details?.request as { description: string }).description) ||
+  null;
+
+const buildCanonicalInterrupt = (
+  interrupt?: Record<string, unknown>,
+): Record<string, unknown> | null => {
+  if (!interrupt) {
+    return null;
+  }
+  const requestId =
+    typeof interrupt.requestId === "string" ? interrupt.requestId : null;
+  const type = typeof interrupt.type === "string" ? interrupt.type : null;
+  if (!requestId || !type) {
+    return null;
+  }
+  const phase =
+    typeof interrupt.phase === "string"
+      ? interrupt.phase.toLowerCase()
+      : "asked";
+  if (phase === "resolved") {
+    return {
+      requestId,
+      type,
+      phase: "resolved",
+      resolution:
+        typeof interrupt.resolution === "string"
+          ? interrupt.resolution
+          : "replied",
+      source: "stream",
+    };
+  }
+  const details =
+    interrupt.details && typeof interrupt.details === "object"
+      ? (interrupt.details as Record<string, unknown>)
+      : null;
+  if (type === "permission") {
+    return {
+      requestId,
+      type,
+      phase: "asked",
+      source: "stream",
+      details: {
+        permission:
+          typeof details?.permission === "string" ? details.permission : null,
+        patterns: Array.isArray(details?.patterns) ? details.patterns : [],
+        displayMessage: pickDisplayMessage(details),
+      },
+    };
+  }
+  if (type === "permissions") {
+    return {
+      requestId,
+      type,
+      phase: "asked",
+      source: "stream",
+      details: {
+        permissions:
+          details?.permissions && typeof details.permissions === "object"
+            ? details.permissions
+            : null,
+        displayMessage: pickDisplayMessage(details),
+      },
+    };
+  }
+  if (type === "elicitation") {
+    return {
+      requestId,
+      type,
+      phase: "asked",
+      source: "stream",
+      details: {
+        displayMessage: pickDisplayMessage(details),
+        serverName:
+          typeof details?.serverName === "string" ? details.serverName : null,
+        mode: typeof details?.mode === "string" ? details.mode : null,
+        requestedSchema: details?.requestedSchema ?? null,
+        url: typeof details?.url === "string" ? details.url : null,
+        elicitationId:
+          typeof details?.elicitationId === "string"
+            ? details.elicitationId
+            : null,
+        meta:
+          details?.meta && typeof details.meta === "object"
+            ? details.meta
+            : null,
+      },
+    };
+  }
+  const rawQuestions =
+    Array.isArray(details?.questions) && details?.questions
+      ? details.questions
+      : [];
+  return {
+    requestId,
+    type: "question",
+    phase: "asked",
+    source: "stream",
+    details: {
+      displayMessage: pickDisplayMessage(details),
+      questions: rawQuestions.map((question) => {
+        const record =
+          question && typeof question === "object"
+            ? (question as Record<string, unknown>)
+            : {};
+        const options = Array.isArray(record.options) ? record.options : [];
+        return {
+          header:
+            typeof record.header === "string"
+              ? record.header
+              : typeof record.title === "string"
+                ? record.title
+                : null,
+          question:
+            typeof record.question === "string"
+              ? record.question
+              : typeof record.prompt === "string"
+                ? record.prompt
+                : typeof record.message === "string"
+                  ? record.message
+                  : "",
+          description:
+            typeof record.description === "string" ? record.description : null,
+          options: options.map((option) => {
+            const optionRecord =
+              option && typeof option === "object"
+                ? (option as Record<string, unknown>)
+                : {};
+            return {
+              label:
+                typeof optionRecord.label === "string"
+                  ? optionRecord.label
+                  : "",
+              value:
+                typeof optionRecord.value === "string"
+                  ? optionRecord.value
+                  : null,
+              description:
+                typeof optionRecord.description === "string"
+                  ? optionRecord.description
+                  : null,
+            };
+          }),
+        };
+      }),
+    },
+  };
+};
+
+const withHubStreamBlock = (
+  payload: Record<string, unknown>,
+  streamBlock: Record<string, unknown>,
+  eventKind:
+    | "artifact-update"
+    | "message"
+    | "status-update" = "artifact-update",
+) => ({
+  ...payload,
+  hub: {
+    version: "v1",
+    eventKind,
+    streamBlock,
   },
 });
 
@@ -115,6 +342,38 @@ const buildBlockUpdatePayload = (input: {
           },
         },
       },
+    },
+  };
+  const laneId =
+    input.laneId ??
+    (input.blockType === "text" ? "primary_text" : input.blockType);
+  const messageId = input.messageId ?? "msg-1";
+  payload.hub = {
+    version: "v1",
+    eventKind: "artifact-update",
+    streamBlock: {
+      eventId: input.eventId ?? "evt-1",
+      eventIdSource: "upstream",
+      messageIdSource: "upstream",
+      seq: input.seq ?? null,
+      taskId: input.taskId ?? "task-1",
+      artifactId: input.artifactId,
+      blockId: input.blockId ?? `${messageId}:${laneId}`,
+      laneId,
+      blockType: input.blockType,
+      op: input.op ?? (input.append === false ? "replace" : "append"),
+      baseSeq: input.baseSeq ?? null,
+      source: input.source ?? "stream",
+      messageId,
+      role: "agent",
+      delta: input.delta ?? "",
+      append:
+        input.append ?? !(input.op === "replace" || input.op === "finalize"),
+      done: input.lastChunk ?? input.op === "finalize",
+      toolCall:
+        input.blockType === "tool_call"
+          ? buildToolCallViewFromDelta(input.delta)
+          : null,
     },
   };
   return payload;
@@ -897,75 +1156,119 @@ describe("block-based stream parser and reducer", () => {
   });
 
   it("parses blockType from canonical metadata", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        taskId: "task-9",
-        artifact: {
-          artifactId: "task-9:stream",
-          parts: [{ text: "hello" }],
-          metadata: {
-            blockType: "text",
-            op: "append",
-            shared: {
-              stream: {
-                messageId: "msg-9",
-                eventId: "evt-9",
-                seq: 9,
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            taskId: "task-9",
+            artifact: {
+              artifactId: "task-9:stream",
+              parts: [{ text: "hello" }],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-9",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: 9,
+          taskId: "task-9",
+          artifactId: "task-9:stream",
+          blockId: "msg-9:primary_text",
+          laneId: "primary_text",
+          blockType: "text",
+          op: "append",
+          baseSeq: null,
+          source: null,
+          messageId: "msg-9",
+          role: "agent",
+          delta: "hello",
+          append: true,
+          done: false,
+        },
+      ),
+    );
     expect(parsed?.blockType).toBe("text");
     expect(parsed?.eventIdSource).toBe("upstream");
   });
 
   it("prefers standard metadata.blockType", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        taskId: "task-9",
-        artifact: {
-          artifactId: "task-9:stream",
-          parts: [{ text: "thinking" }],
-          metadata: {
-            blockType: "reasoning",
-            op: "append",
-            shared: {
-              stream: {
-                messageId: "msg-9",
-                eventId: "evt-9",
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            taskId: "task-9",
+            artifact: {
+              artifactId: "task-9:stream",
+              parts: [{ text: "thinking" }],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-9",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: null,
+          taskId: "task-9",
+          artifactId: "task-9:stream",
+          blockId: "msg-9:reasoning",
+          laneId: "reasoning",
+          blockType: "reasoning",
+          op: "append",
+          baseSeq: null,
+          source: null,
+          messageId: "msg-9",
+          role: "agent",
+          delta: "thinking",
+          append: true,
+          done: false,
+        },
+      ),
+    );
     expect(parsed?.blockType).toBe("reasoning");
   });
 
   it("prefers shared.stream metadata for tool_call blocks carried in text parts", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        taskId: "task-10",
-        artifact: {
-          artifactId: "task-10:stream",
-          parts: [{ text: '{"tool":"bash","status":"running"}' }],
-          metadata: {
-            shared: {
-              stream: {
-                blockType: "tool_call",
-                op: "append",
-                source: "tool_part_update",
-                messageId: "msg-shared",
-                eventId: "evt-shared",
-                seq: 10,
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            taskId: "task-10",
+            artifact: {
+              artifactId: "task-10:stream",
+              parts: [{ text: '{"tool":"bash","status":"running"}' }],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-shared",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: 10,
+          taskId: "task-10",
+          artifactId: "task-10:stream",
+          blockId: "msg-shared:tool_call",
+          laneId: "tool_call",
+          blockType: "tool_call",
+          op: "append",
+          baseSeq: null,
+          source: "tool_part_update",
+          messageId: "msg-shared",
+          role: "agent",
+          delta: '{"tool":"bash","status":"running"}',
+          append: true,
+          done: false,
+          toolCall: {
+            name: "bash",
+            status: "running",
+            callId: null,
+            arguments: null,
+            result: null,
+            error: null,
+          },
+        },
+      ),
+    );
     expect(parsed?.blockType).toBe("tool_call");
     expect(parsed?.messageId).toBe("msg-shared");
     expect(parsed?.eventId).toBe("evt-shared");
@@ -974,31 +1277,38 @@ describe("block-based stream parser and reducer", () => {
   });
 
   it("parses interrupt_event blocks carried in artifact metadata", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        append: false,
-        artifact: {
-          artifactId: "artifact-interrupt-2",
-          parts: [
-            {
-              text: "Agent requested additional input: Proceed?",
-            },
-          ],
-          metadata: {
-            blockType: "interrupt_event",
-            op: "replace",
-            source: "interrupt_lifecycle",
-            shared: {
-              stream: {
-                messageId: "msg-interrupt-2",
-                eventId: "evt-interrupt-2",
-                seq: 8,
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            append: false,
+            artifact: {
+              artifactId: "artifact-interrupt-2",
+              parts: [{ text: "Agent requested additional input: Proceed?" }],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-interrupt-2",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: 8,
+          taskId: "artifact-interrupt-2",
+          artifactId: "artifact-interrupt-2",
+          blockId: "msg-interrupt-2:interrupt_event",
+          laneId: "interrupt_event",
+          blockType: "interrupt_event",
+          op: "replace",
+          baseSeq: null,
+          source: "interrupt_lifecycle",
+          messageId: "msg-interrupt-2",
+          role: "agent",
+          delta: "Agent requested additional input: Proceed?",
+          append: false,
+          done: false,
+        },
+      ),
+    );
 
     expect(parsed).toMatchObject({
       blockType: "interrupt_event",
@@ -1011,42 +1321,54 @@ describe("block-based stream parser and reducer", () => {
   });
 
   it("parses tool_call blocks carried in data parts", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        taskId: "task-10",
-        toolCall: {
-          name: "read",
-          status: "running",
-          callId: "call-1",
-          arguments: {},
-        },
-        artifact: {
-          artifactId: "task-10:stream",
-          parts: [
-            {
-              data: {
-                call_id: "call-1",
-                tool: "read",
-                status: "pending",
-                input: {},
-              },
-            },
-          ],
-          metadata: {
-            shared: {
-              stream: {
-                blockType: "tool_call",
-                op: "append",
-                source: "tool_part_update",
-                messageId: "msg-data",
-                eventId: "evt-data",
-                seq: 11,
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            taskId: "task-10",
+            artifact: {
+              artifactId: "task-10:stream",
+              parts: [
+                {
+                  data: {
+                    call_id: "call-1",
+                    tool: "read",
+                    status: "pending",
+                    input: {},
+                  },
+                },
+              ],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-data",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: 11,
+          taskId: "task-10",
+          artifactId: "task-10:stream",
+          blockId: "msg-data:tool_call",
+          laneId: "tool_call",
+          blockType: "tool_call",
+          op: "append",
+          baseSeq: null,
+          source: "tool_part_update",
+          messageId: "msg-data",
+          role: "agent",
+          delta:
+            '{"call_id":"call-1","input":{},"status":"pending","tool":"read"}',
+          append: true,
+          done: false,
+          toolCall: {
+            name: "read",
+            status: "running",
+            callId: "call-1",
+            arguments: {},
+          },
+        },
+      ),
+    );
     expect(parsed?.blockType).toBe("tool_call");
     expect(parsed?.delta).toBe(
       '{"call_id":"call-1","input":{},"status":"pending","tool":"read"}',
@@ -1065,45 +1387,78 @@ describe("block-based stream parser and reducer", () => {
   });
 
   it("infers text block type for canonical message wrappers", () => {
-    const parsed = extractStreamBlockUpdate({
-      message: {
-        role: "ROLE_AGENT",
-        parts: [{ text: "hello" }],
-        metadata: {
-          shared: {
-            stream: {
-              messageId: "msg-message-9",
-              eventId: "evt-message-9",
-            },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          message: {
+            role: "ROLE_AGENT",
+            parts: [{ text: "hello" }],
           },
         },
-      },
-    });
+        {
+          eventId: "evt-message-9",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: null,
+          taskId: "msg-message-9",
+          artifactId: "msg-message-9:text",
+          blockId: "msg-message-9:primary_text",
+          laneId: "primary_text",
+          blockType: "text",
+          op: "replace",
+          baseSeq: null,
+          source: null,
+          messageId: "msg-message-9",
+          role: "agent",
+          delta: "hello",
+          append: false,
+          done: false,
+        },
+        "message",
+      ),
+    );
     expect(parsed?.blockType).toBe("text");
     expect(parsed?.messageId).toBe("msg-message-9");
   });
 
   it("infers text block type for status-update message wrappers", () => {
-    const parsed = extractStreamBlockUpdate({
-      statusUpdate: {
-        status: {
-          state: "TASK_STATE_WORKING",
-          message: {
-            messageId: "msg-status-9",
-            taskId: "task-status-9",
-            role: "ROLE_AGENT",
-            parts: [{ text: "hello from status message" }],
-          },
-        },
-        metadata: {
-          shared: {
-            stream: {
-              eventId: "evt-status-9",
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          statusUpdate: {
+            status: {
+              state: "TASK_STATE_WORKING",
+              message: {
+                messageId: "msg-status-9",
+                taskId: "task-status-9",
+                role: "ROLE_AGENT",
+                parts: [{ text: "hello from status message" }],
+              },
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-status-9",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: null,
+          taskId: "task-status-9",
+          artifactId: "msg-status-9:text",
+          blockId: "msg-status-9:primary_text",
+          laneId: "primary_text",
+          blockType: "text",
+          op: "replace",
+          baseSeq: null,
+          source: null,
+          messageId: "msg-status-9",
+          role: "agent",
+          delta: "hello from status message",
+          append: false,
+          done: false,
+        },
+        "status-update",
+      ),
+    );
     expect(parsed?.blockType).toBe("text");
     expect(parsed?.messageId).toBe("msg-status-9");
     expect(parsed?.taskId).toBe("task-status-9");
@@ -1112,48 +1467,74 @@ describe("block-based stream parser and reducer", () => {
   });
 
   it("parses chunk when taskId is missing but messageId exists", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        artifact: {
-          artifactId: "stream-1",
-          parts: [{ text: "hello" }],
-          metadata: {
-            shared: {
-              stream: {
-                blockType: "text",
-                op: "append",
-                messageId: "msg-only-1",
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            artifact: {
+              artifactId: "stream-1",
+              parts: [{ text: "hello" }],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "chunk:msg-only-1:stream-1",
+          eventIdSource: "fallback_chunk",
+          messageIdSource: "upstream",
+          seq: null,
+          taskId: "msg-only-1",
+          artifactId: "stream-1",
+          blockId: "msg-only-1:primary_text",
+          laneId: "primary_text",
+          blockType: "text",
+          op: "append",
+          baseSeq: null,
+          source: null,
+          messageId: "msg-only-1",
+          role: "agent",
+          delta: "hello",
+          append: true,
+          done: false,
+        },
+      ),
+    );
     expect(parsed?.messageId).toBe("msg-only-1");
     expect(parsed?.taskId).toBe("msg-only-1");
   });
 
   it("ignores unsupported blockType values", () => {
-    const parsed = extractStreamBlockUpdate({
-      artifactUpdate: {
-        taskId: "task-8",
-        artifact: {
-          artifactId: "task-8:stream",
-          parts: [{ text: "noop" }],
-          metadata: {
-            blockType: "custom_phase",
-            op: "append",
-            shared: {
-              stream: {
-                messageId: "msg-8",
-                eventId: "evt-8",
-                seq: 8,
-              },
+    const parsed = extractStreamBlockUpdate(
+      withHubStreamBlock(
+        {
+          artifactUpdate: {
+            taskId: "task-8",
+            artifact: {
+              artifactId: "task-8:stream",
+              parts: [{ text: "noop" }],
             },
           },
         },
-      },
-    });
+        {
+          eventId: "evt-8",
+          eventIdSource: "upstream",
+          messageIdSource: "upstream",
+          seq: 8,
+          taskId: "task-8",
+          artifactId: "task-8:stream",
+          blockId: "msg-8:custom_phase",
+          laneId: "custom_phase",
+          blockType: "custom_phase",
+          op: "append",
+          baseSeq: null,
+          source: null,
+          messageId: "msg-8",
+          role: "agent",
+          delta: "noop",
+          append: true,
+          done: false,
+        },
+      ),
+    );
     expect(parsed).toBeNull();
   });
 
@@ -1171,32 +1552,61 @@ describe("block-based stream parser and reducer", () => {
         };
       }
     ).artifact?.metadata?.shared?.stream?.messageId;
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).messageId = "task:task-1";
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).messageIdSource = "task_fallback";
     const parsed = extractStreamBlockUpdate(payload);
     expect(parsed?.messageId).toBe("task:task-1");
     expect(parsed?.messageIdSource).toBe("task_fallback");
   });
 
   it("accepts raw A2A artifact text chunks without custom block metadata", () => {
-    const payload = {
-      artifactUpdate: {
-        taskId: "task-raw-1",
-        contextId: "ctx-raw-1",
-        append: true,
-        lastChunk: false,
-        artifact: {
-          artifactId: "task-raw-1:stream:text",
-          parts: [{ text: "Code" }],
-        },
-        metadata: {
-          shared: {
-            stream: {
-              seq: 4,
-              eventId: "stream:4",
+    const payload = withHubStreamBlock(
+      {
+        artifactUpdate: {
+          taskId: "task-raw-1",
+          contextId: "ctx-raw-1",
+          append: true,
+          lastChunk: false,
+          artifact: {
+            artifactId: "task-raw-1:stream:text",
+            parts: [{ text: "Code" }],
+          },
+          metadata: {
+            shared: {
+              stream: {
+                seq: 4,
+                eventId: "stream:4",
+              },
             },
           },
         },
       },
-    };
+      {
+        eventId: "stream:4",
+        eventIdSource: "upstream",
+        messageIdSource: "task_fallback",
+        seq: 4,
+        taskId: "task-raw-1",
+        artifactId: "task-raw-1:stream:text",
+        blockId: "task:task-raw-1:primary_text",
+        laneId: "primary_text",
+        blockType: "text",
+        op: "append",
+        baseSeq: null,
+        source: null,
+        messageId: "task:task-raw-1",
+        role: "agent",
+        delta: "Code",
+        append: true,
+        done: false,
+      },
+    );
 
     const parsed = extractStreamBlockUpdate(payload);
 
@@ -1223,31 +1633,50 @@ describe("block-based stream parser and reducer", () => {
         };
       }
     ).artifact?.metadata?.shared?.stream?.eventId;
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).eventId = "seq:msg-1:7";
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).eventIdSource = "fallback_seq";
     const parsed = extractStreamBlockUpdate(payload);
     expect(parsed?.eventId).toBe("seq:msg-1:7");
     expect(parsed?.eventIdSource).toBe("fallback_seq");
   });
 
   it("accepts chunks using camelCase message/event fields", () => {
-    const payload = {
-      artifactUpdate: {
-        taskId: "task-1",
-        artifact: {
-          artifactId: "task-1:stream",
-          parts: [{ text: "hello" }],
-          metadata: {
-            blockType: "text",
-            op: "append",
-            shared: {
-              stream: {
-                messageId: "msg-camel",
-                eventId: "evt-camel",
-              },
-            },
+    const payload = withHubStreamBlock(
+      {
+        artifactUpdate: {
+          taskId: "task-1",
+          artifact: {
+            artifactId: "task-1:stream",
+            parts: [{ text: "hello" }],
           },
         },
       },
-    };
+      {
+        eventId: "evt-camel",
+        eventIdSource: "upstream",
+        messageIdSource: "upstream",
+        seq: null,
+        taskId: "task-1",
+        artifactId: "task-1:stream",
+        blockId: "msg-camel:primary_text",
+        laneId: "primary_text",
+        blockType: "text",
+        op: "append",
+        baseSeq: null,
+        source: null,
+        messageId: "msg-camel",
+        role: "agent",
+        delta: "hello",
+        append: true,
+        done: false,
+      },
+    );
     const parsed = extractStreamBlockUpdate(payload);
     expect(parsed?.messageId).toBe("msg-camel");
     expect(parsed?.eventId).toBe("evt-camel");
@@ -1280,6 +1709,14 @@ describe("block-based stream parser and reducer", () => {
         };
       }
     ).artifact?.metadata?.shared?.stream?.eventId;
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).eventId = "chunk:msg-1:task-1:stream";
+    (
+      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+        {}) as Record<string, unknown>
+    ).eventIdSource = "fallback_chunk";
     const parsed = extractStreamBlockUpdate(payload);
     expect(parsed?.seq).toBeNull();
     expect(parsed?.eventId).toBe("chunk:msg-1:task-1:stream");
@@ -1546,14 +1983,12 @@ describe("block-based stream parser and reducer", () => {
 
   it("extracts external session from canonical shared session metadata", () => {
     const meta = extractSessionMeta({
-      statusUpdate: {
-        metadata: {
-          shared: {
-            session: {
-              provider: "opencode",
-              id: "ses_upstream_1",
-            },
-          },
+      hub: {
+        version: "v1",
+        eventKind: "status-update",
+        sessionMeta: {
+          provider: "opencode",
+          externalSessionId: "ses_upstream_1",
         },
       },
     });
@@ -1563,17 +1998,13 @@ describe("block-based stream parser and reducer", () => {
 
   it("requires shared interrupt metadata on canonical status-update payloads", () => {
     const payload = {
-      statusUpdate: {
-        status: { state: "TASK_STATE_INPUT_REQUIRED" },
-        metadata: {
-          interrupt: {
-            requestId: "perm-legacy-1",
-            type: "permission",
-            details: {
-              permission: "read",
-              patterns: ["/repo/.env"],
-            },
-          },
+      hub: {
+        version: "v1",
+        eventKind: "status-update",
+        runtimeStatus: {
+          state: "input-required",
+          isFinal: true,
+          interrupt: null,
         },
       },
     };

--- a/frontend/lib/api/__tests__/chat-utils.test.ts
+++ b/frontend/lib/api/__tests__/chat-utils.test.ts
@@ -55,6 +55,31 @@ describe("runtime status contract", () => {
     });
   });
 
+  it("reads snake_case shared stream fields from runtime status events", () => {
+    expect(
+      extractRuntimeStatusEvent({
+        statusUpdate: {
+          status: { state: "TASK_STATE_INPUT_REQUIRED" },
+          metadata: {
+            shared: {
+              stream: {
+                message_id: "msg-status-snake-1",
+                sequence: 7,
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      state: "input-required",
+      isFinal: true,
+      interrupt: null,
+      seq: 7,
+      completionPhase: null,
+      messageId: "msg-status-snake-1",
+    });
+  });
+
   it("extracts shared stream turn identity from lifecycle event properties", () => {
     expect(
       extractSessionMeta({

--- a/frontend/lib/api/__tests__/chat-utils.test.ts
+++ b/frontend/lib/api/__tests__/chat-utils.test.ts
@@ -6,6 +6,22 @@ import {
   normalizeRuntimeState,
 } from "@/lib/api/chat-utils";
 
+const withHubRuntimeStatus = (runtimeStatus: Record<string, unknown>) => ({
+  hub: {
+    version: "v1",
+    eventKind: "status-update",
+    runtimeStatus,
+  },
+});
+
+const withHubSessionMeta = (sessionMeta: Record<string, unknown>) => ({
+  hub: {
+    version: "v1",
+    eventKind: "artifact-update",
+    sessionMeta,
+  },
+});
+
 describe("runtime status contract", () => {
   it("normalizes declared runtime status aliases", () => {
     expect(normalizeRuntimeState("input_required")).toBe("input-required");
@@ -40,11 +56,16 @@ describe("runtime status contract", () => {
 
   it("canonicalizes runtime status events", () => {
     expect(
-      extractRuntimeStatusEvent({
-        statusUpdate: {
-          status: { state: "TASK_STATE_INPUT_REQUIRED" },
-        },
-      }),
+      extractRuntimeStatusEvent(
+        withHubRuntimeStatus({
+          state: "input-required",
+          isFinal: true,
+          interrupt: null,
+          seq: null,
+          completionPhase: null,
+          messageId: null,
+        }),
+      ),
     ).toEqual({
       state: "input-required",
       isFinal: true,
@@ -55,45 +76,36 @@ describe("runtime status contract", () => {
     });
   });
 
-  it("reads snake_case shared stream fields from runtime status events", () => {
+  it("reads canonical runtime status fields from the hub envelope", () => {
     expect(
-      extractRuntimeStatusEvent({
-        statusUpdate: {
-          status: { state: "TASK_STATE_INPUT_REQUIRED" },
-          metadata: {
-            shared: {
-              stream: {
-                message_id: "msg-status-snake-1",
-                sequence: 7,
-              },
-            },
-          },
-        },
-      }),
+      extractRuntimeStatusEvent(
+        withHubRuntimeStatus({
+          state: "input-required",
+          isFinal: true,
+          interrupt: null,
+          seq: 7,
+          completionPhase: null,
+          messageId: "msg-status-1",
+        }),
+      ),
     ).toEqual({
       state: "input-required",
       isFinal: true,
       interrupt: null,
       seq: 7,
       completionPhase: null,
-      messageId: "msg-status-snake-1",
+      messageId: "msg-status-1",
     });
   });
 
-  it("extracts shared stream turn identity from lifecycle event properties", () => {
+  it("extracts session metadata from the hub envelope", () => {
     expect(
-      extractSessionMeta({
-        artifactUpdate: {
-          metadata: {
-            shared: {
-              stream: {
-                threadId: "thread-1",
-                turnId: "turn-2",
-              },
-            },
-          },
-        },
-      }),
+      extractSessionMeta(
+        withHubSessionMeta({
+          streamThreadId: "thread-1",
+          streamTurnId: "turn-2",
+        }),
+      ),
     ).toEqual({
       provider: undefined,
       externalSessionId: undefined,

--- a/frontend/lib/api/chatRuntimeStatus.ts
+++ b/frontend/lib/api/chatRuntimeStatus.ts
@@ -9,6 +9,7 @@ import {
   pickString,
   resolveNestedValue,
 } from "./chatUtilsShared";
+import { MESSAGE_ID_KEYS, SEQ_KEYS } from "./streamFieldAliases";
 
 import {
   getPreferredInterruptMetadata,
@@ -526,11 +527,7 @@ export const extractRuntimeStatusEvent = (
       rawCompletionPhase?.trim().toLowerCase() === "persisted"
         ? "persisted"
         : null;
-    const messageId =
-      typeof sharedStream?.messageId === "string" &&
-      sharedStream.messageId.trim().length > 0
-        ? sharedStream.messageId.trim()
-        : null;
+    const messageId = pickString(sharedStream, MESSAGE_ID_KEYS);
     const resolvedContract = resolveRuntimeStatusContract(contract);
     const state = normalizeRuntimeState(status.state, resolvedContract);
     const isFinal = resolvedContract.terminalStates
@@ -541,8 +538,7 @@ export const extractRuntimeStatusEvent = (
       isFinal,
       interrupt: extractRuntimeInterrupt(statusUpdate, state, resolvedContract),
       seq:
-        pickInteger(sharedStream, ["seq", "sequence"]) ??
-        pickInteger(metadata, ["seq"]),
+        pickInteger(sharedStream, SEQ_KEYS) ?? pickInteger(metadata, SEQ_KEYS),
       completionPhase,
       messageId,
     };

--- a/frontend/lib/api/chatRuntimeStatus.ts
+++ b/frontend/lib/api/chatRuntimeStatus.ts
@@ -3,18 +3,12 @@ import {
   coerceStringArray,
   pickFirstArray,
   pickInt,
-  pickInteger,
   pickNestedRawString,
   pickRawString,
   pickString,
   resolveNestedValue,
 } from "./chatUtilsShared";
-import { MESSAGE_ID_KEYS, SEQ_KEYS } from "./streamFieldAliases";
-
-import {
-  getPreferredInterruptMetadata,
-  getPreferredSessionMetadata,
-} from "@/lib/sharedMetadata";
+import { extractHubStreamEnvelope } from "./hubStreamEnvelope";
 
 export type StreamMissingParam = {
   name: string;
@@ -84,18 +78,6 @@ export const DEFAULT_RUNTIME_STATUS_CONTRACT: RuntimeStatusContract = {
   },
   passthroughUnknown: true,
 };
-
-const resolveStatusUpdateBody = (
-  data: Record<string, unknown>,
-): Record<string, unknown> | null => asRecord(data.statusUpdate);
-
-const resolveCanonicalStreamBody = (
-  data: Record<string, unknown>,
-): Record<string, unknown> | null =>
-  asRecord(data.artifactUpdate) ??
-  asRecord(data.message) ??
-  asRecord(data.statusUpdate) ??
-  asRecord(data.task);
 
 type InterruptQuestionOption = {
   label: string;
@@ -213,35 +195,16 @@ const coerceMissingParams = (value: unknown): StreamMissingParam[] | null => {
 };
 
 export const extractSessionMeta = (data: Record<string, unknown>) => {
-  const body = resolveCanonicalStreamBody(data) ?? data;
-  const session = getPreferredSessionMetadata(body);
-  const properties = asRecord(body.properties);
-  const metadata = asRecord(body.metadata);
-  const shared = asRecord(metadata?.shared);
-  const sharedStream = asRecord(shared?.stream);
-  const externalSessionId = pickString(session, ["id"]) ?? undefined;
-  const rawProvider = pickString(session, ["provider"]);
-  const provider = rawProvider?.trim().toLowerCase() ?? undefined;
+  const sessionMeta = extractHubStreamEnvelope(data)?.sessionMeta ?? null;
+  const provider = pickString(sessionMeta, ["provider"]) ?? undefined;
+  const externalSessionId =
+    pickString(sessionMeta, ["externalSessionId"]) ?? undefined;
   const streamThreadId =
-    pickString(properties, ["threadId"]) ??
-    pickString(sharedStream, ["threadId"]) ??
-    pickString(body, ["threadId"]) ??
-    undefined;
-  const streamTurnId =
-    pickString(properties, ["turnId"]) ??
-    pickString(sharedStream, ["turnId"]) ??
-    pickString(body, ["turnId"]) ??
-    undefined;
-  const transport =
-    typeof body.transport === "string"
-      ? body.transport
-      : typeof data.transport === "string"
-        ? data.transport
-        : undefined;
-  const inputModes =
-    coerceStringArray(body.inputModes) ?? coerceStringArray(data.inputModes);
-  const outputModes =
-    coerceStringArray(body.outputModes) ?? coerceStringArray(data.outputModes);
+    pickString(sessionMeta, ["streamThreadId"]) ?? undefined;
+  const streamTurnId = pickString(sessionMeta, ["streamTurnId"]) ?? undefined;
+  const transport = pickString(sessionMeta, ["transport"]) ?? undefined;
+  const inputModes = coerceStringArray(sessionMeta?.inputModes);
+  const outputModes = coerceStringArray(sessionMeta?.outputModes);
 
   return {
     provider,
@@ -381,11 +344,8 @@ export const isInputRequiredRuntimeState = (
 };
 
 const extractRuntimeInterrupt = (
-  data: Record<string, unknown>,
-  runtimeState: string,
-  contract?: RuntimeStatusContract | null,
+  interrupt: Record<string, unknown> | null,
 ): RuntimeInterrupt | null => {
-  const interrupt = getPreferredInterruptMetadata(data);
   if (!interrupt) {
     return null;
   }
@@ -401,9 +361,7 @@ const extractRuntimeInterrupt = (
     return null;
   }
 
-  const phase =
-    pickString(interrupt, ["phase"])?.toLowerCase() ??
-    (isInputRequiredRuntimeState(runtimeState, contract) ? "asked" : null);
+  const phase = pickString(interrupt, ["phase"])?.toLowerCase();
   if (phase === "resolved") {
     const resolution = pickString(interrupt, ["resolution"])?.toLowerCase();
     if (
@@ -495,55 +453,31 @@ export const extractRuntimeStatusEvent = (
   data: Record<string, unknown>,
   contract?: RuntimeStatusContract | null,
 ): RuntimeStatusEvent | null => {
-  const statusUpdate = resolveStatusUpdateBody(data);
-  if (!statusUpdate) {
+  const runtimeStatus = extractHubStreamEnvelope(data)?.runtimeStatus;
+  if (!runtimeStatus) {
     return null;
   }
-  const status = statusUpdate.status as { state?: unknown } | undefined;
-  if (status && typeof status.state === "string" && status.state.trim()) {
-    const metadata =
-      statusUpdate.metadata &&
-      typeof statusUpdate.metadata === "object" &&
-      !Array.isArray(statusUpdate.metadata)
-        ? (statusUpdate.metadata as Record<string, unknown>)
-        : null;
-    const shared =
-      metadata?.shared &&
-      typeof metadata.shared === "object" &&
-      !Array.isArray(metadata.shared)
-        ? (metadata.shared as Record<string, unknown>)
-        : null;
-    const sharedStream =
-      shared?.stream &&
-      typeof shared.stream === "object" &&
-      !Array.isArray(shared.stream)
-        ? (shared.stream as Record<string, unknown>)
-        : null;
-    const rawCompletionPhase =
-      typeof sharedStream?.completionPhase === "string"
-        ? sharedStream.completionPhase
-        : null;
-    const completionPhase =
-      rawCompletionPhase?.trim().toLowerCase() === "persisted"
-        ? "persisted"
-        : null;
-    const messageId = pickString(sharedStream, MESSAGE_ID_KEYS);
-    const resolvedContract = resolveRuntimeStatusContract(contract);
-    const state = normalizeRuntimeState(status.state, resolvedContract);
-    const isFinal = resolvedContract.terminalStates
-      .map((item) => normalizeRuntimeState(item, resolvedContract))
-      .includes(state);
-    return {
-      state,
-      isFinal,
-      interrupt: extractRuntimeInterrupt(statusUpdate, state, resolvedContract),
-      seq:
-        pickInteger(sharedStream, SEQ_KEYS) ?? pickInteger(metadata, SEQ_KEYS),
-      completionPhase,
-      messageId,
-    };
+  const rawState = pickString(runtimeStatus, ["state"]);
+  if (!rawState) {
+    return null;
   }
-  return null;
+  const resolvedContract = resolveRuntimeStatusContract(contract);
+  const state = normalizeRuntimeState(rawState, resolvedContract);
+  return {
+    state,
+    isFinal:
+      runtimeStatus.isFinal === true ||
+      resolvedContract.terminalStates
+        .map((item) => normalizeRuntimeState(item, resolvedContract))
+        .includes(state),
+    interrupt: extractRuntimeInterrupt(asRecord(runtimeStatus.interrupt)),
+    seq: typeof runtimeStatus.seq === "number" ? runtimeStatus.seq : null,
+    completionPhase:
+      pickString(runtimeStatus, ["completionPhase"]) === "persisted"
+        ? "persisted"
+        : null,
+    messageId: pickString(runtimeStatus, ["messageId"]),
+  };
 };
 
 export const extractStreamErrorDetails = (

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -72,8 +72,16 @@ export type ChatMessage = {
 
 export type StreamBlockUpdate = {
   eventId: string;
-  eventIdSource: "upstream" | "fallback_seq" | "fallback_chunk";
-  messageIdSource: "upstream" | "task_fallback" | "artifact_fallback";
+  eventIdSource:
+    | "upstream"
+    | "fallback_seq"
+    | "fallback_chunk"
+    | "local_persistence";
+  messageIdSource:
+    | "upstream"
+    | "task_fallback"
+    | "artifact_fallback"
+    | "local_persistence";
   seq: number | null;
   taskId: string;
   artifactId: string;
@@ -555,13 +563,15 @@ export const extractStreamBlockUpdate = (
     eventIdSource:
       streamBlock.eventIdSource === "upstream" ||
       streamBlock.eventIdSource === "fallback_seq" ||
-      streamBlock.eventIdSource === "fallback_chunk"
+      streamBlock.eventIdSource === "fallback_chunk" ||
+      streamBlock.eventIdSource === "local_persistence"
         ? streamBlock.eventIdSource
         : "fallback_chunk",
     messageIdSource:
       streamBlock.messageIdSource === "upstream" ||
       streamBlock.messageIdSource === "task_fallback" ||
-      streamBlock.messageIdSource === "artifact_fallback"
+      streamBlock.messageIdSource === "artifact_fallback" ||
+      streamBlock.messageIdSource === "local_persistence"
         ? streamBlock.messageIdSource
         : "artifact_fallback",
     seq: typeof streamBlock.seq === "number" ? streamBlock.seq : null,

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -4,26 +4,8 @@ import type {
   RuntimeInterrupt,
   StreamMissingParam,
 } from "./chatRuntimeStatus";
-import {
-  asRecord,
-  extractTextFromParts,
-  pickInteger,
-  pickRawString,
-  pickString,
-  serializeStructuredStreamData,
-} from "./chatUtilsShared";
-import {
-  BASE_SEQ_KEYS,
-  BLOCK_ID_KEYS,
-  BLOCK_TYPE_KEYS,
-  EVENT_ID_KEYS,
-  LANE_ID_KEYS,
-  MESSAGE_ID_KEYS,
-  SEQ_KEYS,
-  TASK_ID_KEYS,
-} from "./streamFieldAliases";
-
-import { mergeSharedMetadataSection } from "@/lib/sharedMetadata";
+import { asRecord, pickRawString, pickString } from "./chatUtilsShared";
+import { extractHubStreamEnvelope } from "./hubStreamEnvelope";
 
 export type ChatRole = "user" | "agent" | "system";
 
@@ -118,23 +100,6 @@ const finalizeRunningToolCallView = (
     : toolCall;
 
 const BLOCK_OPERATION_TYPES = new Set(["append", "replace", "finalize"]);
-const extractDataFromParts = (parts: unknown[]) =>
-  parts
-    .map((part) => {
-      if (!part || typeof part !== "object") {
-        return null;
-      }
-      const typed = part as {
-        data?: unknown;
-      };
-      if (!("data" in typed)) {
-        return null;
-      }
-      return serializeStructuredStreamData(typed.data);
-    })
-    .filter((item): item is string => Boolean(item))
-    .join("\n");
-
 const buildInterruptEventMessageCode = (
   interrupt: RuntimeInterrupt,
 ):
@@ -539,10 +504,6 @@ const parseBlockOperation = (
     : null;
 };
 
-const defaultLaneIdForBlockType = (
-  blockType: StreamBlockUpdate["blockType"],
-): string => (blockType === "text" ? "primary_text" : blockType);
-
 const findBlockIndexByBlockId = (
   blocks: MessageBlock[],
   blockId: string,
@@ -553,338 +514,37 @@ const adaptStreamBlockUpdateForReducer = (
   update: StreamBlockUpdate,
 ): StreamBlockUpdate => update;
 
-const inferTaskIdFromArtifactId = (
-  artifactId: string | null,
-): string | null => {
-  if (!artifactId) return null;
-  const firstSep = artifactId.indexOf(":");
-  if (firstSep <= 0) return null;
-  return artifactId.slice(0, firstSep);
-};
-
-const inferTaskIdFromMessageId = (messageId: string | null): string | null => {
-  if (!messageId) return null;
-  const normalized = messageId.trim();
-  if (!normalized.startsWith("task:")) {
-    return null;
-  }
-  const taskId = normalized.slice("task:".length).trim();
-  return taskId.length > 0 ? taskId : null;
-};
-
-const buildFallbackEventId = ({
-  messageId,
-  artifactId,
-  seq,
-}: {
-  messageId: string;
-  artifactId: string;
-  seq: number | null;
-}) => {
-  if (seq !== null) {
-    return `seq:${messageId}:${seq}`;
-  }
-  return `chunk:${messageId}:${artifactId}`;
-};
-
-const extractSharedStreamMetadata = (
-  artifactMetadata: Record<string, unknown> | null,
-  rootMetadata: Record<string, unknown> | null,
-) => mergeSharedMetadataSection([rootMetadata, artifactMetadata], "stream");
-
-const resolveCanonicalStreamResponse = (
-  data: Record<string, unknown>,
-): {
-  kind: "artifact-update" | "message" | "status-update" | "task" | null;
-  body: Record<string, unknown> | null;
-} => {
-  const artifactUpdate = asRecord(data.artifactUpdate);
-  if (artifactUpdate) {
-    return { kind: "artifact-update", body: artifactUpdate };
-  }
-  const message = asRecord(data.message);
-  if (message) {
-    return { kind: "message", body: message };
-  }
-  const statusUpdate = asRecord(data.statusUpdate);
-  if (statusUpdate) {
-    return { kind: "status-update", body: statusUpdate };
-  }
-  const task = asRecord(data.task);
-  if (task) {
-    return { kind: "task", body: task };
-  }
-  return { kind: null, body: null };
-};
-
-const resolveCanonicalContentArtifact = (
-  kind: "artifact-update" | "message" | "status-update" | "task" | null,
-  body: Record<string, unknown> | null,
-  rootMetadata: Record<string, unknown> | null,
-) => {
-  if (kind === "artifact-update") {
-    return asRecord(body?.artifact);
-  }
-  if (kind === "message") {
-    if (!Array.isArray(body?.parts)) {
-      return null;
-    }
-    return {
-      parts: body.parts,
-      ...(rootMetadata ? { metadata: rootMetadata } : {}),
-      ...(typeof body?.messageId === "string"
-        ? { messageId: body.messageId }
-        : {}),
-      ...(typeof body?.taskId === "string" ? { taskId: body.taskId } : {}),
-      ...(typeof body?.role === "string" ? { role: body.role } : {}),
-      ...(body?.toolCall ? { toolCall: body.toolCall } : {}),
-    };
-  }
-  if (kind === "status-update") {
-    const status = asRecord(body?.status);
-    const message = asRecord(status?.message);
-    if (!Array.isArray(message?.parts)) {
-      return null;
-    }
-    const messageMetadata = asRecord(message?.metadata);
-    return {
-      parts: message.parts,
-      ...(messageMetadata ? { metadata: messageMetadata } : {}),
-      ...(typeof message?.messageId === "string"
-        ? { messageId: message.messageId }
-        : {}),
-      ...(typeof message?.taskId === "string"
-        ? { taskId: message.taskId }
-        : {}),
-      ...(typeof message?.role === "string" ? { role: message.role } : {}),
-      ...(message?.toolCall ? { toolCall: message.toolCall } : {}),
-    };
-  }
-  return null;
-};
-
-const extractToolCallView = (
-  source: Record<string, unknown> | null,
-): ToolCallView | null => {
-  if (!source) {
-    return null;
-  }
-  const status = pickString(source, ["status"]);
-  if (
-    status !== "running" &&
-    status !== "success" &&
-    status !== "failed" &&
-    status !== "interrupted" &&
-    status !== "unknown"
-  ) {
-    return null;
-  }
-  return {
-    name:
-      pickRawString(source, ["name", "tool", "tool_name", "function_name"]) ??
-      null,
-    status,
-    callId: pickRawString(source, ["callId", "call_id"]) ?? null,
-    arguments: source.arguments,
-    result: source.result,
-    error: source.error,
-  };
-};
-
-const extractToolCallViewFromRawContent = (
-  rawContent: string,
-): ToolCallView | null => {
-  const trimmed = rawContent.trim();
-  if (!trimmed) {
-    return null;
-  }
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    if (Array.isArray(parsed)) {
-      for (let index = parsed.length - 1; index >= 0; index -= 1) {
-        const candidate = extractToolCallView(asRecord(parsed[index]));
-        if (candidate) {
-          return candidate;
-        }
-      }
-      return null;
-    }
-    return extractToolCallView(asRecord(parsed));
-  } catch {
-    return null;
-  }
-};
-
 export const extractStreamBlockUpdate = (
   data: Record<string, unknown>,
 ): StreamBlockUpdate | null => {
-  const { kind, body } = resolveCanonicalStreamResponse(data);
-  if (
-    kind !== "artifact-update" &&
-    kind !== "message" &&
-    kind !== "status-update"
-  ) {
+  const hub = extractHubStreamEnvelope(data);
+  const streamBlock = hub?.streamBlock;
+  if (!streamBlock) {
     return null;
   }
-  const rootMetadata = asRecord(body?.metadata);
-  const artifact = resolveCanonicalContentArtifact(kind, body, rootMetadata);
-  const metadata = asRecord(artifact?.metadata) ?? rootMetadata;
-  const sharedStream = extractSharedStreamMetadata(metadata, rootMetadata);
-  const parts = Array.isArray(artifact?.parts) ? artifact.parts : [];
-  const textFromParts = extractTextFromParts(parts);
-  const dataFromParts = extractDataFromParts(parts);
-  const rawBlockType =
-    pickString(sharedStream, BLOCK_TYPE_KEYS) ??
-    pickString(metadata, BLOCK_TYPE_KEYS) ??
-    pickString(rootMetadata, BLOCK_TYPE_KEYS);
-  const explicitBlockType = parseBlockType(rawBlockType);
-  const blockType =
-    explicitBlockType ??
-    ((kind === "artifact-update" ||
-      kind === "message" ||
-      kind === "status-update") &&
-    rawBlockType === null
-      ? dataFromParts
-        ? "tool_call"
-        : textFromParts
-          ? "text"
-          : null
-      : null);
+  const blockType = parseBlockType(pickString(streamBlock, ["blockType"]));
   if (!blockType) {
     return null;
   }
-
-  const seq =
-    pickInteger(sharedStream, SEQ_KEYS) ??
-    pickInteger(body ?? null, SEQ_KEYS) ??
-    pickInteger(artifact ?? null, SEQ_KEYS) ??
-    pickInteger(metadata, SEQ_KEYS) ??
-    pickInteger(rootMetadata, SEQ_KEYS);
-
-  const artifactId = pickString(artifact ?? null, ["artifactId", "id"]) ?? null;
-  const taskIdHint =
-    pickString(body ?? null, TASK_ID_KEYS) ??
-    pickString(artifact ?? null, TASK_ID_KEYS) ??
-    pickString(rootMetadata, TASK_ID_KEYS) ??
-    inferTaskIdFromArtifactId(artifactId);
-
-  const upstreamMessageId =
-    pickString(sharedStream, MESSAGE_ID_KEYS) ??
-    pickString(body ?? null, MESSAGE_ID_KEYS) ??
-    pickString(artifact ?? null, MESSAGE_ID_KEYS) ??
-    pickString(metadata, MESSAGE_ID_KEYS) ??
-    pickString(rootMetadata, MESSAGE_ID_KEYS);
-  const messageIdSource: StreamBlockUpdate["messageIdSource"] =
-    upstreamMessageId !== null
-      ? "upstream"
-      : taskIdHint
-        ? "task_fallback"
-        : "artifact_fallback";
-  const resolvedMessageId =
-    upstreamMessageId ?? (taskIdHint ? `task:${taskIdHint}` : null);
-  const resolvedArtifactId =
-    artifactId ?? `${resolvedMessageId ?? "stream"}:${blockType}`;
-  const taskId =
-    taskIdHint ??
-    inferTaskIdFromArtifactId(resolvedArtifactId) ??
-    inferTaskIdFromMessageId(resolvedMessageId) ??
-    resolvedMessageId ??
-    resolvedArtifactId;
-  const messageId = resolvedMessageId ?? `artifact:${resolvedArtifactId}`;
-
-  const delta =
-    (blockType === "tool_call"
-      ? dataFromParts || textFromParts
-      : textFromParts) ||
-    pickRawString(body ?? null, ["delta"]) ||
-    pickRawString(artifact ?? null, ["delta"]) ||
-    pickRawString(body ?? null, ["text"]) ||
-    pickRawString(artifact ?? null, ["text"]) ||
-    "";
-
-  const explicitOp =
-    parseBlockOperation(pickString(sharedStream, ["op", "operation"])) ??
-    parseBlockOperation(pickString(metadata, ["op", "operation"])) ??
-    parseBlockOperation(pickString(rootMetadata, ["op", "operation"])) ??
-    parseBlockOperation(pickString(artifact ?? null, ["op", "operation"])) ??
-    parseBlockOperation(pickString(body ?? null, ["op", "operation"]));
-  const op =
-    explicitOp ??
-    (kind === "message" || kind === "status-update"
-      ? "replace"
-      : kind === "artifact-update"
-        ? body?.append === true
-          ? "append"
-          : "replace"
-        : null);
+  const op = parseBlockOperation(pickString(streamBlock, ["op"]));
   if (!op) {
     return null;
   }
-  const append = op === "append";
-  const done =
-    op === "finalize" ||
-    body?.lastChunk === true ||
-    artifact?.lastChunk === true;
-  const upstreamEventId =
-    pickString(sharedStream, EVENT_ID_KEYS) ??
-    pickString(body ?? null, EVENT_ID_KEYS) ??
-    pickString(artifact ?? null, EVENT_ID_KEYS) ??
-    pickString(metadata, EVENT_ID_KEYS) ??
-    pickString(rootMetadata, EVENT_ID_KEYS);
-  const eventId = upstreamEventId
-    ? upstreamEventId
-    : buildFallbackEventId({
-        messageId,
-        artifactId: resolvedArtifactId,
-        seq: seq ?? null,
-      });
-  const eventIdSource: StreamBlockUpdate["eventIdSource"] = upstreamEventId
-    ? "upstream"
-    : seq !== null
-      ? "fallback_seq"
-      : "fallback_chunk";
 
-  const source =
-    pickString(sharedStream, ["source"]) ??
-    pickString(metadata, ["source"]) ??
-    pickString(rootMetadata, ["source"]) ??
-    null;
+  const eventId = pickString(streamBlock, ["eventId"]);
+  const messageId = pickString(streamBlock, ["messageId"]);
+  const taskId = pickString(streamBlock, ["taskId"]);
+  const artifactId = pickString(streamBlock, ["artifactId"]);
+  const blockId = pickString(streamBlock, ["blockId"]);
+  const laneId = pickString(streamBlock, ["laneId"]);
+  if (!eventId || !messageId || !taskId || !artifactId || !blockId || !laneId) {
+    return null;
+  }
+  const delta = pickRawString(streamBlock, ["delta"]) ?? "";
   if (!delta && op !== "finalize") {
     return null;
   }
-  const laneId =
-    pickString(sharedStream, LANE_ID_KEYS) ??
-    pickString(metadata, LANE_ID_KEYS) ??
-    pickString(rootMetadata, LANE_ID_KEYS) ??
-    pickString(artifact ?? null, LANE_ID_KEYS) ??
-    pickString(body ?? null, LANE_ID_KEYS) ??
-    defaultLaneIdForBlockType(blockType);
-  const blockId =
-    pickString(sharedStream, BLOCK_ID_KEYS) ??
-    pickString(metadata, BLOCK_ID_KEYS) ??
-    pickString(rootMetadata, BLOCK_ID_KEYS) ??
-    pickString(artifact ?? null, BLOCK_ID_KEYS) ??
-    pickString(body ?? null, BLOCK_ID_KEYS) ??
-    `${messageId}:${laneId}`;
-  const baseSeq =
-    pickInteger(sharedStream, BASE_SEQ_KEYS) ??
-    pickInteger(metadata, BASE_SEQ_KEYS) ??
-    pickInteger(rootMetadata, BASE_SEQ_KEYS) ??
-    pickInteger(artifact ?? null, BASE_SEQ_KEYS) ??
-    pickInteger(body ?? null, BASE_SEQ_KEYS);
-  const role = normalizeRole(
-    pickString(body ?? null, ["role"]) ??
-      pickString(artifact ?? null, ["role"]) ??
-      pickString(sharedStream, ["role"]) ??
-      pickString(metadata, ["role"]) ??
-      pickString(rootMetadata, ["role"]),
-  );
-  const toolCall =
-    blockType === "tool_call"
-      ? (extractToolCallView(
-          asRecord(body?.toolCall) ?? asRecord(artifact?.toolCall),
-        ) ?? extractToolCallViewFromRawContent(delta))
-      : null;
+  const toolCall = asRecord(streamBlock.toolCall);
   const interruptPayload =
     blockType === "interrupt_event"
       ? parseSerializedInterruptEventContent(delta)
@@ -892,23 +552,43 @@ export const extractStreamBlockUpdate = (
 
   return {
     eventId,
-    eventIdSource,
-    messageIdSource,
-    seq: seq ?? null,
+    eventIdSource:
+      streamBlock.eventIdSource === "upstream" ||
+      streamBlock.eventIdSource === "fallback_seq" ||
+      streamBlock.eventIdSource === "fallback_chunk"
+        ? streamBlock.eventIdSource
+        : "fallback_chunk",
+    messageIdSource:
+      streamBlock.messageIdSource === "upstream" ||
+      streamBlock.messageIdSource === "task_fallback" ||
+      streamBlock.messageIdSource === "artifact_fallback"
+        ? streamBlock.messageIdSource
+        : "artifact_fallback",
+    seq: typeof streamBlock.seq === "number" ? streamBlock.seq : null,
     taskId,
-    artifactId: resolvedArtifactId,
+    artifactId,
     blockId,
     laneId,
     blockType,
     op,
-    baseSeq: baseSeq ?? null,
-    source,
+    baseSeq:
+      typeof streamBlock.baseSeq === "number" ? streamBlock.baseSeq : null,
+    source: pickString(streamBlock, ["source"]),
     messageId,
-    role,
+    role: normalizeRole(pickString(streamBlock, ["role"])),
     delta: interruptPayload.content,
-    append,
-    done: op === "finalize" ? true : done,
-    toolCall,
+    append:
+      typeof streamBlock.append === "boolean"
+        ? streamBlock.append
+        : op === "append",
+    done:
+      typeof streamBlock.done === "boolean"
+        ? streamBlock.done
+        : op === "finalize",
+    toolCall:
+      blockType === "tool_call"
+        ? ((toolCall as ToolCallView | null) ?? null)
+        : null,
     interrupt: interruptPayload.interrupt,
   };
 };

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -12,6 +12,16 @@ import {
   pickString,
   serializeStructuredStreamData,
 } from "./chatUtilsShared";
+import {
+  BASE_SEQ_KEYS,
+  BLOCK_ID_KEYS,
+  BLOCK_TYPE_KEYS,
+  EVENT_ID_KEYS,
+  LANE_ID_KEYS,
+  MESSAGE_ID_KEYS,
+  SEQ_KEYS,
+  TASK_ID_KEYS,
+} from "./streamFieldAliases";
 
 import { mergeSharedMetadataSection } from "@/lib/sharedMetadata";
 
@@ -108,15 +118,6 @@ const finalizeRunningToolCallView = (
     : toolCall;
 
 const BLOCK_OPERATION_TYPES = new Set(["append", "replace", "finalize"]);
-const BLOCK_TYPE_KEYS = ["blockType", "block_type"];
-const MESSAGE_ID_KEYS = ["messageId", "message_id"];
-const EVENT_ID_KEYS = ["eventId", "event_id"];
-const SEQ_KEYS = ["seq", "sequence"];
-const TASK_ID_KEYS = ["taskId", "task_id"];
-const BLOCK_ID_KEYS = ["blockId", "block_id"];
-const LANE_ID_KEYS = ["laneId", "lane_id"];
-const BASE_SEQ_KEYS = ["baseSeq", "base_seq"];
-
 const extractDataFromParts = (parts: unknown[]) =>
   parts
     .map((part) => {

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -108,6 +108,14 @@ const finalizeRunningToolCallView = (
     : toolCall;
 
 const BLOCK_OPERATION_TYPES = new Set(["append", "replace", "finalize"]);
+const BLOCK_TYPE_KEYS = ["blockType", "block_type"];
+const MESSAGE_ID_KEYS = ["messageId", "message_id"];
+const EVENT_ID_KEYS = ["eventId", "event_id"];
+const SEQ_KEYS = ["seq", "sequence"];
+const TASK_ID_KEYS = ["taskId", "task_id"];
+const BLOCK_ID_KEYS = ["blockId", "block_id"];
+const LANE_ID_KEYS = ["laneId", "lane_id"];
+const BASE_SEQ_KEYS = ["baseSeq", "base_seq"];
 
 const extractDataFromParts = (parts: unknown[]) =>
   parts
@@ -725,9 +733,9 @@ export const extractStreamBlockUpdate = (
   const textFromParts = extractTextFromParts(parts);
   const dataFromParts = extractDataFromParts(parts);
   const rawBlockType =
-    pickString(sharedStream, ["blockType"]) ??
-    pickString(metadata, ["blockType"]) ??
-    pickString(rootMetadata, ["blockType"]);
+    pickString(sharedStream, BLOCK_TYPE_KEYS) ??
+    pickString(metadata, BLOCK_TYPE_KEYS) ??
+    pickString(rootMetadata, BLOCK_TYPE_KEYS);
   const explicitBlockType = parseBlockType(rawBlockType);
   const blockType =
     explicitBlockType ??
@@ -746,25 +754,25 @@ export const extractStreamBlockUpdate = (
   }
 
   const seq =
-    pickInteger(sharedStream, ["seq", "sequence"]) ??
-    pickInteger(body ?? null, ["seq"]) ??
-    pickInteger(artifact ?? null, ["seq"]) ??
-    pickInteger(metadata, ["seq"]) ??
-    pickInteger(rootMetadata, ["seq"]);
+    pickInteger(sharedStream, SEQ_KEYS) ??
+    pickInteger(body ?? null, SEQ_KEYS) ??
+    pickInteger(artifact ?? null, SEQ_KEYS) ??
+    pickInteger(metadata, SEQ_KEYS) ??
+    pickInteger(rootMetadata, SEQ_KEYS);
 
   const artifactId = pickString(artifact ?? null, ["artifactId", "id"]) ?? null;
   const taskIdHint =
-    pickString(body ?? null, ["taskId"]) ??
-    pickString(artifact ?? null, ["taskId"]) ??
-    pickString(rootMetadata, ["taskId"]) ??
+    pickString(body ?? null, TASK_ID_KEYS) ??
+    pickString(artifact ?? null, TASK_ID_KEYS) ??
+    pickString(rootMetadata, TASK_ID_KEYS) ??
     inferTaskIdFromArtifactId(artifactId);
 
   const upstreamMessageId =
-    pickString(sharedStream, ["messageId"]) ??
-    pickString(body ?? null, ["messageId"]) ??
-    pickString(artifact ?? null, ["messageId"]) ??
-    pickString(metadata, ["messageId"]) ??
-    pickString(rootMetadata, ["messageId"]);
+    pickString(sharedStream, MESSAGE_ID_KEYS) ??
+    pickString(body ?? null, MESSAGE_ID_KEYS) ??
+    pickString(artifact ?? null, MESSAGE_ID_KEYS) ??
+    pickString(metadata, MESSAGE_ID_KEYS) ??
+    pickString(rootMetadata, MESSAGE_ID_KEYS);
   const messageIdSource: StreamBlockUpdate["messageIdSource"] =
     upstreamMessageId !== null
       ? "upstream"
@@ -817,11 +825,11 @@ export const extractStreamBlockUpdate = (
     body?.lastChunk === true ||
     artifact?.lastChunk === true;
   const upstreamEventId =
-    pickString(sharedStream, ["eventId"]) ??
-    pickString(body ?? null, ["eventId"]) ??
-    pickString(artifact ?? null, ["eventId"]) ??
-    pickString(metadata, ["eventId"]) ??
-    pickString(rootMetadata, ["eventId"]);
+    pickString(sharedStream, EVENT_ID_KEYS) ??
+    pickString(body ?? null, EVENT_ID_KEYS) ??
+    pickString(artifact ?? null, EVENT_ID_KEYS) ??
+    pickString(metadata, EVENT_ID_KEYS) ??
+    pickString(rootMetadata, EVENT_ID_KEYS);
   const eventId = upstreamEventId
     ? upstreamEventId
     : buildFallbackEventId({
@@ -844,25 +852,25 @@ export const extractStreamBlockUpdate = (
     return null;
   }
   const laneId =
-    pickString(sharedStream, ["laneId"]) ??
-    pickString(metadata, ["laneId"]) ??
-    pickString(rootMetadata, ["laneId"]) ??
-    pickString(artifact ?? null, ["laneId"]) ??
-    pickString(body ?? null, ["laneId"]) ??
+    pickString(sharedStream, LANE_ID_KEYS) ??
+    pickString(metadata, LANE_ID_KEYS) ??
+    pickString(rootMetadata, LANE_ID_KEYS) ??
+    pickString(artifact ?? null, LANE_ID_KEYS) ??
+    pickString(body ?? null, LANE_ID_KEYS) ??
     defaultLaneIdForBlockType(blockType);
   const blockId =
-    pickString(sharedStream, ["blockId"]) ??
-    pickString(metadata, ["blockId"]) ??
-    pickString(rootMetadata, ["blockId"]) ??
-    pickString(artifact ?? null, ["blockId"]) ??
-    pickString(body ?? null, ["blockId"]) ??
+    pickString(sharedStream, BLOCK_ID_KEYS) ??
+    pickString(metadata, BLOCK_ID_KEYS) ??
+    pickString(rootMetadata, BLOCK_ID_KEYS) ??
+    pickString(artifact ?? null, BLOCK_ID_KEYS) ??
+    pickString(body ?? null, BLOCK_ID_KEYS) ??
     `${messageId}:${laneId}`;
   const baseSeq =
-    pickInteger(sharedStream, ["baseSeq"]) ??
-    pickInteger(metadata, ["baseSeq"]) ??
-    pickInteger(rootMetadata, ["baseSeq"]) ??
-    pickInteger(artifact ?? null, ["baseSeq"]) ??
-    pickInteger(body ?? null, ["baseSeq"]);
+    pickInteger(sharedStream, BASE_SEQ_KEYS) ??
+    pickInteger(metadata, BASE_SEQ_KEYS) ??
+    pickInteger(rootMetadata, BASE_SEQ_KEYS) ??
+    pickInteger(artifact ?? null, BASE_SEQ_KEYS) ??
+    pickInteger(body ?? null, BASE_SEQ_KEYS);
   const role = normalizeRole(
     pickString(body ?? null, ["role"]) ??
       pickString(artifact ?? null, ["role"]) ??

--- a/frontend/lib/api/hubStreamEnvelope.ts
+++ b/frontend/lib/api/hubStreamEnvelope.ts
@@ -1,0 +1,35 @@
+import { asRecord } from "./chatUtilsShared";
+
+export type HubStreamEnvelope = {
+  version: "v1";
+  eventKind?: "artifact-update" | "message" | "status-update" | "task" | null;
+  streamBlock?: Record<string, unknown> | null;
+  runtimeStatus?: Record<string, unknown> | null;
+  sessionMeta?: Record<string, unknown> | null;
+};
+
+export const extractHubStreamEnvelope = (
+  data: Record<string, unknown>,
+): HubStreamEnvelope | null => {
+  const hub = asRecord(data.hub);
+  if (!hub) {
+    return null;
+  }
+  const version = hub.version;
+  if (version !== "v1") {
+    return null;
+  }
+  return {
+    version,
+    eventKind:
+      hub.eventKind === "artifact-update" ||
+      hub.eventKind === "message" ||
+      hub.eventKind === "status-update" ||
+      hub.eventKind === "task"
+        ? hub.eventKind
+        : null,
+    streamBlock: asRecord(hub.streamBlock),
+    runtimeStatus: asRecord(hub.runtimeStatus),
+    sessionMeta: asRecord(hub.sessionMeta),
+  };
+};

--- a/frontend/lib/api/streamFieldAliases.ts
+++ b/frontend/lib/api/streamFieldAliases.ts
@@ -1,8 +1,0 @@
-export const BLOCK_TYPE_KEYS = ["blockType", "block_type"];
-export const MESSAGE_ID_KEYS = ["messageId", "message_id"];
-export const EVENT_ID_KEYS = ["eventId", "event_id"];
-export const SEQ_KEYS = ["seq", "sequence"];
-export const TASK_ID_KEYS = ["taskId", "task_id"];
-export const BLOCK_ID_KEYS = ["blockId", "block_id"];
-export const LANE_ID_KEYS = ["laneId", "lane_id"];
-export const BASE_SEQ_KEYS = ["baseSeq", "base_seq"];

--- a/frontend/lib/api/streamFieldAliases.ts
+++ b/frontend/lib/api/streamFieldAliases.ts
@@ -1,0 +1,8 @@
+export const BLOCK_TYPE_KEYS = ["blockType", "block_type"];
+export const MESSAGE_ID_KEYS = ["messageId", "message_id"];
+export const EVENT_ID_KEYS = ["eventId", "event_id"];
+export const SEQ_KEYS = ["seq", "sequence"];
+export const TASK_ID_KEYS = ["taskId", "task_id"];
+export const BLOCK_ID_KEYS = ["blockId", "block_id"];
+export const LANE_ID_KEYS = ["laneId", "lane_id"];
+export const BASE_SEQ_KEYS = ["baseSeq", "base_seq"];

--- a/frontend/store/__tests__/chatRuntime.interrupts.test.ts
+++ b/frontend/store/__tests__/chatRuntime.interrupts.test.ts
@@ -17,6 +17,25 @@ import type {
   RuntimeStatusContract,
 } from "./chatRuntime.test.support";
 
+const normalizeRuntimeStateToken = (state: string) => {
+  const normalized = state.trim().toLowerCase().replace(/_/g, "-");
+  return normalized.startsWith("task-state-")
+    ? normalized.slice("task-state-".length)
+    : normalized;
+};
+
+const buildCanonicalInterrupt = (interrupt?: Record<string, unknown>) => {
+  if (!interrupt) {
+    return null;
+  }
+  const phase = typeof interrupt.phase === "string" ? interrupt.phase : "asked";
+  return {
+    ...interrupt,
+    phase,
+    source: "stream",
+  };
+};
+
 const buildStatusUpdate = ({
   state,
   seq,
@@ -41,6 +60,21 @@ const buildStatusUpdate = ({
           ...(completionPhase ? { completionPhase } : {}),
         },
       },
+    },
+  },
+  hub: {
+    version: "v1",
+    eventKind: "status-update",
+    runtimeStatus: {
+      state: normalizeRuntimeStateToken(state),
+      isFinal:
+        state === "TASK_STATE_COMPLETED" ||
+        state === "TASK_STATE_FAILED" ||
+        state === "TASK_STATE_INPUT_REQUIRED",
+      interrupt: buildCanonicalInterrupt(interrupt),
+      seq: seq ?? null,
+      completionPhase: completionPhase ?? null,
+      messageId: messageId ?? null,
     },
   },
 });
@@ -74,6 +108,29 @@ const buildArtifactUpdate = ({
           },
         },
       },
+    },
+  },
+  hub: {
+    version: "v1",
+    eventKind: "artifact-update",
+    streamBlock: {
+      eventId,
+      eventIdSource: "upstream",
+      messageIdSource: "upstream",
+      seq,
+      taskId: agentMessageId,
+      artifactId: `${agentMessageId}:stream:${seq}`,
+      blockId: `${agentMessageId}:primary_text`,
+      laneId: "primary_text",
+      blockType: "text",
+      op: "append",
+      baseSeq: null,
+      source,
+      messageId: agentMessageId,
+      role: "agent",
+      delta: text,
+      append: true,
+      done: false,
     },
   },
 });

--- a/frontend/store/__tests__/chatRuntime.recovery.test.ts
+++ b/frontend/store/__tests__/chatRuntime.recovery.test.ts
@@ -16,6 +16,13 @@ import type {
   SessionMessageItem,
 } from "./chatRuntime.test.support";
 
+const normalizeRuntimeStateToken = (state: string) => {
+  const normalized = state.trim().toLowerCase().replace(/_/g, "-");
+  return normalized.startsWith("task-state-")
+    ? normalized.slice("task-state-".length)
+    : normalized;
+};
+
 const buildStatusUpdate = ({
   state,
   messageId,
@@ -34,6 +41,21 @@ const buildStatusUpdate = ({
           ...(completionPhase ? { completionPhase } : {}),
         },
       },
+    },
+  },
+  hub: {
+    version: "v1",
+    eventKind: "status-update",
+    runtimeStatus: {
+      state: normalizeRuntimeStateToken(state),
+      isFinal:
+        state === "TASK_STATE_COMPLETED" ||
+        state === "TASK_STATE_FAILED" ||
+        state === "TASK_STATE_INPUT_REQUIRED",
+      interrupt: null,
+      seq: null,
+      completionPhase: completionPhase ?? null,
+      messageId: messageId ?? null,
     },
   },
 });
@@ -69,6 +91,29 @@ const buildArtifactUpdate = ({
       },
     },
   },
+  hub: {
+    version: "v1",
+    eventKind: "artifact-update",
+    streamBlock: {
+      eventId,
+      eventIdSource: "upstream",
+      messageIdSource: "upstream",
+      seq,
+      taskId: agentMessageId,
+      artifactId: `${agentMessageId}:stream:1`,
+      blockId: `${agentMessageId}:primary_text`,
+      laneId: "primary_text",
+      blockType: "text",
+      op: "append",
+      baseSeq: null,
+      source,
+      messageId: agentMessageId,
+      role: "agent",
+      delta: text,
+      append: true,
+      done: false,
+    },
+  },
 });
 
 const buildRawCompatArtifactUpdate = ({
@@ -102,6 +147,29 @@ const buildRawCompatArtifactUpdate = ({
           seq,
         },
       },
+    },
+  },
+  hub: {
+    version: "v1",
+    eventKind: "artifact-update",
+    streamBlock: {
+      eventId,
+      eventIdSource: "upstream",
+      messageIdSource: "task_fallback",
+      seq,
+      taskId,
+      artifactId: `${taskId}:stream:text`,
+      blockId: `task:${taskId}:primary_text`,
+      laneId: "primary_text",
+      blockType: "text",
+      op: append ? "append" : "replace",
+      baseSeq: null,
+      source: null,
+      messageId: `task:${taskId}`,
+      role: "agent",
+      delta: text,
+      append,
+      done: lastChunk,
     },
   },
 });
@@ -852,6 +920,29 @@ describe("executeChatRuntime empty-content recovery", () => {
               },
             },
           },
+          hub: {
+            version: "v1",
+            eventKind: "artifact-update",
+            streamBlock: {
+              eventId: `${agentMessageId}:1`,
+              eventIdSource: "upstream",
+              messageIdSource: "upstream",
+              seq: 1,
+              taskId: "task-compat-1",
+              artifactId: "stream-compat-1",
+              blockId: `${agentMessageId}:primary_text`,
+              laneId: "primary_text",
+              blockType: "text",
+              op: "append",
+              baseSeq: null,
+              source: "assistant_text",
+              messageId: agentMessageId,
+              role: "agent",
+              delta: "Hello from stream",
+              append: true,
+              done: false,
+            },
+          },
         });
         await new Promise((resolve) => setTimeout(resolve, 30));
         renderedDuringStream = getConversationMessages(conversationId).some(
@@ -983,6 +1074,42 @@ describe("executeChatRuntime empty-content recovery", () => {
               },
             },
           },
+          hub: {
+            version: "v1",
+            eventKind: "artifact-update",
+            streamBlock: {
+              eventId: `${agentMessageId}:1`,
+              eventIdSource: "upstream",
+              messageIdSource: "upstream",
+              seq: 1,
+              taskId: agentMessageId,
+              artifactId: `${agentMessageId}:stream`,
+              blockId: `${agentMessageId}:tool_call`,
+              laneId: "tool_call",
+              blockType: "tool_call",
+              op: "replace",
+              baseSeq: null,
+              source: "tool_part_update",
+              messageId: agentMessageId,
+              role: "agent",
+              delta: JSON.stringify({
+                call_id: "call-1",
+                tool: "bash",
+                status: "running",
+                input: { command: "pwd" },
+              }),
+              append: false,
+              done: false,
+              toolCall: {
+                name: "bash",
+                status: "running",
+                callId: "call-1",
+                arguments: { command: "pwd" },
+                result: null,
+                error: null,
+              },
+            },
+          },
         });
 
         const agentMessage = getConversationMessages(conversationId).find(
@@ -1097,6 +1224,29 @@ describe("executeChatRuntime empty-content recovery", () => {
                   },
                 },
               },
+            },
+          },
+          hub: {
+            version: "v1",
+            eventKind: "artifact-update",
+            streamBlock: {
+              eventId: `${agentMessageId}:1`,
+              eventIdSource: "upstream",
+              messageIdSource: "upstream",
+              seq: 1,
+              taskId: agentMessageId,
+              artifactId: `${agentMessageId}:stream`,
+              blockId: `${agentMessageId}:reasoning`,
+              laneId: "reasoning",
+              blockType: "reasoning",
+              op: "replace",
+              baseSeq: null,
+              source: "reasoning_part_update",
+              messageId: agentMessageId,
+              role: "agent",
+              delta: "Reasoning in progress",
+              append: false,
+              done: false,
             },
           },
         });

--- a/frontend/store/__tests__/chatRuntime.recovery.test.ts
+++ b/frontend/store/__tests__/chatRuntime.recovery.test.ts
@@ -6,6 +6,7 @@ import {
   executeChatRuntime,
   flushPromises,
   getConversationMessages,
+  invokeAgent,
   mockedChatConnectionService,
   mockedListSessionMessagesPage,
   queryClient,
@@ -731,6 +732,108 @@ describe("executeChatRuntime empty-content recovery", () => {
     ).toMatchObject({
       status: "interrupted",
       content: "Hello before stream end.",
+    });
+  });
+
+  it("ignores empty hub envelopes and falls back to JSON when no stream event was observed", async () => {
+    const conversationId = "conv-empty-hub-envelope-1";
+    const agentId = "agent-empty-hub-envelope-1";
+    const userMessageId = "user-empty-hub-envelope-1";
+    const agentMessageId = "agent-empty-hub-envelope-1";
+
+    addConversationMessage(conversationId, {
+      id: userMessageId,
+      role: "user",
+      content: "hello",
+      createdAt: "2026-03-23T10:20:00.000Z",
+      status: "done",
+    });
+    addConversationMessage(conversationId, {
+      id: agentMessageId,
+      role: "agent",
+      content: "",
+      blocks: [],
+      createdAt: "2026-03-23T10:20:01.000Z",
+      status: "streaming",
+    });
+
+    let state: ChatRuntimeState = {
+      sessions: {
+        [conversationId]: {
+          ...createAgentSession(agentId),
+          streamState: "streaming",
+          lastUserMessageId: userMessageId,
+          lastAgentMessageId: agentMessageId,
+        },
+      },
+    };
+
+    const get = () => state;
+    const set: ChatRuntimeSetState<ChatRuntimeState> = (partial) => {
+      const next =
+        typeof partial === "function"
+          ? partial(state as ChatRuntimeState)
+          : partial;
+      state = {
+        ...state,
+        ...(next as Partial<ChatRuntimeState>),
+      };
+    };
+
+    invokeAgent.mockResolvedValueOnce({
+      success: true,
+      content: "JSON fallback response.",
+    });
+
+    mockedChatConnectionService.tryWebSocketTransport.mockImplementationOnce(
+      async (params: {
+        callbacks: {
+          onData: (data: Record<string, unknown>) => boolean | void;
+        };
+      }) => {
+        params.callbacks.onData({
+          hub: {
+            version: "v1",
+            eventKind: "artifact-update",
+          },
+        });
+        return false;
+      },
+    );
+
+    await executeChatRuntime(
+      conversationId,
+      agentId,
+      "personal",
+      {
+        query: "hello",
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      },
+      agentMessageId,
+      get,
+      set,
+    );
+
+    expect(mockedListSessionMessagesPage).not.toHaveBeenCalled();
+    expect(invokeAgent).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        conversationId,
+        userMessageId,
+        agentMessageId,
+      }),
+    );
+    expect(state.sessions[conversationId]?.streamState).toBe("idle");
+    expect(state.sessions[conversationId]?.lastStreamError).toBeNull();
+    expect(
+      getConversationMessages(conversationId).find(
+        (message) => message.id === agentMessageId,
+      ),
+    ).toMatchObject({
+      status: "done",
+      content: "JSON fallback response.",
     });
   });
 

--- a/frontend/store/chatRuntime.ts
+++ b/frontend/store/chatRuntime.ts
@@ -618,16 +618,16 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
       data,
       runtimeStatusContract,
     );
-    const kind = typeof data.kind === "string" ? data.kind : "";
-    const isLegacyContentEvent =
-      typeof data.content === "string" && data.content.trim().length > 0;
-    if (
-      chunk ||
-      runtimeStatusEvent ||
-      kind === "artifact-update" ||
-      kind === "status-update" ||
-      isLegacyContentEvent
-    ) {
+    const meta = extractSessionMeta(data);
+    const hasSessionMetaEvent =
+      meta.provider !== undefined ||
+      meta.externalSessionId !== undefined ||
+      meta.streamThreadId !== undefined ||
+      meta.streamTurnId !== undefined ||
+      meta.transport !== undefined ||
+      meta.inputModes !== null ||
+      meta.outputModes !== null;
+    if (chunk || runtimeStatusEvent || hasSessionMetaEvent) {
       hasObservedStreamEvent = true;
     }
     advanceResumeCursor(runtimeStatusEvent?.seq);
@@ -644,7 +644,6 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
       );
     }
 
-    const meta = extractSessionMeta(data);
     const runtimeStatus = runtimeStatusEvent?.state ?? null;
     const hasRuntimeStatusEvent = runtimeStatusEvent !== null;
     if (

--- a/frontend/store/chatRuntime.ts
+++ b/frontend/store/chatRuntime.ts
@@ -625,8 +625,8 @@ export const executeChatRuntime = async <TState extends ChatRuntimeState>(
       meta.streamThreadId !== undefined ||
       meta.streamTurnId !== undefined ||
       meta.transport !== undefined ||
-      meta.inputModes !== null ||
-      meta.outputModes !== null;
+      meta.inputModes !== undefined ||
+      meta.outputModes !== undefined;
     if (chunk || runtimeStatusEvent || hasSessionMetaEvent) {
       hasObservedStreamEvent = true;
     }


### PR DESCRIPTION
## 变更说明

本 PR 围绕 #892，对 Hub 的流式协议消费、内部归一边界与前端渲染协议进行了完整收口，最终覆盖六个方面：

- 后端消费上游流事件时，支持按 `stream-hints` 契约解析 `snake_case` 字段，不再把内部 camelCase key 当作上游输入前提
- 后端统一产出稳定的 `hub` envelope：`hub.version`、`hub.streamBlock`、`hub.runtimeStatus`、`hub.sessionMeta`
- 前端流解析与运行时状态处理改为只消费 `hub` envelope，不再直接解析上游 `artifactUpdate` / `statusUpdate` 的字段形状
- 后端不再把内部 legacy stream 字段回写到对前端暴露的原始流包中
- 修复 `on_event` 后二次归一仍可能读取旧 `hub` 的问题，确保回调修改后的 raw payload 能稳定反映到最终 `hub.streamBlock` 与文本累积结果中
- 将本地 persistence identity 从 raw 上游事件中彻底拆出，改为后端内部 `local persistence overlay`，由 `hub` 归一层显式消费，并通过 `messageIdSource/eventIdSource = local_persistence` 对下游表达来源

当前分支的最终协议边界为：

- 上游到后端：按已协商 extension 和标准语义消费
- 本地持久化 identity：走内部 overlay，不污染 raw upstream event
- 后端到前端：只暴露稳定的 Hub 内部流协议
- 前端：不再感知上游字段 alias，也不再依赖 raw payload 中的内部 key

## 相关提交

本 PR 当前包含以下相关提交：

- `fix(a2a): consume stream-hints contract fields (#892)`
- `refactor(a2a): centralize stream field aliases (#892)`
- `refactor(a2a): stabilize hub stream envelope (#892)`
- `fix(stream): remove outbound legacy stream rewrites (#892)`
- `fix(stream): rebuild hub after on_event mutations (#892)`
- `refactor(stream): isolate local persistence overlay (#892)`
- `refactor(stream): remove adapter-only wrappers (#892)`

## 审查结论

独立审查后，我认为这条 PR 当前已经较完整、较稳健地实现了 #892 想解决的问题，且实现方向符合长期最佳实践。

已经确认收掉的关键风险包括：

- `hub` 构建层现在只基于 raw payload 与内部 overlay 归一，不再复用“优先读 hub”的通用流块提取逻辑
- `on_event` 现在发生在归一化之前，回调对 raw payload 的修改会进入最终 `hub` envelope、缓存与文本累积
- 本地 persistence identity 不再反写 raw upstream event，避免上游语义与本地语义混层
- 新增回归测试覆盖 SSE、WS、blocking consume、route-runner persistence 等关键路径，验证 `hub` 输出、文本累积和本地 overlay 消费保持一致

当前判断：本 PR 与 #892 的关系使用 `Closes #892` 是准确的。

## 关联 Issue

- Closes #892

## 验证结果

已按仓库要求串行执行 scoped checks。

### Backend

- `cd backend && uv run --locked pre-commit run --files app/features/invoke/hub_stream_contract.py app/features/invoke/hub_stream_local_context.py app/features/invoke/service_streaming.py app/features/invoke/stream_persistence.py tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_invoke_stream_persistence.py tests/invoke/test_invoke_route_runner_streaming.py --config ../.pre-commit-config.yaml`
  - 结果：通过
- `cd backend && uv run --locked pytest tests/invoke/test_a2a_invoke_service_streaming.py tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_a2a_invoke_service_contract_fallback.py tests/invoke/test_invoke_stream_persistence.py tests/invoke/test_invoke_route_runner_streaming.py`
  - 结果：`109 passed in 3.10s`

### Frontend

- `cd frontend && npm run lint`
  - 结果：通过
- `cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types`
  - 结果：通过
- `cd frontend && npm test -- --findRelatedTests lib/api/chatStreamBlocks.ts lib/__tests__/streamContract.test.ts --maxWorkers=25%`
  - 结果：`61 passed, 369 total`

