### PR TITLE
refactor(stream): shrink client chunks to top-level canonical payload (#895)

### DIFF
--- a/backend/app/features/invoke/hub_stream_contract.py
+++ b/backend/app/features/invoke/hub_stream_contract.py
@@ -32,6 +32,19 @@ _HUB_STREAM_VERSION = "v1"
 _VALID_EVENT_KINDS = frozenset({"artifact-update", "message", "status-update", "task"})
 
 
+def _compact_payload(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        compacted: dict[str, Any] = {}
+        for key, nested_value in value.items():
+            if nested_value is None:
+                continue
+            compacted[str(key)] = _compact_payload(nested_value)
+        return compacted
+    if isinstance(value, list):
+        return [_compact_payload(item) for item in value]
+    return value
+
+
 def _coerce_string_list(value: Any) -> list[str] | None:
     if not isinstance(value, list):
         return None
@@ -448,10 +461,7 @@ def attach_hub_stream_contract(
     if kind not in _VALID_EVENT_KINDS:
         return
 
-    hub_payload: dict[str, Any] = {
-        "version": _HUB_STREAM_VERSION,
-        "eventKind": kind,
-    }
+    hub_payload: dict[str, Any] = {"version": _HUB_STREAM_VERSION}
     stream_block = _build_stream_block(
         payload,
         upstream_shared_stream=upstream_shared_stream,
@@ -469,4 +479,20 @@ def attach_hub_stream_contract(
     session_meta = _build_session_meta(payload)
     if session_meta is not None:
         hub_payload["sessionMeta"] = session_meta
-    payload["hub"] = hub_payload
+    payload["hub"] = _compact_payload(hub_payload)
+
+
+def project_hub_frontend_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    hub = _dict_field(payload, "hub")
+    if hub.get("version") != _HUB_STREAM_VERSION:
+        return None
+
+    projected_hub: dict[str, Any] = {"version": _HUB_STREAM_VERSION}
+    for field_name in ("streamBlock", "runtimeStatus", "sessionMeta"):
+        field_value = _dict_field(hub, field_name)
+        if field_value:
+            projected_hub[field_name] = _compact_payload(field_value)
+
+    if len(projected_hub) == 1:
+        return None
+    return {"hub": projected_hub}

--- a/backend/app/features/invoke/hub_stream_contract.py
+++ b/backend/app/features/invoke/hub_stream_contract.py
@@ -1,4 +1,4 @@
-"""Stable backend-to-frontend stream contract for Hub clients."""
+"""Stable backend-to-frontend stream contract for client consumers."""
 
 from __future__ import annotations
 
@@ -461,7 +461,7 @@ def attach_hub_stream_contract(
     if kind not in _VALID_EVENT_KINDS:
         return
 
-    hub_payload: dict[str, Any] = {"version": _HUB_STREAM_VERSION}
+    contract_payload: dict[str, Any] = {"version": _HUB_STREAM_VERSION}
     stream_block = _build_stream_block(
         payload,
         upstream_shared_stream=upstream_shared_stream,
@@ -469,30 +469,29 @@ def attach_hub_stream_contract(
         local_event_sequence=local_event_sequence,
     )
     if stream_block is not None:
-        hub_payload["streamBlock"] = stream_block
+        contract_payload["streamBlock"] = stream_block
     runtime_status = _build_runtime_status(
         payload,
         local_event_sequence=local_event_sequence,
     )
     if runtime_status is not None:
-        hub_payload["runtimeStatus"] = runtime_status
+        contract_payload["runtimeStatus"] = runtime_status
     session_meta = _build_session_meta(payload)
     if session_meta is not None:
-        hub_payload["sessionMeta"] = session_meta
-    payload["hub"] = _compact_payload(hub_payload)
+        contract_payload["sessionMeta"] = session_meta
+    payload.update(_compact_payload(contract_payload))
 
 
-def project_hub_frontend_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
-    hub = _dict_field(payload, "hub")
-    if hub.get("version") != _HUB_STREAM_VERSION:
+def project_frontend_stream_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    if payload.get("version") != _HUB_STREAM_VERSION:
         return None
 
-    projected_hub: dict[str, Any] = {"version": _HUB_STREAM_VERSION}
+    projected_payload: dict[str, Any] = {"version": _HUB_STREAM_VERSION}
     for field_name in ("streamBlock", "runtimeStatus", "sessionMeta"):
-        field_value = _dict_field(hub, field_name)
+        field_value = _dict_field(payload, field_name)
         if field_value:
-            projected_hub[field_name] = _compact_payload(field_value)
+            projected_payload[field_name] = _compact_payload(field_value)
 
-    if len(projected_hub) == 1:
+    if len(projected_payload) == 1:
         return None
-    return {"hub": projected_hub}
+    return projected_payload

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -31,7 +31,7 @@ from app.utils.json_encoder import json_dumps
 
 
 def _project_frontend_stream_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    projected = hub_stream_contract.project_hub_frontend_payload(payload)
+    projected = hub_stream_contract.project_frontend_stream_payload(payload)
     return projected if projected is not None else payload
 
 

--- a/backend/app/features/invoke/service_streaming_transport.py
+++ b/backend/app/features/invoke/service_streaming_transport.py
@@ -9,8 +9,7 @@ from typing import Any, Callable
 from fastapi import WebSocket
 from fastapi.responses import StreamingResponse
 
-from app.features.invoke import stream_payloads
-from app.features.invoke.payload_helpers import pick_first_int
+from app.features.invoke import hub_stream_contract, stream_payloads
 from app.features.invoke.service_types import (
     StreamErrorMetadataCallbackFn,
     StreamEventPayloadCallbackFn,
@@ -28,8 +27,12 @@ from app.features.invoke.stream_diagnostics import (
     extract_stream_content_validation_errors,
     warn_non_contract_stream_content_once,
 )
-from app.features.invoke.stream_field_aliases import SEQ_KEYS
 from app.utils.json_encoder import json_dumps
+
+
+def _project_frontend_stream_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    projected = hub_stream_contract.project_hub_frontend_payload(payload)
+    return projected if projected is not None else payload
 
 
 def stream_sse(
@@ -79,19 +82,7 @@ def stream_sse(
                 cache_key, resume_from_sequence
             )
             for cached_sequence, cached_event in cached_events:
-                envelope = stream_payloads.resolve_stream_content_envelope(cached_event)
-                parsed_sequence = pick_first_int(
-                    (
-                        envelope.shared_stream,
-                        envelope.event_metadata,
-                        envelope.artifact_metadata,
-                    ),
-                    SEQ_KEYS,
-                )
-                if parsed_sequence is not None:
-                    seq_counter = max(seq_counter, parsed_sequence)
-                else:
-                    seq_counter = max(seq_counter, cached_sequence)
+                seq_counter = max(seq_counter, cached_sequence)
                 stream_text_accumulator.consume(cached_event)
                 yield f"data: {json_dumps(cached_event, ensure_ascii=False)}\n\n"
 
@@ -148,6 +139,7 @@ def stream_sse(
                 runtime._ensure_outbound_stream_contract(
                     serialized, event_sequence=event_sequence
                 )
+                outbound_payload = _project_frontend_stream_payload(serialized)
                 seq_counter = max(seq_counter, event_sequence)
                 stream_block, non_contract_reason = (
                     stream_payloads.analyze_stream_chunk_contract(serialized)
@@ -162,11 +154,11 @@ def stream_sse(
                 )
                 if cache_key:
                     await global_stream_cache.append_event(
-                        cache_key, serialized, seq_counter
+                        cache_key, outbound_payload, seq_counter
                     )
                 stream_text_accumulator.consume(serialized, stream_block=stream_block)
                 last_event_at = time.monotonic()
-                yield f"data: {json_dumps(serialized, ensure_ascii=False)}\n\n"
+                yield f"data: {json_dumps(outbound_payload, ensure_ascii=False)}\n\n"
                 if runtime._is_terminal_status_event(serialized):
                     terminal_event_seen = True
                     break
@@ -239,7 +231,10 @@ def stream_sse(
                     finalization_event,
                     event_sequence=seq_counter + 1,
                 )
-                yield f"data: {json_dumps(finalization_event, ensure_ascii=False)}\n\n"
+                yield (
+                    "data: "
+                    f"{json_dumps(_project_frontend_stream_payload(finalization_event), ensure_ascii=False)}\n\n"
+                )
             if not client_disconnected:
                 yield "event: stream_end\ndata: {}\n\n"
 
@@ -301,19 +296,7 @@ async def stream_ws(
             cache_key, resume_from_sequence
         )
         for cached_sequence, cached_event in cached_events:
-            envelope = stream_payloads.resolve_stream_content_envelope(cached_event)
-            parsed_sequence = pick_first_int(
-                (
-                    envelope.shared_stream,
-                    envelope.event_metadata,
-                    envelope.artifact_metadata,
-                ),
-                SEQ_KEYS,
-            )
-            if parsed_sequence is not None:
-                seq_counter = max(seq_counter, parsed_sequence)
-            else:
-                seq_counter = max(seq_counter, cached_sequence)
+            seq_counter = max(seq_counter, cached_sequence)
             stream_text_accumulator.consume(cached_event)
             await websocket.send_text(json_dumps(cached_event, ensure_ascii=False))
 
@@ -372,6 +355,7 @@ async def stream_ws(
             runtime._ensure_outbound_stream_contract(
                 serialized, event_sequence=event_sequence
             )
+            outbound_payload = _project_frontend_stream_payload(serialized)
             seq_counter = max(seq_counter, event_sequence)
             stream_block, non_contract_reason = (
                 stream_payloads.analyze_stream_chunk_contract(serialized)
@@ -386,11 +370,11 @@ async def stream_ws(
             )
             if cache_key:
                 await global_stream_cache.append_event(
-                    cache_key, serialized, seq_counter
+                    cache_key, outbound_payload, seq_counter
                 )
             stream_text_accumulator.consume(serialized, stream_block=stream_block)
             last_event_at = time.monotonic()
-            await websocket.send_text(json_dumps(serialized, ensure_ascii=False))
+            await websocket.send_text(json_dumps(outbound_payload, ensure_ascii=False))
             if runtime._is_terminal_status_event(serialized):
                 terminal_event_seen = True
                 break
@@ -482,7 +466,10 @@ async def stream_ws(
                 event_sequence=seq_counter + 1,
             )
             await websocket.send_text(
-                json_dumps(finalization_event, ensure_ascii=False)
+                json_dumps(
+                    _project_frontend_stream_payload(finalization_event),
+                    ensure_ascii=False,
+                )
             )
         if send_stream_end and not client_disconnected:
             await runtime.send_ws_stream_end(websocket)

--- a/backend/app/features/invoke/stream_payloads.py
+++ b/backend/app/features/invoke/stream_payloads.py
@@ -141,13 +141,12 @@ def resolve_stream_content_envelope(
     )
 
 
-def _extract_stream_chunk_from_hub_envelope(
+def _extract_stream_chunk_from_stream_envelope(
     payload: dict[str, Any],
 ) -> dict[str, Any] | None:
-    hub = _dict_field(payload, "hub")
-    if hub.get("version") != "v1":
+    if payload.get("version") != "v1":
         return None
-    stream_block = _dict_field(hub, "streamBlock")
+    stream_block = _dict_field(payload, "streamBlock")
     if not stream_block:
         return None
 
@@ -572,9 +571,9 @@ def extract_raw_stream_chunk_from_serialized_event(
 def extract_stream_chunk_from_serialized_event(
     payload: dict[str, Any],
 ) -> dict[str, Any] | None:
-    hub_stream_chunk = _extract_stream_chunk_from_hub_envelope(payload)
-    if hub_stream_chunk is not None:
-        return hub_stream_chunk
+    stream_envelope_chunk = _extract_stream_chunk_from_stream_envelope(payload)
+    if stream_envelope_chunk is not None:
+        return stream_envelope_chunk
     return extract_raw_stream_chunk_from_serialized_event(payload)
 
 

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.features.invoke.hub_stream_contract import project_hub_frontend_payload
 from app.features.invoke.hub_stream_local_context import attach_local_stream_context
 from app.features.invoke.stream_payloads import resolve_stream_content_envelope
 from tests.invoke.a2a_invoke_service_support import (
@@ -522,7 +523,6 @@ def test_ensure_outbound_stream_contract_attaches_hub_message_contract_only():
     assert payload["message"]["role"] == "ROLE_AGENT"
     assert payload["message"]["messageId"] == "msg-root-2"
     assert payload["hub"]["version"] == "v1"
-    assert payload["hub"]["eventKind"] == "message"
     assert payload["hub"]["streamBlock"]["seq"] == 4
     assert payload["hub"]["streamBlock"]["eventId"] == "seq:msg-root-2:4"
     assert payload["hub"]["streamBlock"]["messageId"] == "msg-root-2"
@@ -554,7 +554,6 @@ def test_ensure_outbound_stream_contract_attaches_hub_status_contract_only():
         {"text": "render status message"}
     ]
     assert payload["hub"]["version"] == "v1"
-    assert payload["hub"]["eventKind"] == "status-update"
     assert payload["hub"]["streamBlock"]["seq"] == 5
     assert payload["hub"]["streamBlock"]["eventId"] == "seq:msg-status-2:5"
     assert payload["hub"]["streamBlock"]["messageId"] == "msg-status-2"
@@ -641,6 +640,70 @@ def test_ensure_outbound_stream_contract_consumes_local_stream_overlay():
     assert payload["hub"]["streamBlock"]["blockId"] == "block-local-1"
     assert payload["hub"]["streamBlock"]["baseSeq"] == 2
     assert payload["hub"]["streamBlock"]["op"] == "replace"
+
+
+def test_project_hub_frontend_payload_omits_raw_event_and_none_fields():
+    payload = {
+        "artifactUpdate": {
+            "artifact": {"artifactId": "task-projected-1:stream:text"},
+        },
+        "hub": {
+            "version": "v1",
+            "streamBlock": {
+                "eventId": "evt-projected-1",
+                "seq": 7,
+                "taskId": "task-projected-1",
+                "artifactId": "task-projected-1:stream:text",
+                "blockId": "task-projected-1:primary_text",
+                "laneId": "primary_text",
+                "blockType": "text",
+                "op": "append",
+                "baseSeq": None,
+                "source": None,
+                "messageId": "msg-projected-1",
+                "role": "agent",
+                "delta": "hello",
+                "append": True,
+                "done": False,
+            },
+            "runtimeStatus": {
+                "state": "working",
+                "isFinal": False,
+                "interrupt": None,
+                "seq": 7,
+                "completionPhase": None,
+                "messageId": None,
+            },
+        },
+    }
+
+    projected = project_hub_frontend_payload(payload)
+
+    assert projected == {
+        "hub": {
+            "version": "v1",
+            "streamBlock": {
+                "eventId": "evt-projected-1",
+                "seq": 7,
+                "taskId": "task-projected-1",
+                "artifactId": "task-projected-1:stream:text",
+                "blockId": "task-projected-1:primary_text",
+                "laneId": "primary_text",
+                "blockType": "text",
+                "op": "append",
+                "messageId": "msg-projected-1",
+                "role": "agent",
+                "delta": "hello",
+                "append": True,
+                "done": False,
+            },
+            "runtimeStatus": {
+                "state": "working",
+                "isFinal": False,
+                "seq": 7,
+            },
+        }
+    }
 
 
 def test_serialize_stream_event_keeps_canonical_message_payload_before_validation(

--- a/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_stream_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from app.features.invoke.hub_stream_contract import project_hub_frontend_payload
+from app.features.invoke.hub_stream_contract import project_frontend_stream_payload
 from app.features.invoke.hub_stream_local_context import attach_local_stream_context
 from app.features.invoke.stream_payloads import resolve_stream_content_envelope
 from tests.invoke.a2a_invoke_service_support import (
@@ -522,12 +522,12 @@ def test_ensure_outbound_stream_contract_attaches_hub_message_contract_only():
     assert payload["message"]["parts"] == [{"text": "render me"}]
     assert payload["message"]["role"] == "ROLE_AGENT"
     assert payload["message"]["messageId"] == "msg-root-2"
-    assert payload["hub"]["version"] == "v1"
-    assert payload["hub"]["streamBlock"]["seq"] == 4
-    assert payload["hub"]["streamBlock"]["eventId"] == "seq:msg-root-2:4"
-    assert payload["hub"]["streamBlock"]["messageId"] == "msg-root-2"
-    assert payload["hub"]["streamBlock"]["blockType"] == "text"
-    assert payload["hub"]["streamBlock"]["op"] == "replace"
+    assert payload["version"] == "v1"
+    assert payload["streamBlock"]["seq"] == 4
+    assert payload["streamBlock"]["eventId"] == "seq:msg-root-2:4"
+    assert payload["streamBlock"]["messageId"] == "msg-root-2"
+    assert payload["streamBlock"]["blockType"] == "text"
+    assert payload["streamBlock"]["op"] == "replace"
 
 
 def test_ensure_outbound_stream_contract_attaches_hub_status_contract_only():
@@ -553,14 +553,14 @@ def test_ensure_outbound_stream_contract_attaches_hub_status_contract_only():
     assert payload["statusUpdate"]["status"]["message"]["parts"] == [
         {"text": "render status message"}
     ]
-    assert payload["hub"]["version"] == "v1"
-    assert payload["hub"]["streamBlock"]["seq"] == 5
-    assert payload["hub"]["streamBlock"]["eventId"] == "seq:msg-status-2:5"
-    assert payload["hub"]["streamBlock"]["messageId"] == "msg-status-2"
-    assert payload["hub"]["runtimeStatus"]["state"] == "working"
-    assert payload["hub"]["runtimeStatus"]["isFinal"] is False
-    assert payload["hub"]["runtimeStatus"]["seq"] == 5
-    assert payload["hub"]["runtimeStatus"]["messageId"] == "msg-status-2"
+    assert payload["version"] == "v1"
+    assert payload["streamBlock"]["seq"] == 5
+    assert payload["streamBlock"]["eventId"] == "seq:msg-status-2:5"
+    assert payload["streamBlock"]["messageId"] == "msg-status-2"
+    assert payload["runtimeStatus"]["state"] == "working"
+    assert payload["runtimeStatus"]["isFinal"] is False
+    assert payload["runtimeStatus"]["seq"] == 5
+    assert payload["runtimeStatus"]["messageId"] == "msg-status-2"
 
 
 def test_ensure_outbound_stream_contract_exposes_fallback_message_identity_in_hub():
@@ -580,11 +580,11 @@ def test_ensure_outbound_stream_contract_exposes_fallback_message_identity_in_hu
         event_sequence=6,
     )
 
-    assert payload["hub"]["streamBlock"]["messageId"] == "task:task-fallback-1"
-    assert payload["hub"]["streamBlock"]["messageIdSource"] == "task_fallback"
-    assert payload["hub"]["streamBlock"]["eventIdSource"] == "fallback_seq"
-    assert payload["hub"]["streamBlock"]["seq"] == 6
-    assert payload["hub"]["streamBlock"]["eventId"] == "seq:task:task-fallback-1:6"
+    assert payload["streamBlock"]["messageId"] == "task:task-fallback-1"
+    assert payload["streamBlock"]["messageIdSource"] == "task_fallback"
+    assert payload["streamBlock"]["eventIdSource"] == "fallback_seq"
+    assert payload["streamBlock"]["seq"] == 6
+    assert payload["streamBlock"]["eventId"] == "seq:task:task-fallback-1:6"
 
 
 def test_ensure_outbound_stream_contract_consumes_local_stream_overlay():
@@ -632,77 +632,73 @@ def test_ensure_outbound_stream_contract_consumes_local_stream_overlay():
         "eventId": "evt-upstream-local-1",
         "seq": 9,
     }
-    assert payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
-    assert payload["hub"]["streamBlock"]["messageIdSource"] == "local_persistence"
-    assert payload["hub"]["streamBlock"]["eventId"] == "evt-local-1"
-    assert payload["hub"]["streamBlock"]["eventIdSource"] == "local_persistence"
-    assert payload["hub"]["streamBlock"]["seq"] == 3
-    assert payload["hub"]["streamBlock"]["blockId"] == "block-local-1"
-    assert payload["hub"]["streamBlock"]["baseSeq"] == 2
-    assert payload["hub"]["streamBlock"]["op"] == "replace"
+    assert payload["streamBlock"]["messageId"] == "msg-local-1"
+    assert payload["streamBlock"]["messageIdSource"] == "local_persistence"
+    assert payload["streamBlock"]["eventId"] == "evt-local-1"
+    assert payload["streamBlock"]["eventIdSource"] == "local_persistence"
+    assert payload["streamBlock"]["seq"] == 3
+    assert payload["streamBlock"]["blockId"] == "block-local-1"
+    assert payload["streamBlock"]["baseSeq"] == 2
+    assert payload["streamBlock"]["op"] == "replace"
 
 
-def test_project_hub_frontend_payload_omits_raw_event_and_none_fields():
+def test_project_frontend_stream_payload_omits_raw_event_and_none_fields():
     payload = {
         "artifactUpdate": {
             "artifact": {"artifactId": "task-projected-1:stream:text"},
         },
-        "hub": {
-            "version": "v1",
-            "streamBlock": {
-                "eventId": "evt-projected-1",
-                "seq": 7,
-                "taskId": "task-projected-1",
-                "artifactId": "task-projected-1:stream:text",
-                "blockId": "task-projected-1:primary_text",
-                "laneId": "primary_text",
-                "blockType": "text",
-                "op": "append",
-                "baseSeq": None,
-                "source": None,
-                "messageId": "msg-projected-1",
-                "role": "agent",
-                "delta": "hello",
-                "append": True,
-                "done": False,
-            },
-            "runtimeStatus": {
-                "state": "working",
-                "isFinal": False,
-                "interrupt": None,
-                "seq": 7,
-                "completionPhase": None,
-                "messageId": None,
-            },
+        "version": "v1",
+        "streamBlock": {
+            "eventId": "evt-projected-1",
+            "seq": 7,
+            "taskId": "task-projected-1",
+            "artifactId": "task-projected-1:stream:text",
+            "blockId": "task-projected-1:primary_text",
+            "laneId": "primary_text",
+            "blockType": "text",
+            "op": "append",
+            "baseSeq": None,
+            "source": None,
+            "messageId": "msg-projected-1",
+            "role": "agent",
+            "delta": "hello",
+            "append": True,
+            "done": False,
+        },
+        "runtimeStatus": {
+            "state": "working",
+            "isFinal": False,
+            "interrupt": None,
+            "seq": 7,
+            "completionPhase": None,
+            "messageId": None,
         },
     }
 
-    projected = project_hub_frontend_payload(payload)
+    projected = project_frontend_stream_payload(payload)
 
     assert projected == {
-        "hub": {
-            "version": "v1",
-            "streamBlock": {
-                "eventId": "evt-projected-1",
-                "seq": 7,
-                "taskId": "task-projected-1",
-                "artifactId": "task-projected-1:stream:text",
-                "blockId": "task-projected-1:primary_text",
-                "laneId": "primary_text",
-                "blockType": "text",
-                "op": "append",
-                "messageId": "msg-projected-1",
-                "role": "agent",
-                "delta": "hello",
-                "append": True,
-                "done": False,
-            },
-            "runtimeStatus": {
-                "state": "working",
-                "isFinal": False,
-                "seq": 7,
-            },
-        }
+        "version": "v1",
+        "streamBlock": {
+            "eventId": "evt-projected-1",
+            "seq": 7,
+            "taskId": "task-projected-1",
+            "artifactId": "task-projected-1:stream:text",
+            "blockId": "task-projected-1:primary_text",
+            "laneId": "primary_text",
+            "blockType": "text",
+            "op": "append",
+            "messageId": "msg-projected-1",
+            "role": "agent",
+            "delta": "hello",
+            "append": True,
+            "done": False,
+        },
+        "runtimeStatus": {
+            "state": "working",
+            "isFinal": False,
+            "seq": 7,
+        },
     }
 
 

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -61,7 +61,7 @@ def _extract_stream_payloads(frames: list[str]) -> list[dict]:
     return [
         json.loads(line.removeprefix("data: "))
         for line in "".join(frames).splitlines()
-        if line.startswith("data: ") and '"hub"' in line
+        if line.startswith("data: ") and '"version"' in line
     ]
 
 
@@ -805,11 +805,11 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
     initial_payload = next(
         payload
         for payload in _extract_stream_payloads(initial_frames)
-        if payload.get("hub", {}).get("streamBlock")
+        if payload.get("streamBlock")
     )
-    assert initial_payload["hub"]["streamBlock"]["seq"] == 1
-    assert initial_payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
-    assert initial_payload["hub"]["streamBlock"]["eventId"] == "evt-cache-1"
+    assert initial_payload["streamBlock"]["seq"] == 1
+    assert initial_payload["streamBlock"]["messageId"] == "msg-local-1"
+    assert initial_payload["streamBlock"]["eventId"] == "evt-cache-1"
 
     replay = a2a_invoke_service.stream_sse(
         gateway=_GatewayWithEvents([]),
@@ -830,11 +830,11 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
     replay_payload = next(
         payload
         for payload in _extract_stream_payloads(replay_frames)
-        if payload.get("hub", {}).get("streamBlock")
+        if payload.get("streamBlock")
     )
-    assert replay_payload["hub"]["streamBlock"]["seq"] == 1
-    assert replay_payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
-    assert replay_payload["hub"]["streamBlock"]["eventId"] == "evt-cache-1"
+    assert replay_payload["streamBlock"]["seq"] == 1
+    assert replay_payload["streamBlock"]["messageId"] == "msg-local-1"
+    assert replay_payload["streamBlock"]["eventId"] == "evt-cache-1"
 
     await global_stream_cache.mark_completed(cache_key)
 
@@ -877,9 +877,9 @@ async def test_sse_rebuilds_hub_stream_block_after_on_event_text_mutation():
 
     payloads = _extract_stream_payloads(frames)
     artifact_payload = next(
-        payload for payload in payloads if payload["hub"].get("streamBlock")
+        payload for payload in payloads if payload.get("streamBlock")
     )
-    assert artifact_payload["hub"]["streamBlock"]["delta"] == "rewritten"
+    assert artifact_payload["streamBlock"]["delta"] == "rewritten"
     assert completed == ["rewritten"]
 
 
@@ -965,14 +965,12 @@ async def test_sse_preserves_upstream_seq_in_hub_stream_blocks():
         frames.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
 
     payloads = _extract_stream_payloads(frames)
-    artifact_payloads = [
-        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
-    ]
-    assert [payload["hub"]["streamBlock"]["seq"] for payload in artifact_payloads] == [
+    artifact_payloads = [payload for payload in payloads if payload.get("streamBlock")]
+    assert [payload["streamBlock"]["seq"] for payload in artifact_payloads] == [
         9,
         12,
     ]
-    assert payloads[-1]["hub"]["runtimeStatus"]["seq"] == 3
+    assert payloads[-1]["runtimeStatus"]["seq"] == 3
 
 
 @pytest.mark.asyncio
@@ -1001,15 +999,13 @@ async def test_sse_preserves_canonical_message_payload_for_upstream_message_even
 
     payloads = _extract_stream_payloads(frames)
     message_payload = next(
-        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
+        payload for payload in payloads if payload.get("streamBlock")
     )
-    assert message_payload["hub"]["streamBlock"]["seq"] == 1
-    assert message_payload["hub"]["streamBlock"]["messageId"] == "msg-upstream-sse-1"
-    assert (
-        message_payload["hub"]["streamBlock"]["eventId"] == "seq:msg-upstream-sse-1:1"
-    )
-    assert message_payload["hub"]["streamBlock"]["blockType"] == "text"
-    assert message_payload["hub"]["streamBlock"]["op"] == "replace"
+    assert message_payload["streamBlock"]["seq"] == 1
+    assert message_payload["streamBlock"]["messageId"] == "msg-upstream-sse-1"
+    assert message_payload["streamBlock"]["eventId"] == "seq:msg-upstream-sse-1:1"
+    assert message_payload["streamBlock"]["blockType"] == "text"
+    assert message_payload["streamBlock"]["op"] == "replace"
 
 
 @pytest.mark.asyncio
@@ -1108,7 +1104,7 @@ async def test_ws_breaks_stream_after_terminal_status_update():
     )
 
     payloads = [json.loads(item) for item in websocket.sent]
-    assert "runtimeStatus" in payloads[0]["hub"]
+    assert "runtimeStatus" in payloads[0]
     assert payloads[-1]["event"] == "stream_end"
     assert not any(
         item.get("content") == "should-not-be-forwarded" for item in payloads
@@ -1142,16 +1138,16 @@ async def test_ws_preserves_canonical_message_payload_for_upstream_message_event
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{") and '"hub"' in item
+        if item.startswith("{") and '"version"' in item
     ]
     message_payload = next(
-        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
+        payload for payload in payloads if payload.get("streamBlock")
     )
-    assert message_payload["hub"]["streamBlock"]["seq"] == 1
-    assert message_payload["hub"]["streamBlock"]["messageId"] == "msg-upstream-ws-1"
-    assert message_payload["hub"]["streamBlock"]["eventId"] == "seq:msg-upstream-ws-1:1"
-    assert message_payload["hub"]["streamBlock"]["blockType"] == "text"
-    assert message_payload["hub"]["streamBlock"]["op"] == "replace"
+    assert message_payload["streamBlock"]["seq"] == 1
+    assert message_payload["streamBlock"]["messageId"] == "msg-upstream-ws-1"
+    assert message_payload["streamBlock"]["eventId"] == "seq:msg-upstream-ws-1:1"
+    assert message_payload["streamBlock"]["blockType"] == "text"
+    assert message_payload["streamBlock"]["op"] == "replace"
 
 
 @pytest.mark.asyncio
@@ -1199,8 +1195,7 @@ async def test_ws_emits_persisted_completion_ack_before_stream_end():
     persisted_index = next(
         index
         for index, item in enumerate(payloads)
-        if item.get("hub", {}).get("runtimeStatus", {}).get("completionPhase")
-        == "persisted"
+        if item.get("runtimeStatus", {}).get("completionPhase") == "persisted"
     )
     stream_end_index = next(
         index
@@ -1250,10 +1245,10 @@ async def test_ws_assigns_fallback_seq_and_event_id_after_on_event_mutation():
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{") and '"hub"' in item
+        if item.startswith("{") and '"version"' in item
     ]
     assert payloads
-    stream_block = payloads[0]["hub"]["streamBlock"]
+    stream_block = payloads[0]["streamBlock"]
     assert stream_block["seq"] == 1
     assert stream_block["messageId"] == "msg-local-ws-1"
     assert stream_block["eventId"] == "seq:msg-local-ws-1:1"
@@ -1292,10 +1287,10 @@ async def test_ws_rebuilds_hub_stream_block_after_on_event_text_mutation():
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{") and '"hub"' in item
+        if item.startswith("{") and '"version"' in item
     ]
     assert payloads
-    assert payloads[0]["hub"]["streamBlock"]["delta"] == "rewritten"
+    assert payloads[0]["streamBlock"]["delta"] == "rewritten"
 
 
 @pytest.mark.asyncio
@@ -1357,16 +1352,14 @@ async def test_ws_preserves_upstream_seq_in_hub_stream_blocks():
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{") and '"hub"' in item
+        if item.startswith("{") and '"version"' in item
     ]
-    artifact_payloads = [
-        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
-    ]
-    assert [payload["hub"]["streamBlock"]["seq"] for payload in artifact_payloads] == [
+    artifact_payloads = [payload for payload in payloads if payload.get("streamBlock")]
+    assert [payload["streamBlock"]["seq"] for payload in artifact_payloads] == [
         9,
         12,
     ]
-    assert payloads[-1]["hub"]["runtimeStatus"]["seq"] == 3
+    assert payloads[-1]["runtimeStatus"]["seq"] == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/invoke/test_a2a_invoke_service_streaming.py
+++ b/backend/tests/invoke/test_a2a_invoke_service_streaming.py
@@ -61,12 +61,7 @@ def _extract_stream_payloads(frames: list[str]) -> list[dict]:
     return [
         json.loads(line.removeprefix("data: "))
         for line in "".join(frames).splitlines()
-        if line.startswith("data: ")
-        and (
-            '"artifactUpdate"' in line
-            or '"message"' in line
-            or '"statusUpdate"' in line
-        )
+        if line.startswith("data: ") and '"hub"' in line
     ]
 
 
@@ -711,7 +706,6 @@ async def test_sse_accepts_tool_call_data_parts_without_non_contract_warning(cap
     ]
     assert warning_records == []
     payload = "".join(frames)
-    assert '"artifactUpdate"' in payload
     assert '"blockType": "tool_call"' in payload
 
 
@@ -761,7 +755,7 @@ async def test_sse_validates_status_message_content_events(caplog):
     assert len(warning_records) == 1
     payload = "".join(frames)
     assert '"msg-status-invalid"' not in payload
-    assert '"TASK_STATE_COMPLETED"' in payload
+    assert '"state": "completed"' in payload
 
 
 @pytest.mark.asyncio
@@ -811,16 +805,11 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
     initial_payload = next(
         payload
         for payload in _extract_stream_payloads(initial_frames)
-        if "artifactUpdate" in payload
+        if payload.get("hub", {}).get("streamBlock")
     )
-    initial_shared_stream = initial_payload["artifactUpdate"]["artifact"]["metadata"][
-        "shared"
-    ]["stream"]
-    assert initial_shared_stream["messageId"] == "msg-local-1"
-    assert initial_shared_stream["eventId"] == "evt-cache-1"
-    assert "seq" not in initial_shared_stream
     assert initial_payload["hub"]["streamBlock"]["seq"] == 1
     assert initial_payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
+    assert initial_payload["hub"]["streamBlock"]["eventId"] == "evt-cache-1"
 
     replay = a2a_invoke_service.stream_sse(
         gateway=_GatewayWithEvents([]),
@@ -841,16 +830,11 @@ async def test_sse_cache_replays_mutated_event_payload_from_on_event():
     replay_payload = next(
         payload
         for payload in _extract_stream_payloads(replay_frames)
-        if "artifactUpdate" in payload
+        if payload.get("hub", {}).get("streamBlock")
     )
-    replay_shared_stream = replay_payload["artifactUpdate"]["artifact"]["metadata"][
-        "shared"
-    ]["stream"]
-    assert replay_shared_stream["messageId"] == "msg-local-1"
-    assert replay_shared_stream["eventId"] == "evt-cache-1"
-    assert "seq" not in replay_shared_stream
     assert replay_payload["hub"]["streamBlock"]["seq"] == 1
     assert replay_payload["hub"]["streamBlock"]["messageId"] == "msg-local-1"
+    assert replay_payload["hub"]["streamBlock"]["eventId"] == "evt-cache-1"
 
     await global_stream_cache.mark_completed(cache_key)
 
@@ -893,11 +877,8 @@ async def test_sse_rebuilds_hub_stream_block_after_on_event_text_mutation():
 
     payloads = _extract_stream_payloads(frames)
     artifact_payload = next(
-        payload for payload in payloads if "artifactUpdate" in payload
+        payload for payload in payloads if payload["hub"].get("streamBlock")
     )
-    assert artifact_payload["artifactUpdate"]["artifact"]["parts"] == [
-        {"text": "rewritten"}
-    ]
     assert artifact_payload["hub"]["streamBlock"]["delta"] == "rewritten"
     assert completed == ["rewritten"]
 
@@ -984,7 +965,9 @@ async def test_sse_preserves_upstream_seq_in_hub_stream_blocks():
         frames.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
 
     payloads = _extract_stream_payloads(frames)
-    artifact_payloads = [payload for payload in payloads if "artifactUpdate" in payload]
+    artifact_payloads = [
+        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
+    ]
     assert [payload["hub"]["streamBlock"]["seq"] for payload in artifact_payloads] == [
         9,
         12,
@@ -1017,11 +1000,9 @@ async def test_sse_preserves_canonical_message_payload_for_upstream_message_even
         frames.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
 
     payloads = _extract_stream_payloads(frames)
-    message_payload = next(payload for payload in payloads if "message" in payload)
-    assert message_payload["message"]["messageId"] == "msg-upstream-sse-1"
-    assert message_payload["message"]["role"] == "ROLE_AGENT"
-    assert message_payload["message"]["parts"] == [{"text": "hello from raw message"}]
-    assert "metadata" not in message_payload["message"]
+    message_payload = next(
+        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
+    )
     assert message_payload["hub"]["streamBlock"]["seq"] == 1
     assert message_payload["hub"]["streamBlock"]["messageId"] == "msg-upstream-sse-1"
     assert (
@@ -1053,7 +1034,7 @@ async def test_sse_breaks_stream_after_terminal_status_update():
         chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
 
     payload = "".join(chunks)
-    assert '"statusUpdate"' in payload
+    assert '"runtimeStatus"' in payload
     assert "should-not-be-forwarded" not in payload
     assert "event: stream_end" in payload
 
@@ -1127,7 +1108,7 @@ async def test_ws_breaks_stream_after_terminal_status_update():
     )
 
     payloads = [json.loads(item) for item in websocket.sent]
-    assert "statusUpdate" in payloads[0]
+    assert "runtimeStatus" in payloads[0]["hub"]
     assert payloads[-1]["event"] == "stream_end"
     assert not any(
         item.get("content") == "should-not-be-forwarded" for item in payloads
@@ -1161,18 +1142,11 @@ async def test_ws_preserves_canonical_message_payload_for_upstream_message_event
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{")
-        and (
-            '"artifactUpdate"' in item
-            or '"message"' in item
-            or '"statusUpdate"' in item
-        )
+        if item.startswith("{") and '"hub"' in item
     ]
-    message_payload = next(payload for payload in payloads if "message" in payload)
-    assert message_payload["message"]["messageId"] == "msg-upstream-ws-1"
-    assert message_payload["message"]["role"] == "ROLE_AGENT"
-    assert message_payload["message"]["parts"] == [{"text": "hello from raw message"}]
-    assert "metadata" not in message_payload["message"]
+    message_payload = next(
+        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
+    )
     assert message_payload["hub"]["streamBlock"]["seq"] == 1
     assert message_payload["hub"]["streamBlock"]["messageId"] == "msg-upstream-ws-1"
     assert message_payload["hub"]["streamBlock"]["eventId"] == "seq:msg-upstream-ws-1:1"
@@ -1225,11 +1199,7 @@ async def test_ws_emits_persisted_completion_ack_before_stream_end():
     persisted_index = next(
         index
         for index, item in enumerate(payloads)
-        if item.get("statusUpdate", {})
-        .get("metadata", {})
-        .get("shared", {})
-        .get("stream", {})
-        .get("completionPhase")
+        if item.get("hub", {}).get("runtimeStatus", {}).get("completionPhase")
         == "persisted"
     )
     stream_end_index = next(
@@ -1280,18 +1250,13 @@ async def test_ws_assigns_fallback_seq_and_event_id_after_on_event_mutation():
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{") and '"artifactUpdate"' in item
+        if item.startswith("{") and '"hub"' in item
     ]
     assert payloads
-    assert payloads[0]["artifactUpdate"]["artifact"]["metadata"]["shared"][
-        "stream"
-    ] == {
-        "blockType": "text",
-        "messageId": "msg-local-ws-1",
-    }
-    assert payloads[0]["hub"]["streamBlock"]["seq"] == 1
-    assert payloads[0]["hub"]["streamBlock"]["messageId"] == "msg-local-ws-1"
-    assert payloads[0]["hub"]["streamBlock"]["eventId"] == "seq:msg-local-ws-1:1"
+    stream_block = payloads[0]["hub"]["streamBlock"]
+    assert stream_block["seq"] == 1
+    assert stream_block["messageId"] == "msg-local-ws-1"
+    assert stream_block["eventId"] == "seq:msg-local-ws-1:1"
 
 
 @pytest.mark.asyncio
@@ -1327,10 +1292,9 @@ async def test_ws_rebuilds_hub_stream_block_after_on_event_text_mutation():
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{") and '"artifactUpdate"' in item
+        if item.startswith("{") and '"hub"' in item
     ]
     assert payloads
-    assert payloads[0]["artifactUpdate"]["artifact"]["parts"] == [{"text": "rewritten"}]
     assert payloads[0]["hub"]["streamBlock"]["delta"] == "rewritten"
 
 
@@ -1393,10 +1357,11 @@ async def test_ws_preserves_upstream_seq_in_hub_stream_blocks():
     payloads = [
         json.loads(item)
         for item in websocket.sent
-        if item.startswith("{")
-        and ('"artifactUpdate"' in item or '"statusUpdate"' in item)
+        if item.startswith("{") and '"hub"' in item
     ]
-    artifact_payloads = [payload for payload in payloads if "artifactUpdate" in payload]
+    artifact_payloads = [
+        payload for payload in payloads if payload.get("hub", {}).get("streamBlock")
+    ]
     assert [payload["hub"]["streamBlock"]["seq"] for payload in artifact_payloads] == [
         9,
         12,

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -119,7 +119,7 @@ Message id contract:
 - Structured command results may be persisted as `data` blocks and should render as first-class canonical history blocks rather than overlay text fallbacks.
 - `blocks:query` detail items include `messageId` and must match the target message before cache patching.
 - `tool_call` blocks may include a normalized `toolCall` view from backend (`name`, `status`, `callId`, `arguments`, `result`, `error`); frontend should render that stable field instead of parsing provider-private raw payloads.
-- Frontend stream rendering reads only the backend `hub` envelope (`hub.version`, `hub.streamBlock`, `hub.runtimeStatus`, `hub.sessionMeta`); raw upstream A2A stream payloads stay on the backend for diagnostics and are no longer forwarded to the client stream.
+- Frontend stream rendering reads only the backend top-level canonical stream payload (`version`, `streamBlock`, `runtimeStatus`, `sessionMeta`); raw upstream A2A stream payloads stay on the backend for diagnostics and are no longer forwarded to the client stream.
 - Invoke payloads should carry both `userMessageId` and `agentMessageId` (UUID).
 - Message status semantics are preserved from history payloads (`streaming`, `done`, `error`, `interrupted`).
 - The Hub Assistant is injected into the normal agent catalog and reuses the existing permission interrupt card: read-only runs can return a `permission` interrupt, and the same UI resolves it through the dedicated hub-assistant reply endpoint.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -119,7 +119,7 @@ Message id contract:
 - Structured command results may be persisted as `data` blocks and should render as first-class canonical history blocks rather than overlay text fallbacks.
 - `blocks:query` detail items include `messageId` and must match the target message before cache patching.
 - `tool_call` blocks may include a normalized `toolCall` view from backend (`name`, `status`, `callId`, `arguments`, `result`, `error`); frontend should render that stable field instead of parsing provider-private raw payloads.
-- Frontend stream rendering reads only the backend `hub` envelope (`hub.version`, `hub.streamBlock`, `hub.runtimeStatus`, `hub.sessionMeta`); upstream A2A `artifactUpdate` / `statusUpdate` payloads remain available for diagnostics but are no longer parsed on the client.
+- Frontend stream rendering reads only the backend `hub` envelope (`hub.version`, `hub.streamBlock`, `hub.runtimeStatus`, `hub.sessionMeta`); raw upstream A2A stream payloads stay on the backend for diagnostics and are no longer forwarded to the client stream.
 - Invoke payloads should carry both `userMessageId` and `agentMessageId` (UUID).
 - Message status semantics are preserved from history payloads (`streaming`, `done`, `error`, `interrupted`).
 - The Hub Assistant is injected into the normal agent catalog and reuses the existing permission interrupt card: read-only runs can return a `permission` interrupt, and the same UI resolves it through the dedicated hub-assistant reply endpoint.

--- a/frontend/lib/__tests__/streamBlockOperationContract.test.ts
+++ b/frontend/lib/__tests__/streamBlockOperationContract.test.ts
@@ -15,7 +15,6 @@ const normalizeParsedUpdate = (
     ...payload,
     hub: {
       version: "v1",
-      eventKind: "artifact-update",
       streamBlock: {
         eventId: expected.eventId,
         eventIdSource: "upstream",

--- a/frontend/lib/__tests__/streamBlockOperationContract.test.ts
+++ b/frontend/lib/__tests__/streamBlockOperationContract.test.ts
@@ -13,30 +13,28 @@ const normalizeParsedUpdate = (
 ) => {
   const parsed = extractStreamBlockUpdate({
     ...payload,
-    hub: {
-      version: "v1",
-      streamBlock: {
-        eventId: expected.eventId,
-        eventIdSource: "upstream",
-        messageIdSource: "upstream",
-        seq: expected.seq,
-        taskId:
-          typeof expected.artifactId === "string"
-            ? expected.artifactId.split(":")[0]
-            : "task-1",
-        artifactId: expected.artifactId,
-        blockId: expected.blockId,
-        laneId: expected.laneId,
-        blockType: expected.blockType,
-        op: expected.op,
-        baseSeq: expected.baseSeq,
-        source: expected.source,
-        messageId: expected.messageId,
-        role: "agent",
-        delta: expected.content,
-        append: expected.op === "append",
-        done: expected.isFinished,
-      },
+    version: "v1",
+    streamBlock: {
+      eventId: expected.eventId,
+      eventIdSource: "upstream",
+      messageIdSource: "upstream",
+      seq: expected.seq,
+      taskId:
+        typeof expected.artifactId === "string"
+          ? expected.artifactId.split(":")[0]
+          : "task-1",
+      artifactId: expected.artifactId,
+      blockId: expected.blockId,
+      laneId: expected.laneId,
+      blockType: expected.blockType,
+      op: expected.op,
+      baseSeq: expected.baseSeq,
+      source: expected.source,
+      messageId: expected.messageId,
+      role: "agent",
+      delta: expected.content,
+      append: expected.op === "append",
+      done: expected.isFinished,
     },
   });
   expect(parsed).not.toBeNull();

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -47,19 +47,17 @@ const buildStatusUpdatePayload = (input: {
     },
     hub: {
       version: "v1",
-      eventKind: "status-update",
       runtimeStatus: {
         state: normalizeRuntimeState(input.state),
         isFinal: DEFAULT_RUNTIME_STATUS_CONTRACT.terminalStates
           .map((item) => normalizeRuntimeState(item))
           .includes(normalizeRuntimeState(input.state)),
-        interrupt: canonicalInterrupt,
-        seq: input.seq ?? null,
-        completionPhase:
-          input.completionPhase?.trim().toLowerCase() === "persisted"
-            ? "persisted"
-            : null,
-        messageId: input.messageId ?? null,
+        ...(canonicalInterrupt ? { interrupt: canonicalInterrupt } : {}),
+        ...(input.seq !== undefined ? { seq: input.seq } : {}),
+        ...(input.completionPhase?.trim().toLowerCase() === "persisted"
+          ? { completionPhase: "persisted" }
+          : {}),
+        ...(input.messageId ? { messageId: input.messageId } : {}),
       },
     },
   };
@@ -257,15 +255,10 @@ const buildCanonicalInterrupt = (
 const withHubStreamBlock = (
   payload: Record<string, unknown>,
   streamBlock: Record<string, unknown>,
-  eventKind:
-    | "artifact-update"
-    | "message"
-    | "status-update" = "artifact-update",
 ) => ({
   ...payload,
   hub: {
     version: "v1",
-    eventKind,
     streamBlock,
   },
 });
@@ -350,20 +343,19 @@ const buildBlockUpdatePayload = (input: {
   const messageId = input.messageId ?? "msg-1";
   payload.hub = {
     version: "v1",
-    eventKind: "artifact-update",
     streamBlock: {
       eventId: input.eventId ?? "evt-1",
       eventIdSource: "upstream",
       messageIdSource: "upstream",
-      seq: input.seq ?? null,
+      ...(input.seq !== undefined ? { seq: input.seq } : {}),
       taskId: input.taskId ?? "task-1",
       artifactId: input.artifactId,
       blockId: input.blockId ?? `${messageId}:${laneId}`,
       laneId,
       blockType: input.blockType,
       op: input.op ?? (input.append === false ? "replace" : "append"),
-      baseSeq: input.baseSeq ?? null,
-      source: input.source ?? "stream",
+      ...(input.baseSeq !== undefined ? { baseSeq: input.baseSeq } : {}),
+      ...(input.source ? { source: input.source } : { source: "stream" }),
       messageId,
       role: "agent",
       delta: input.delta ?? "",
@@ -373,7 +365,7 @@ const buildBlockUpdatePayload = (input: {
       toolCall:
         input.blockType === "tool_call"
           ? buildToolCallViewFromDelta(input.delta)
-          : null,
+          : undefined,
     },
   };
   return payload;
@@ -1414,7 +1406,6 @@ describe("block-based stream parser and reducer", () => {
           append: false,
           done: false,
         },
-        "message",
       ),
     );
     expect(parsed?.blockType).toBe("text");
@@ -1456,7 +1447,6 @@ describe("block-based stream parser and reducer", () => {
           append: false,
           done: false,
         },
-        "status-update",
       ),
     );
     expect(parsed?.blockType).toBe("text");

--- a/frontend/lib/__tests__/streamContract.test.ts
+++ b/frontend/lib/__tests__/streamContract.test.ts
@@ -45,20 +45,18 @@ const buildStatusUpdatePayload = (input: {
         },
       },
     },
-    hub: {
-      version: "v1",
-      runtimeStatus: {
-        state: normalizeRuntimeState(input.state),
-        isFinal: DEFAULT_RUNTIME_STATUS_CONTRACT.terminalStates
-          .map((item) => normalizeRuntimeState(item))
-          .includes(normalizeRuntimeState(input.state)),
-        ...(canonicalInterrupt ? { interrupt: canonicalInterrupt } : {}),
-        ...(input.seq !== undefined ? { seq: input.seq } : {}),
-        ...(input.completionPhase?.trim().toLowerCase() === "persisted"
-          ? { completionPhase: "persisted" }
-          : {}),
-        ...(input.messageId ? { messageId: input.messageId } : {}),
-      },
+    version: "v1",
+    runtimeStatus: {
+      state: normalizeRuntimeState(input.state),
+      isFinal: DEFAULT_RUNTIME_STATUS_CONTRACT.terminalStates
+        .map((item) => normalizeRuntimeState(item))
+        .includes(normalizeRuntimeState(input.state)),
+      ...(canonicalInterrupt ? { interrupt: canonicalInterrupt } : {}),
+      ...(input.seq !== undefined ? { seq: input.seq } : {}),
+      ...(input.completionPhase?.trim().toLowerCase() === "persisted"
+        ? { completionPhase: "persisted" }
+        : {}),
+      ...(input.messageId ? { messageId: input.messageId } : {}),
     },
   };
 };
@@ -257,10 +255,8 @@ const withHubStreamBlock = (
   streamBlock: Record<string, unknown>,
 ) => ({
   ...payload,
-  hub: {
-    version: "v1",
-    streamBlock,
-  },
+  version: "v1",
+  streamBlock,
 });
 
 const buildBlockUpdatePayload = (input: {
@@ -341,32 +337,30 @@ const buildBlockUpdatePayload = (input: {
     input.laneId ??
     (input.blockType === "text" ? "primary_text" : input.blockType);
   const messageId = input.messageId ?? "msg-1";
-  payload.hub = {
-    version: "v1",
-    streamBlock: {
-      eventId: input.eventId ?? "evt-1",
-      eventIdSource: "upstream",
-      messageIdSource: "upstream",
-      ...(input.seq !== undefined ? { seq: input.seq } : {}),
-      taskId: input.taskId ?? "task-1",
-      artifactId: input.artifactId,
-      blockId: input.blockId ?? `${messageId}:${laneId}`,
-      laneId,
-      blockType: input.blockType,
-      op: input.op ?? (input.append === false ? "replace" : "append"),
-      ...(input.baseSeq !== undefined ? { baseSeq: input.baseSeq } : {}),
-      ...(input.source ? { source: input.source } : { source: "stream" }),
-      messageId,
-      role: "agent",
-      delta: input.delta ?? "",
-      append:
-        input.append ?? !(input.op === "replace" || input.op === "finalize"),
-      done: input.lastChunk ?? input.op === "finalize",
-      toolCall:
-        input.blockType === "tool_call"
-          ? buildToolCallViewFromDelta(input.delta)
-          : undefined,
-    },
+  payload.version = "v1";
+  payload.streamBlock = {
+    eventId: input.eventId ?? "evt-1",
+    eventIdSource: "upstream",
+    messageIdSource: "upstream",
+    ...(input.seq !== undefined ? { seq: input.seq } : {}),
+    taskId: input.taskId ?? "task-1",
+    artifactId: input.artifactId,
+    blockId: input.blockId ?? `${messageId}:${laneId}`,
+    laneId,
+    blockType: input.blockType,
+    op: input.op ?? (input.append === false ? "replace" : "append"),
+    ...(input.baseSeq !== undefined ? { baseSeq: input.baseSeq } : {}),
+    ...(input.source ? { source: input.source } : { source: "stream" }),
+    messageId,
+    role: "agent",
+    delta: input.delta ?? "",
+    append:
+      input.append ?? !(input.op === "replace" || input.op === "finalize"),
+    done: input.lastChunk ?? input.op === "finalize",
+    toolCall:
+      input.blockType === "tool_call"
+        ? buildToolCallViewFromDelta(input.delta)
+        : undefined,
   };
   return payload;
 };
@@ -1543,11 +1537,11 @@ describe("block-based stream parser and reducer", () => {
       }
     ).artifact?.metadata?.shared?.stream?.messageId;
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).messageId = "task:task-1";
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).messageIdSource = "task_fallback";
     const parsed = extractStreamBlockUpdate(payload);
@@ -1624,11 +1618,11 @@ describe("block-based stream parser and reducer", () => {
       }
     ).artifact?.metadata?.shared?.stream?.eventId;
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).eventId = "seq:msg-1:7";
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).eventIdSource = "fallback_seq";
     const parsed = extractStreamBlockUpdate(payload);
@@ -1636,18 +1630,18 @@ describe("block-based stream parser and reducer", () => {
     expect(parsed?.eventIdSource).toBe("fallback_seq");
   });
 
-  it("accepts local persistence identity sources from hub stream blocks", () => {
+  it("accepts local persistence identity sources from canonical stream blocks", () => {
     const payload = buildBlockUpdatePayload({
       blockType: "text",
       delta: "hello",
       artifactId: "task-1:stream",
     }) as Record<string, unknown>;
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).messageIdSource = "local_persistence";
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).eventIdSource = "local_persistence";
 
@@ -1721,11 +1715,11 @@ describe("block-based stream parser and reducer", () => {
       }
     ).artifact?.metadata?.shared?.stream?.eventId;
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).eventId = "chunk:msg-1:task-1:stream";
     (
-      ((payload.hub as { streamBlock?: Record<string, unknown> }).streamBlock ??
+      ((payload as { streamBlock?: Record<string, unknown> }).streamBlock ??
         {}) as Record<string, unknown>
     ).eventIdSource = "fallback_chunk";
     const parsed = extractStreamBlockUpdate(payload);
@@ -1994,13 +1988,10 @@ describe("block-based stream parser and reducer", () => {
 
   it("extracts external session from canonical shared session metadata", () => {
     const meta = extractSessionMeta({
-      hub: {
-        version: "v1",
-        eventKind: "status-update",
-        sessionMeta: {
-          provider: "opencode",
-          externalSessionId: "ses_upstream_1",
-        },
+      version: "v1",
+      sessionMeta: {
+        provider: "opencode",
+        externalSessionId: "ses_upstream_1",
       },
     });
     expect(meta.provider).toBe("opencode");
@@ -2009,14 +2000,11 @@ describe("block-based stream parser and reducer", () => {
 
   it("requires shared interrupt metadata on canonical status-update payloads", () => {
     const payload = {
-      hub: {
-        version: "v1",
-        eventKind: "status-update",
-        runtimeStatus: {
-          state: "input-required",
-          isFinal: true,
-          interrupt: null,
-        },
+      version: "v1",
+      runtimeStatus: {
+        state: "input-required",
+        isFinal: true,
+        interrupt: null,
       },
     };
     expect(extractRuntimeStatusEvent(payload)?.interrupt).toBeNull();

--- a/frontend/lib/api/__tests__/chat-utils.test.ts
+++ b/frontend/lib/api/__tests__/chat-utils.test.ts
@@ -7,17 +7,13 @@ import {
 } from "@/lib/api/chat-utils";
 
 const withHubRuntimeStatus = (runtimeStatus: Record<string, unknown>) => ({
-  hub: {
-    version: "v1",
-    runtimeStatus,
-  },
+  version: "v1",
+  runtimeStatus,
 });
 
 const withHubSessionMeta = (sessionMeta: Record<string, unknown>) => ({
-  hub: {
-    version: "v1",
-    sessionMeta,
-  },
+  version: "v1",
+  sessionMeta,
 });
 
 describe("runtime status contract", () => {
@@ -74,7 +70,7 @@ describe("runtime status contract", () => {
     });
   });
 
-  it("reads canonical runtime status fields from the hub envelope", () => {
+  it("reads canonical runtime status fields from the stream envelope", () => {
     expect(
       extractRuntimeStatusEvent(
         withHubRuntimeStatus({
@@ -96,7 +92,7 @@ describe("runtime status contract", () => {
     });
   });
 
-  it("extracts session metadata from the hub envelope", () => {
+  it("extracts session metadata from the stream envelope", () => {
     expect(
       extractSessionMeta(
         withHubSessionMeta({

--- a/frontend/lib/api/__tests__/chat-utils.test.ts
+++ b/frontend/lib/api/__tests__/chat-utils.test.ts
@@ -9,7 +9,6 @@ import {
 const withHubRuntimeStatus = (runtimeStatus: Record<string, unknown>) => ({
   hub: {
     version: "v1",
-    eventKind: "status-update",
     runtimeStatus,
   },
 });
@@ -17,7 +16,6 @@ const withHubRuntimeStatus = (runtimeStatus: Record<string, unknown>) => ({
 const withHubSessionMeta = (sessionMeta: Record<string, unknown>) => ({
   hub: {
     version: "v1",
-    eventKind: "artifact-update",
     sessionMeta,
   },
 });

--- a/frontend/lib/api/chatRuntimeStatus.ts
+++ b/frontend/lib/api/chatRuntimeStatus.ts
@@ -8,7 +8,7 @@ import {
   pickString,
   resolveNestedValue,
 } from "./chatUtilsShared";
-import { extractHubStreamEnvelope } from "./hubStreamEnvelope";
+import { extractStreamEnvelope } from "./streamEnvelope";
 
 export type StreamMissingParam = {
   name: string;
@@ -195,7 +195,7 @@ const coerceMissingParams = (value: unknown): StreamMissingParam[] | null => {
 };
 
 export const extractSessionMeta = (data: Record<string, unknown>) => {
-  const sessionMeta = extractHubStreamEnvelope(data)?.sessionMeta ?? null;
+  const sessionMeta = extractStreamEnvelope(data)?.sessionMeta ?? null;
   const provider = pickString(sessionMeta, ["provider"]) ?? undefined;
   const externalSessionId =
     pickString(sessionMeta, ["externalSessionId"]) ?? undefined;
@@ -453,7 +453,7 @@ export const extractRuntimeStatusEvent = (
   data: Record<string, unknown>,
   contract?: RuntimeStatusContract | null,
 ): RuntimeStatusEvent | null => {
-  const runtimeStatus = extractHubStreamEnvelope(data)?.runtimeStatus;
+  const runtimeStatus = extractStreamEnvelope(data)?.runtimeStatus;
   if (!runtimeStatus) {
     return null;
   }

--- a/frontend/lib/api/chatStreamBlocks.ts
+++ b/frontend/lib/api/chatStreamBlocks.ts
@@ -5,7 +5,7 @@ import type {
   StreamMissingParam,
 } from "./chatRuntimeStatus";
 import { asRecord, pickRawString, pickString } from "./chatUtilsShared";
-import { extractHubStreamEnvelope } from "./hubStreamEnvelope";
+import { extractStreamEnvelope } from "./streamEnvelope";
 
 export type ChatRole = "user" | "agent" | "system";
 
@@ -525,8 +525,8 @@ const adaptStreamBlockUpdateForReducer = (
 export const extractStreamBlockUpdate = (
   data: Record<string, unknown>,
 ): StreamBlockUpdate | null => {
-  const hub = extractHubStreamEnvelope(data);
-  const streamBlock = hub?.streamBlock;
+  const streamEnvelope = extractStreamEnvelope(data);
+  const streamBlock = streamEnvelope?.streamBlock;
   if (!streamBlock) {
     return null;
   }

--- a/frontend/lib/api/hubStreamEnvelope.ts
+++ b/frontend/lib/api/hubStreamEnvelope.ts
@@ -2,7 +2,6 @@ import { asRecord } from "./chatUtilsShared";
 
 export type HubStreamEnvelope = {
   version: "v1";
-  eventKind?: "artifact-update" | "message" | "status-update" | "task" | null;
   streamBlock?: Record<string, unknown> | null;
   runtimeStatus?: Record<string, unknown> | null;
   sessionMeta?: Record<string, unknown> | null;
@@ -21,13 +20,6 @@ export const extractHubStreamEnvelope = (
   }
   return {
     version,
-    eventKind:
-      hub.eventKind === "artifact-update" ||
-      hub.eventKind === "message" ||
-      hub.eventKind === "status-update" ||
-      hub.eventKind === "task"
-        ? hub.eventKind
-        : null,
     streamBlock: asRecord(hub.streamBlock),
     runtimeStatus: asRecord(hub.runtimeStatus),
     sessionMeta: asRecord(hub.sessionMeta),

--- a/frontend/lib/api/streamEnvelope.ts
+++ b/frontend/lib/api/streamEnvelope.ts
@@ -1,27 +1,27 @@
 import { asRecord } from "./chatUtilsShared";
 
-export type HubStreamEnvelope = {
+export type StreamEnvelope = {
   version: "v1";
   streamBlock?: Record<string, unknown> | null;
   runtimeStatus?: Record<string, unknown> | null;
   sessionMeta?: Record<string, unknown> | null;
 };
 
-export const extractHubStreamEnvelope = (
+export const extractStreamEnvelope = (
   data: Record<string, unknown>,
-): HubStreamEnvelope | null => {
-  const hub = asRecord(data.hub);
-  if (!hub) {
+): StreamEnvelope | null => {
+  const envelope = asRecord(data);
+  if (!envelope) {
     return null;
   }
-  const version = hub.version;
+  const version = envelope.version;
   if (version !== "v1") {
     return null;
   }
   return {
     version,
-    streamBlock: asRecord(hub.streamBlock),
-    runtimeStatus: asRecord(hub.runtimeStatus),
-    sessionMeta: asRecord(hub.sessionMeta),
+    streamBlock: asRecord(envelope.streamBlock),
+    runtimeStatus: asRecord(envelope.runtimeStatus),
+    sessionMeta: asRecord(envelope.sessionMeta),
   };
 };

--- a/frontend/store/__tests__/chatRuntime.interrupts.test.ts
+++ b/frontend/store/__tests__/chatRuntime.interrupts.test.ts
@@ -62,21 +62,19 @@ const buildStatusUpdate = ({
       },
     },
   },
-  hub: {
-    version: "v1",
-    runtimeStatus: {
-      state: normalizeRuntimeStateToken(state),
-      isFinal:
-        state === "TASK_STATE_COMPLETED" ||
-        state === "TASK_STATE_FAILED" ||
-        state === "TASK_STATE_INPUT_REQUIRED",
-      ...(buildCanonicalInterrupt(interrupt)
-        ? { interrupt: buildCanonicalInterrupt(interrupt) }
-        : {}),
-      ...(seq !== undefined ? { seq } : {}),
-      ...(completionPhase ? { completionPhase } : {}),
-      ...(messageId ? { messageId } : {}),
-    },
+  version: "v1",
+  runtimeStatus: {
+    state: normalizeRuntimeStateToken(state),
+    isFinal:
+      state === "TASK_STATE_COMPLETED" ||
+      state === "TASK_STATE_FAILED" ||
+      state === "TASK_STATE_INPUT_REQUIRED",
+    ...(buildCanonicalInterrupt(interrupt)
+      ? { interrupt: buildCanonicalInterrupt(interrupt) }
+      : {}),
+    ...(seq !== undefined ? { seq } : {}),
+    ...(completionPhase ? { completionPhase } : {}),
+    ...(messageId ? { messageId } : {}),
   },
 });
 
@@ -111,26 +109,24 @@ const buildArtifactUpdate = ({
       },
     },
   },
-  hub: {
-    version: "v1",
-    streamBlock: {
-      eventId,
-      eventIdSource: "upstream",
-      messageIdSource: "upstream",
-      seq,
-      taskId: agentMessageId,
-      artifactId: `${agentMessageId}:stream:${seq}`,
-      blockId: `${agentMessageId}:primary_text`,
-      laneId: "primary_text",
-      blockType: "text",
-      op: "append",
-      source,
-      messageId: agentMessageId,
-      role: "agent",
-      delta: text,
-      append: true,
-      done: false,
-    },
+  version: "v1",
+  streamBlock: {
+    eventId,
+    eventIdSource: "upstream",
+    messageIdSource: "upstream",
+    seq,
+    taskId: agentMessageId,
+    artifactId: `${agentMessageId}:stream:${seq}`,
+    blockId: `${agentMessageId}:primary_text`,
+    laneId: "primary_text",
+    blockType: "text",
+    op: "append",
+    source,
+    messageId: agentMessageId,
+    role: "agent",
+    delta: text,
+    append: true,
+    done: false,
   },
 });
 

--- a/frontend/store/__tests__/chatRuntime.interrupts.test.ts
+++ b/frontend/store/__tests__/chatRuntime.interrupts.test.ts
@@ -64,17 +64,18 @@ const buildStatusUpdate = ({
   },
   hub: {
     version: "v1",
-    eventKind: "status-update",
     runtimeStatus: {
       state: normalizeRuntimeStateToken(state),
       isFinal:
         state === "TASK_STATE_COMPLETED" ||
         state === "TASK_STATE_FAILED" ||
         state === "TASK_STATE_INPUT_REQUIRED",
-      interrupt: buildCanonicalInterrupt(interrupt),
-      seq: seq ?? null,
-      completionPhase: completionPhase ?? null,
-      messageId: messageId ?? null,
+      ...(buildCanonicalInterrupt(interrupt)
+        ? { interrupt: buildCanonicalInterrupt(interrupt) }
+        : {}),
+      ...(seq !== undefined ? { seq } : {}),
+      ...(completionPhase ? { completionPhase } : {}),
+      ...(messageId ? { messageId } : {}),
     },
   },
 });
@@ -112,7 +113,6 @@ const buildArtifactUpdate = ({
   },
   hub: {
     version: "v1",
-    eventKind: "artifact-update",
     streamBlock: {
       eventId,
       eventIdSource: "upstream",
@@ -124,7 +124,6 @@ const buildArtifactUpdate = ({
       laneId: "primary_text",
       blockType: "text",
       op: "append",
-      baseSeq: null,
       source,
       messageId: agentMessageId,
       role: "agent",

--- a/frontend/store/__tests__/chatRuntime.recovery.test.ts
+++ b/frontend/store/__tests__/chatRuntime.recovery.test.ts
@@ -46,17 +46,14 @@ const buildStatusUpdate = ({
   },
   hub: {
     version: "v1",
-    eventKind: "status-update",
     runtimeStatus: {
       state: normalizeRuntimeStateToken(state),
       isFinal:
         state === "TASK_STATE_COMPLETED" ||
         state === "TASK_STATE_FAILED" ||
         state === "TASK_STATE_INPUT_REQUIRED",
-      interrupt: null,
-      seq: null,
-      completionPhase: completionPhase ?? null,
-      messageId: messageId ?? null,
+      ...(completionPhase ? { completionPhase } : {}),
+      ...(messageId ? { messageId } : {}),
     },
   },
 });
@@ -94,7 +91,6 @@ const buildArtifactUpdate = ({
   },
   hub: {
     version: "v1",
-    eventKind: "artifact-update",
     streamBlock: {
       eventId,
       eventIdSource: "upstream",
@@ -106,7 +102,6 @@ const buildArtifactUpdate = ({
       laneId: "primary_text",
       blockType: "text",
       op: "append",
-      baseSeq: null,
       source,
       messageId: agentMessageId,
       role: "agent",
@@ -152,7 +147,6 @@ const buildRawCompatArtifactUpdate = ({
   },
   hub: {
     version: "v1",
-    eventKind: "artifact-update",
     streamBlock: {
       eventId,
       eventIdSource: "upstream",
@@ -164,8 +158,6 @@ const buildRawCompatArtifactUpdate = ({
       laneId: "primary_text",
       blockType: "text",
       op: append ? "append" : "replace",
-      baseSeq: null,
-      source: null,
       messageId: `task:${taskId}`,
       role: "agent",
       delta: text,

--- a/frontend/store/__tests__/chatRuntime.recovery.test.ts
+++ b/frontend/store/__tests__/chatRuntime.recovery.test.ts
@@ -44,17 +44,15 @@ const buildStatusUpdate = ({
       },
     },
   },
-  hub: {
-    version: "v1",
-    runtimeStatus: {
-      state: normalizeRuntimeStateToken(state),
-      isFinal:
-        state === "TASK_STATE_COMPLETED" ||
-        state === "TASK_STATE_FAILED" ||
-        state === "TASK_STATE_INPUT_REQUIRED",
-      ...(completionPhase ? { completionPhase } : {}),
-      ...(messageId ? { messageId } : {}),
-    },
+  version: "v1",
+  runtimeStatus: {
+    state: normalizeRuntimeStateToken(state),
+    isFinal:
+      state === "TASK_STATE_COMPLETED" ||
+      state === "TASK_STATE_FAILED" ||
+      state === "TASK_STATE_INPUT_REQUIRED",
+    ...(completionPhase ? { completionPhase } : {}),
+    ...(messageId ? { messageId } : {}),
   },
 });
 
@@ -89,26 +87,24 @@ const buildArtifactUpdate = ({
       },
     },
   },
-  hub: {
-    version: "v1",
-    streamBlock: {
-      eventId,
-      eventIdSource: "upstream",
-      messageIdSource: "upstream",
-      seq,
-      taskId: agentMessageId,
-      artifactId: `${agentMessageId}:stream:1`,
-      blockId: `${agentMessageId}:primary_text`,
-      laneId: "primary_text",
-      blockType: "text",
-      op: "append",
-      source,
-      messageId: agentMessageId,
-      role: "agent",
-      delta: text,
-      append: true,
-      done: false,
-    },
+  version: "v1",
+  streamBlock: {
+    eventId,
+    eventIdSource: "upstream",
+    messageIdSource: "upstream",
+    seq,
+    taskId: agentMessageId,
+    artifactId: `${agentMessageId}:stream:1`,
+    blockId: `${agentMessageId}:primary_text`,
+    laneId: "primary_text",
+    blockType: "text",
+    op: "append",
+    source,
+    messageId: agentMessageId,
+    role: "agent",
+    delta: text,
+    append: true,
+    done: false,
   },
 });
 
@@ -145,25 +141,23 @@ const buildRawCompatArtifactUpdate = ({
       },
     },
   },
-  hub: {
-    version: "v1",
-    streamBlock: {
-      eventId,
-      eventIdSource: "upstream",
-      messageIdSource: "task_fallback",
-      seq,
-      taskId,
-      artifactId: `${taskId}:stream:text`,
-      blockId: `task:${taskId}:primary_text`,
-      laneId: "primary_text",
-      blockType: "text",
-      op: append ? "append" : "replace",
-      messageId: `task:${taskId}`,
-      role: "agent",
-      delta: text,
-      append,
-      done: lastChunk,
-    },
+  version: "v1",
+  streamBlock: {
+    eventId,
+    eventIdSource: "upstream",
+    messageIdSource: "task_fallback",
+    seq,
+    taskId,
+    artifactId: `${taskId}:stream:text`,
+    blockId: `task:${taskId}:primary_text`,
+    laneId: "primary_text",
+    blockType: "text",
+    op: append ? "append" : "replace",
+    messageId: `task:${taskId}`,
+    role: "agent",
+    delta: text,
+    append,
+    done: lastChunk,
   },
 });
 
@@ -727,11 +721,11 @@ describe("executeChatRuntime empty-content recovery", () => {
     });
   });
 
-  it("ignores empty hub envelopes and falls back to JSON when no stream event was observed", async () => {
-    const conversationId = "conv-empty-hub-envelope-1";
-    const agentId = "agent-empty-hub-envelope-1";
-    const userMessageId = "user-empty-hub-envelope-1";
-    const agentMessageId = "agent-empty-hub-envelope-1";
+  it("ignores empty stream envelopes and falls back to JSON when no stream event was observed", async () => {
+    const conversationId = "conv-empty-stream-envelope-1";
+    const agentId = "agent-empty-stream-envelope-1";
+    const userMessageId = "user-empty-stream-envelope-1";
+    const agentMessageId = "agent-empty-stream-envelope-1";
 
     addConversationMessage(conversationId, {
       id: userMessageId,
@@ -783,12 +777,7 @@ describe("executeChatRuntime empty-content recovery", () => {
           onData: (data: Record<string, unknown>) => boolean | void;
         };
       }) => {
-        params.callbacks.onData({
-          hub: {
-            version: "v1",
-            eventKind: "artifact-update",
-          },
-        });
+        params.callbacks.onData({ version: "v1" });
         return false;
       },
     );
@@ -1015,28 +1004,24 @@ describe("executeChatRuntime empty-content recovery", () => {
               },
             },
           },
-          hub: {
-            version: "v1",
-            eventKind: "artifact-update",
-            streamBlock: {
-              eventId: `${agentMessageId}:1`,
-              eventIdSource: "upstream",
-              messageIdSource: "upstream",
-              seq: 1,
-              taskId: "task-compat-1",
-              artifactId: "stream-compat-1",
-              blockId: `${agentMessageId}:primary_text`,
-              laneId: "primary_text",
-              blockType: "text",
-              op: "append",
-              baseSeq: null,
-              source: "assistant_text",
-              messageId: agentMessageId,
-              role: "agent",
-              delta: "Hello from stream",
-              append: true,
-              done: false,
-            },
+          version: "v1",
+          streamBlock: {
+            eventId: `${agentMessageId}:1`,
+            eventIdSource: "upstream",
+            messageIdSource: "upstream",
+            seq: 1,
+            taskId: "task-compat-1",
+            artifactId: "stream-compat-1",
+            blockId: `${agentMessageId}:primary_text`,
+            laneId: "primary_text",
+            blockType: "text",
+            op: "append",
+            source: "assistant_text",
+            messageId: agentMessageId,
+            role: "agent",
+            delta: "Hello from stream",
+            append: true,
+            done: false,
           },
         });
         await new Promise((resolve) => setTimeout(resolve, 30));
@@ -1169,40 +1154,36 @@ describe("executeChatRuntime empty-content recovery", () => {
               },
             },
           },
-          hub: {
-            version: "v1",
-            eventKind: "artifact-update",
-            streamBlock: {
-              eventId: `${agentMessageId}:1`,
-              eventIdSource: "upstream",
-              messageIdSource: "upstream",
-              seq: 1,
-              taskId: agentMessageId,
-              artifactId: `${agentMessageId}:stream`,
-              blockId: `${agentMessageId}:tool_call`,
-              laneId: "tool_call",
-              blockType: "tool_call",
-              op: "replace",
-              baseSeq: null,
-              source: "tool_part_update",
-              messageId: agentMessageId,
-              role: "agent",
-              delta: JSON.stringify({
-                call_id: "call-1",
-                tool: "bash",
-                status: "running",
-                input: { command: "pwd" },
-              }),
-              append: false,
-              done: false,
-              toolCall: {
-                name: "bash",
-                status: "running",
-                callId: "call-1",
-                arguments: { command: "pwd" },
-                result: null,
-                error: null,
-              },
+          version: "v1",
+          streamBlock: {
+            eventId: `${agentMessageId}:1`,
+            eventIdSource: "upstream",
+            messageIdSource: "upstream",
+            seq: 1,
+            taskId: agentMessageId,
+            artifactId: `${agentMessageId}:stream`,
+            blockId: `${agentMessageId}:tool_call`,
+            laneId: "tool_call",
+            blockType: "tool_call",
+            op: "replace",
+            source: "tool_part_update",
+            messageId: agentMessageId,
+            role: "agent",
+            delta: JSON.stringify({
+              call_id: "call-1",
+              tool: "bash",
+              status: "running",
+              input: { command: "pwd" },
+            }),
+            append: false,
+            done: false,
+            toolCall: {
+              name: "bash",
+              status: "running",
+              callId: "call-1",
+              arguments: { command: "pwd" },
+              result: null,
+              error: null,
             },
           },
         });
@@ -1321,28 +1302,24 @@ describe("executeChatRuntime empty-content recovery", () => {
               },
             },
           },
-          hub: {
-            version: "v1",
-            eventKind: "artifact-update",
-            streamBlock: {
-              eventId: `${agentMessageId}:1`,
-              eventIdSource: "upstream",
-              messageIdSource: "upstream",
-              seq: 1,
-              taskId: agentMessageId,
-              artifactId: `${agentMessageId}:stream`,
-              blockId: `${agentMessageId}:reasoning`,
-              laneId: "reasoning",
-              blockType: "reasoning",
-              op: "replace",
-              baseSeq: null,
-              source: "reasoning_part_update",
-              messageId: agentMessageId,
-              role: "agent",
-              delta: "Reasoning in progress",
-              append: false,
-              done: false,
-            },
+          version: "v1",
+          streamBlock: {
+            eventId: `${agentMessageId}:1`,
+            eventIdSource: "upstream",
+            messageIdSource: "upstream",
+            seq: 1,
+            taskId: agentMessageId,
+            artifactId: `${agentMessageId}:stream`,
+            blockId: `${agentMessageId}:reasoning`,
+            laneId: "reasoning",
+            blockType: "reasoning",
+            op: "replace",
+            source: "reasoning_part_update",
+            messageId: agentMessageId,
+            role: "agent",
+            delta: "Reasoning in progress",
+            append: false,
+            done: false,
           },
         });
 


### PR DESCRIPTION
## 变更概述

本 PR 聚焦收尾问题 1：收紧聊天页流式 chunk 协议，去掉对前端无用的 raw A2A 事件转发，并继续收掉过渡期遗留的 `hub` wrapper。

本次改动后，前端常规流协议统一为顶层 canonical payload：

- `version`
- `streamBlock`
- `runtimeStatus`
- `sessionMeta`

不再向客户端转发：

- raw `artifactUpdate`
- raw `statusUpdate`
- raw `message`
- raw `task`
- `hub.eventKind`
- `hub` wrapper 本身

## 主要改动

- 后端 stream transport 对前端外发、缓存与 replay 全部改为顶层 canonical payload
- 后端 stream payload 解析支持直接读取顶层 `streamBlock`
- 前端解析从 `hubStreamEnvelope` 收敛为 `streamEnvelope`
- 更新前后端相关 contract / transport / recovery / interrupt / reducer 测试
- 更新前端 README 对流协议边界的说明

## 范围边界

本 PR 只解决问题 1：chunk 形状臃肿、重复包装和协议边界不清。

以下问题**不在本 PR 内解决**：

- 某些中间 text 最终没有显示、只剩最终文本的问题
- text / reasoning / tool_call 的最终权威生成点梳理

## 关联 Issue

Closes #895

不应关闭 #894：该 issue 仍是 OpenCode `response.info.error` 诊断问题，本 PR 未处理该问题。

## 验证

### Backend

```bash
cd backend && uv run --locked pre-commit run --files app/features/invoke/hub_stream_contract.py app/features/invoke/service_streaming_transport.py app/features/invoke/stream_payloads.py tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_a2a_invoke_service_streaming.py --config ../.pre-commit-config.yaml
cd backend && uv run --locked pytest tests/invoke/test_a2a_invoke_service_stream_contract.py tests/invoke/test_a2a_invoke_service_streaming.py tests/invoke/test_a2a_invoke_service_contract_fallback.py tests/invoke/test_invoke_stream_persistence.py
```

结果：`96 passed in 4.61s`

### Frontend

```bash
cd frontend && npm run lint
cd frontend && export NODE_OPTIONS="--max-old-space-size=1024" && npm run check-types
cd frontend && npm test -- --findRelatedTests lib/api/streamEnvelope.ts lib/api/chatStreamBlocks.ts lib/api/chatRuntimeStatus.ts lib/api/__tests__/chat-utils.test.ts lib/__tests__/streamBlockOperationContract.test.ts lib/__tests__/streamContract.test.ts store/__tests__/chatRuntime.recovery.test.ts store/__tests__/chatRuntime.interrupts.test.ts --maxWorkers=25%
```

结果：`61 passed, 369 total`
