### PR TITLE
fix(a2a): allow legacy 0.3 downstream peers (#900)

### DIFF
--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -14,6 +14,7 @@ import httpx
 from a2a.client import (
     A2ACardResolver,
     ClientCallInterceptor,
+    ClientFactory,
 )
 from a2a.client.client import ClientCallContext
 from a2a.client.interceptors import AfterArgs, BeforeArgs
@@ -101,10 +102,6 @@ def _coerce_text_payload_mapping(payload: Any) -> dict[str, Any] | None:
     if normalized is not None:
         return normalized
     return None
-
-
-def _is_legacy_protocol_version(value: str | None) -> bool:
-    return isinstance(value, str) and value.strip().startswith("0.3")
 
 
 class StaticHeaderInterceptor(ClientCallInterceptor):
@@ -626,16 +623,6 @@ class A2AClient:
                 return value.value
             return str(value).strip()
 
-        def _select_preferred_url(
-            candidates: list[tuple[str, bool]],
-        ) -> str | None:
-            for candidate_url, is_legacy in candidates:
-                if not is_legacy:
-                    return candidate_url
-            if candidates:
-                return candidates[0][0]
-            return None
-
         client_set: list[TransportProtocol | str] = list(
             self._supported_transports or [TransportProtocol.JSONRPC]
         )
@@ -650,42 +637,38 @@ class A2AClient:
         if not supported_labels:
             supported_labels = [TransportProtocol.JSONRPC.value]
 
-        server_candidates: dict[str, list[tuple[str, bool]]] = {}
-        ordered_server_transports: list[str] = []
-        for iface in getattr(card, "supported_interfaces", None) or []:
-            transport = normalize_transport_label(
-                getattr(iface, "protocol_binding", None)
+        supported_interfaces = list(getattr(card, "supported_interfaces", None) or [])
+
+        def _resolve_selected_url(protocol_binding: str) -> str | None:
+            selected_interface = ClientFactory._find_best_interface(
+                supported_interfaces,
+                protocol_bindings=[protocol_binding],
             )
-            interface_url = (getattr(iface, "url", "") or "").strip()
-            if transport and interface_url:
-                if transport not in server_candidates:
-                    ordered_server_transports.append(transport)
-                    server_candidates[transport] = []
-                server_candidates[transport].append(
-                    (
-                        interface_url,
-                        _is_legacy_protocol_version(
-                            getattr(iface, "protocol_version", None)
-                        ),
-                    )
-                )
+            selected_url = (getattr(selected_interface, "url", "") or "").strip()
+            return selected_url or None
 
         if self._use_client_preference:
             for transport in client_set:
                 label = _as_display_label(transport)
-                candidate_url = _select_preferred_url(server_candidates.get(label, []))
+                if not label:
+                    continue
+                candidate_url = _resolve_selected_url(label)
                 if candidate_url is not None:
                     return transport, candidate_url, supported_labels
             return None, None, supported_labels
 
-        for candidate_transport in ordered_server_transports:
+        for iface in supported_interfaces:
+            candidate_transport = normalize_transport_label(
+                getattr(iface, "protocol_binding", None)
+            )
+            if not candidate_transport:
+                continue
             for transport in client_set:
                 if candidate_transport == _as_display_label(transport):
-                    candidate_url = _select_preferred_url(
-                        server_candidates.get(candidate_transport, [])
-                    )
+                    candidate_url = _resolve_selected_url(candidate_transport)
                     if candidate_url is not None:
                         return transport, candidate_url, supported_labels
+                    break
         return None, None, supported_labels
 
     async def close(self) -> None:

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -103,7 +103,7 @@ def _coerce_text_payload_mapping(payload: Any) -> dict[str, Any] | None:
     return None
 
 
-def _is_unsupported_protocol_version(value: str | None) -> bool:
+def _is_legacy_protocol_version(value: str | None) -> bool:
     return isinstance(value, str) and value.strip().startswith("0.3")
 
 
@@ -545,19 +545,10 @@ class A2AClient:
                 log_label="A2A agent card",
             )
 
-            (
-                selected_transport,
-                selected_url,
-                supported_labels,
-                saw_unsupported_protocol_interface,
-            ) = self._resolve_negotiated_transport_target(card)
+            selected_transport, selected_url, supported_labels = (
+                self._resolve_negotiated_transport_target(card)
+            )
             if not selected_transport or not selected_url:
-                if saw_unsupported_protocol_interface:
-                    raise A2AUnsupportedBindingError(
-                        f"A2A agent '{redact_url_for_logging(self.agent_url)}' only "
-                        "advertises unsupported A2A protocolVersion 0.3 interfaces. "
-                        "Upgrade the peer to A2A 1.0."
-                    )
                 supported = ", ".join(supported_labels)
                 raise A2AAgentUnavailableError(
                     f"A2A agent '{redact_url_for_logging(self.agent_url)}' has no "
@@ -627,13 +618,23 @@ class A2AClient:
 
     def _resolve_negotiated_transport_target(
         self, card: AgentCard
-    ) -> tuple[TransportProtocol | str | None, str | None, list[str], bool]:
+    ) -> tuple[TransportProtocol | str | None, str | None, list[str]]:
         def _as_display_label(value: TransportProtocol | str | None) -> str:
             if value is None:
                 return ""
             if isinstance(value, TransportProtocol):
                 return value.value
             return str(value).strip()
+
+        def _select_preferred_url(
+            candidates: list[tuple[str, bool]],
+        ) -> str | None:
+            for candidate_url, is_legacy in candidates:
+                if not is_legacy:
+                    return candidate_url
+            if candidates:
+                return candidates[0][0]
+            return None
 
         client_set: list[TransportProtocol | str] = list(
             self._supported_transports or [TransportProtocol.JSONRPC]
@@ -649,33 +650,43 @@ class A2AClient:
         if not supported_labels:
             supported_labels = [TransportProtocol.JSONRPC.value]
 
-        server_set: list[tuple[str, str]] = []
-        skipped_unsupported_protocol_interface = False
+        server_candidates: dict[str, list[tuple[str, bool]]] = {}
+        ordered_server_transports: list[str] = []
         for iface in getattr(card, "supported_interfaces", None) or []:
             transport = normalize_transport_label(
                 getattr(iface, "protocol_binding", None)
             )
             interface_url = (getattr(iface, "url", "") or "").strip()
-            protocol_version = getattr(iface, "protocol_version", None)
-            if _is_unsupported_protocol_version(protocol_version):
-                skipped_unsupported_protocol_interface = True
-                continue
             if transport and interface_url:
-                server_set.append((transport, interface_url))
+                if transport not in server_candidates:
+                    ordered_server_transports.append(transport)
+                    server_candidates[transport] = []
+                server_candidates[transport].append(
+                    (
+                        interface_url,
+                        _is_legacy_protocol_version(
+                            getattr(iface, "protocol_version", None)
+                        ),
+                    )
+                )
 
         if self._use_client_preference:
             for transport in client_set:
                 label = _as_display_label(transport)
-                for candidate_transport, candidate_url in server_set:
-                    if candidate_transport == label:
-                        return transport, candidate_url, supported_labels, False
-            return None, None, supported_labels, skipped_unsupported_protocol_interface
+                candidate_url = _select_preferred_url(server_candidates.get(label, []))
+                if candidate_url is not None:
+                    return transport, candidate_url, supported_labels
+            return None, None, supported_labels
 
-        for candidate_transport, candidate_url in server_set:
+        for candidate_transport in ordered_server_transports:
             for transport in client_set:
                 if candidate_transport == _as_display_label(transport):
-                    return transport, candidate_url, supported_labels, False
-        return None, None, supported_labels, skipped_unsupported_protocol_interface
+                    candidate_url = _select_preferred_url(
+                        server_candidates.get(candidate_transport, [])
+                    )
+                    if candidate_url is not None:
+                        return transport, candidate_url, supported_labels
+        return None, None, supported_labels
 
     async def close(self) -> None:
         """Dispose cached transport wrappers."""

--- a/backend/app/integrations/a2a_client/protobuf.py
+++ b/backend/app/integrations/a2a_client/protobuf.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from dataclasses import asdict, is_dataclass
 from typing import Any, cast
 
+from a2a.client.card_resolver import (
+    _handle_connection_fields_compatibility,
+    _handle_extended_card_compatibility,
+    _handle_security_compatibility,
+)
 from a2a.types import AgentCard
 from google.protobuf.json_format import MessageToDict, ParseDict
 from google.protobuf.message import Message as ProtoMessage
@@ -20,10 +26,15 @@ def parse_agent_card(
 ) -> AgentCard:
     """Parse a JSON-like AgentCard payload into the protobuf message."""
 
+    payload = deepcopy(dict(data))
+    _handle_extended_card_compatibility(payload)
+    _handle_connection_fields_compatibility(payload)
+    _handle_security_compatibility(payload)
+
     return cast(
         AgentCard,
         ParseDict(
-            dict(data),
+            payload,
             AgentCard(),
             ignore_unknown_fields=ignore_unknown_fields,
         ),

--- a/backend/app/integrations/a2a_client/validators.py
+++ b/backend/app/integrations/a2a_client/validators.py
@@ -134,11 +134,6 @@ def validate_agent_card(card_data: dict[str, Any]) -> AgentCardValidationResult:
                             "Each supported interface must declare a non-empty "
                             "'protocolVersion' when provided."
                         )
-                    elif _is_unsupported_protocol_version(protocol_version):
-                        result.errors.append(
-                            "A2A protocolVersion '0.3' is not supported; "
-                            "upgrade the peer to A2A 1.0."
-                        )
 
     capabilities = _pick_first(card_data, "capabilities")
     if capabilities is not None and not isinstance(capabilities, dict):
@@ -294,10 +289,6 @@ def _pick_first(data: dict[str, Any], *field_names: str) -> Any:
 
 def _is_canonical_task_state(value: Any) -> bool:
     return isinstance(value, str) and value.startswith(_CANONICAL_TASK_STATE_PREFIX)
-
-
-def _is_unsupported_protocol_version(value: Any) -> bool:
-    return isinstance(value, str) and value.strip().startswith("0.3")
 
 
 def _find_noncanonical_protojson_alias_paths(

--- a/backend/tests/client/test_a2a_client.py
+++ b/backend/tests/client/test_a2a_client.py
@@ -27,7 +27,6 @@ from app.integrations.a2a_client.errors import (
     A2AAgentUnavailableError,
     A2AClientResetRequiredError,
     A2APeerProtocolError,
-    A2AUnsupportedBindingError,
     A2AUpstreamTimeoutError,
 )
 from app.integrations.a2a_client.http_clients import (
@@ -257,8 +256,15 @@ async def test_get_adapter_uses_shared_sdk_http_client_for_borrowed_http_client(
 
 
 @pytest.mark.asyncio
-async def test_get_agent_card_rejects_unsupported_protocol_interfaces() -> None:
+async def test_get_agent_card_accepts_legacy_protocol_interfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     a2a_client = A2AClient("http://example-agent.internal:24020")
+    monkeypatch.setattr(
+        client_module.a2a_proxy_service,
+        "get_effective_allowed_hosts_sync",
+        Mock(return_value=["example.com"]),
+    )
     a2a_client._fetch_card = AsyncMock(
         return_value=parse_agent_card(
             {
@@ -279,12 +285,9 @@ async def test_get_agent_card_rejects_unsupported_protocol_interfaces() -> None:
             }
         )
     )
+    card = await a2a_client.get_agent_card()
 
-    with pytest.raises(
-        A2AUnsupportedBindingError,
-        match="unsupported A2A protocolVersion 0.3 interfaces",
-    ):
-        await a2a_client.get_agent_card()
+    assert card.name == "Legacy Agent"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/client/test_a2a_client_interoperability.py
+++ b/backend/tests/client/test_a2a_client_interoperability.py
@@ -266,12 +266,39 @@ def test_supported_transports_is_copied_on_init() -> None:
         ]
     )
 
-    selected_transport, selected_url, _, _ = (
+    selected_transport, selected_url, _ = (
         a2a_client._resolve_negotiated_transport_target(card)
     )
 
     assert selected_transport == "JSONRPC"
     assert selected_url == "http://example-agent.internal:24020/jsonrpc"
+
+
+def test_resolve_negotiated_transport_target_prefers_nonlegacy_interface_within_transport() -> (
+    None
+):
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    card = _build_card(
+        supported_interfaces=[
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-legacy",
+                protocol_version="0.3.0",
+            ),
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-v1",
+                protocol_version="1.0",
+            ),
+        ]
+    )
+
+    selected_transport, selected_url, _ = (
+        a2a_client._resolve_negotiated_transport_target(card)
+    )
+
+    assert selected_transport == TransportProtocol.JSONRPC
+    assert selected_url == "http://example-agent.internal:24020/jsonrpc-v1"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/client/test_a2a_client_interoperability.py
+++ b/backend/tests/client/test_a2a_client_interoperability.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
+from a2a.client import ClientFactory
 from a2a.client.card_resolver import parse_agent_card as parse_sdk_agent_card
 from a2a.utils.constants import TransportProtocol
 
@@ -20,6 +21,12 @@ from app.integrations.a2a_client.errors import (
     A2AAgentUnavailableError,
     A2AOutboundNotAllowedError,
     A2AUnsupportedOperationError,
+)
+from app.integrations.a2a_client.protobuf import (
+    parse_agent_card as parse_local_agent_card,
+)
+from app.integrations.a2a_client.protobuf import (
+    to_protojson_object,
 )
 from app.utils.outbound_url import OutboundURLNotAllowedError
 
@@ -352,6 +359,65 @@ def test_resolve_negotiated_transport_target_prefers_nonlegacy_interface_within_
 
     assert selected_transport == TransportProtocol.JSONRPC
     assert selected_url == "http://example-agent.internal:24020/jsonrpc-v1"
+
+
+def test_resolve_negotiated_transport_target_aligns_with_sdk_version_priority() -> None:
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    card = _build_card(
+        supported_interfaces=[
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-0-9",
+                protocol_version="0.9.0",
+            ),
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-1-1",
+                protocol_version="1.1.0",
+            ),
+        ]
+    )
+
+    expected = ClientFactory._find_best_interface(
+        list(card.supported_interfaces),
+        protocol_bindings=[TransportProtocol.JSONRPC],
+    )
+    selected_transport, selected_url, _ = (
+        a2a_client._resolve_negotiated_transport_target(card)
+    )
+
+    assert expected is not None
+    assert selected_transport == TransportProtocol.JSONRPC
+    assert selected_url == expected.url
+
+
+def test_local_parse_agent_card_applies_legacy_connection_field_compatibility() -> None:
+    card = parse_local_agent_card(
+        {
+            "name": "Legacy Agent",
+            "description": "legacy",
+            "version": "0.3.0",
+            "url": "https://example.com/jsonrpc",
+            "protocolVersion": "0.3.0",
+            "capabilities": {"streaming": True},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+        },
+        ignore_unknown_fields=False,
+    )
+
+    payload = to_protojson_object(card)
+
+    assert payload is not None
+    assert payload["supportedInterfaces"] == [
+        {
+            "url": "https://example.com/jsonrpc",
+            "protocolBinding": "JSONRPC",
+            "protocolVersion": "0.3.0",
+            "tenant": "",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/client/test_a2a_client_interoperability.py
+++ b/backend/tests/client/test_a2a_client_interoperability.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
+from a2a.client.card_resolver import parse_agent_card as parse_sdk_agent_card
 from a2a.utils.constants import TransportProtocol
 
 from app.integrations.a2a_client import client as client_module
@@ -241,6 +242,58 @@ async def test_get_agent_card_honors_client_preference_transport_order(
     assert validate_calls == [
         "http://example-agent.internal:24020",
         "http://example-agent.internal:24020/jsonrpc",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_agent_card_accepts_legacy_agent_card_shape_via_sdk_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    card = parse_sdk_agent_card(
+        {
+            "name": "Legacy Agent",
+            "description": "legacy",
+            "version": "0.3.0",
+            "url": "https://example.com/jsonrpc",
+            "protocolVersion": "0.3.0",
+            "capabilities": {"streaming": True},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+        }
+    )
+    validate_calls: list[str] = []
+
+    def fake_validate_outbound_http_url(
+        url: str,
+        *,
+        allowed_hosts,
+        purpose: str = "outbound HTTP request",
+    ) -> str:
+        validate_calls.append(url)
+        return url
+
+    monkeypatch.setattr(
+        client_module,
+        "validate_outbound_http_url",
+        fake_validate_outbound_http_url,
+    )
+    monkeypatch.setattr(
+        client_module.a2a_proxy_service,
+        "get_effective_allowed_hosts_sync",
+        lambda: ["example-agent.internal:24020", "example.com"],
+    )
+
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    a2a_client._get_http_client = AsyncMock(return_value=Mock())
+    a2a_client._build_card_resolver = Mock(return_value=_FakeResolver(card))
+
+    fetched = await a2a_client.get_agent_card()
+
+    assert fetched is card
+    assert validate_calls == [
+        "http://example-agent.internal:24020",
+        "https://example.com/jsonrpc",
     ]
 
 

--- a/backend/tests/client/test_a2a_validators.py
+++ b/backend/tests/client/test_a2a_validators.py
@@ -135,7 +135,9 @@ class TestValidateAgentCard:
             "'protocolBinding' (JSONRPC, HTTP+JSON, GRPC)." in result.errors
         )
 
-    def test_rejects_unsupported_protocol_version(self, valid_card_data):
+    def test_accepts_legacy_protocol_version_for_sdk_compatibility(
+        self, valid_card_data
+    ):
         card_data = valid_card_data.copy()
         card_data["supportedInterfaces"] = [
             {
@@ -145,10 +147,7 @@ class TestValidateAgentCard:
             }
         ]
         result = validators.validate_agent_card(card_data)
-        assert (
-            "A2A protocolVersion '0.3' is not supported; "
-            "upgrade the peer to A2A 1.0." in result.errors
-        )
+        assert result.errors == []
 
 
 class TestValidateMessage:

--- a/backend/tests/invoke/test_validation_errors_debug_mode.py
+++ b/backend/tests/invoke/test_validation_errors_debug_mode.py
@@ -83,6 +83,31 @@ async def test_fetch_and_validate_agent_card_exposes_warning_only_success(monkey
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_validate_agent_card_accepts_legacy_core_protocol_version() -> (
+    None
+):
+    class _LegacyCardGateway:
+        async def fetch_agent_card_detail(self, **kwargs):
+            payload = build_agent_card_payload()
+            payload["supportedInterfaces"] = [
+                {
+                    "url": "https://example.com/jsonrpc-legacy",
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": "0.3.0",
+                }
+            ]
+            return parse_agent_card(payload)
+
+    resp = await fetch_and_validate_agent_card(
+        gateway=_LegacyCardGateway(), resolved=object()
+    )
+
+    assert resp.success is True
+    assert resp.message == "Agent card validated"
+    assert resp.validation_warnings is None
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_validate_agent_card_exposes_invalid_session_query_contract() -> (
     None
 ):

--- a/backend/tests/invoke/test_validation_errors_debug_mode.py
+++ b/backend/tests/invoke/test_validation_errors_debug_mode.py
@@ -108,6 +108,39 @@ async def test_fetch_and_validate_agent_card_accepts_legacy_core_protocol_versio
 
 
 @pytest.mark.asyncio
+async def test_fetch_and_validate_agent_card_accepts_legacy_top_level_connection_shape() -> (
+    None
+):
+    class _LegacyRawCard:
+        def model_dump(self, **kwargs):
+            return {
+                "name": "legacy",
+                "description": "legacy",
+                "version": "0.3.0",
+                "url": "https://example.com/jsonrpc",
+                "protocolVersion": "0.3.0",
+                "capabilities": {"streaming": True},
+                "defaultInputModes": ["text/plain"],
+                "defaultOutputModes": ["text/plain"],
+                "skills": [{"id": "s1", "name": "s1", "description": "d", "tags": []}],
+            }
+
+    class _LegacyRawGateway:
+        async def fetch_agent_card_detail(self, **kwargs):
+            return _LegacyRawCard()
+
+    resp = await fetch_and_validate_agent_card(
+        gateway=_LegacyRawGateway(), resolved=object()
+    )
+
+    assert resp.success is True
+    assert resp.message == "Agent card validated"
+    assert resp.validation_warnings is None
+    assert resp.card is not None
+    assert resp.card["supportedInterfaces"][0]["protocolVersion"] == "0.3.0"
+
+
+@pytest.mark.asyncio
 async def test_fetch_and_validate_agent_card_exposes_invalid_session_query_contract() -> (
     None
 ):

--- a/docs/a2a-consumer-baseline.md
+++ b/docs/a2a-consumer-baseline.md
@@ -71,7 +71,7 @@ Hub should treat provider-private contracts as:
 - capability-specific diagnostics
 - runtime negotiation inputs when they are declared and intentionally consumed
 
-Hub should not treat missing provider-private details as proof that the peer is not a usable A2A v1.0 peer.
+Hub should not treat missing provider-private details as proof that the peer is not a usable Hub-consumable A2A peer.
 
 ## Minimal Adapter Boundary
 
@@ -95,7 +95,7 @@ Not allowed:
 
 `card:validate` should answer:
 
-- Is this peer basically interoperable as an A2A v1.0 peer?
+- Is this peer basically interoperable under the Hub consumer baseline?
 - Which extensions are declared?
 - Which declared extensions are consumable by Hub?
 - Which contracts are invalid, unsupported, or enhancement-only?

--- a/docs/a2a-consumer-baseline.md
+++ b/docs/a2a-consumer-baseline.md
@@ -27,10 +27,10 @@ Hub should consume peer capabilities in this order:
 
 ### 1. Core Interoperability
 
-The following checks determine whether a peer is basically usable as an A2A v1.0 peer:
+The following checks determine whether a peer is basically usable as a Hub-consumable A2A peer:
 
 - `supportedInterfaces` exists and contains at least one usable interface
-- `protocolVersion` is compatible with A2A v1.0 expectations
+- `protocolVersion` is compatible with the Hub consumer baseline, including `a2a-sdk` legacy `0.3` transport compatibility when available
 - authentication requirements are understood
 - transport reachability is acceptable for the selected binding
 

--- a/docs/compatibility-and-non-goals.md
+++ b/docs/compatibility-and-non-goals.md
@@ -59,6 +59,7 @@ Typical examples:
 
 - invoke-only peers
 - stream-capable peers without session-query extensions
+- legacy `0.3` peers that remain usable through the current `a2a-sdk` consumer compatibility transport
 - peers that are standard enough for transport-level interoperability but do not provide the continuity workflows expected by the Hub UI
 
 For these peers, the Hub may still support onboarding, invocation, and basic streaming while feature depth is reduced.


### PR DESCRIPTION
## 背景

当前仓库已经使用 `a2a-sdk==1.0.2`，而 SDK 本身具备 legacy `0.3` consumer compat transport、interface version 选择逻辑，以及 legacy Agent Card 字段映射能力。但 `a2a-client-hub` 作为 consumer 时，仍在自定义 Agent Card 校验和 transport 协商阶段提前硬拒绝 `0.3` peer，导致 SDK 的兼容能力没有真正生效。

## 本次范围

本次 PR 聚焦 **consumer 侧 core A2A surface**：

- 允许声明 `protocolVersion=0.3.x` 的下游 interface 继续进入 SDK transport 选择层
- 不再在 Hub 自定义协商层提前过滤 legacy `0.3` interface
- 让 Hub 本地的 same-transport interface 选择与 SDK `_find_best_interface()` 保持一致
- 让本地 Agent Card 解析 helper 复用 SDK 的 legacy connection/security 兼容映射，避免未来路径分叉
- 更新英文文档，使 consumer 兼容声明与当前实现一致

非目标：

- 不把 `a2a-client-hub` 改造成 A2A provider
- 不承诺所有 provider-private extension / wire-contract 在 `0.3` peer 上都可用
- 不放宽对 Hub 内部 canonical stream/message 校验的既有边界

## 主要改动

相关 commits：

- `fix(a2a): allow legacy 0.3 downstream peers (#900)`
- `tests(a2a): cover legacy card resolver compatibility (#900)`
- `fix(a2a): align legacy card compatibility with sdk (#900)`

代码与文档改动：

- 移除 consumer 侧对 `supportedInterfaces[].protocolVersion=0.3.x` 的前置硬失败校验
- 调整 `A2AClient` transport 协商逻辑，不再过滤 legacy `0.3` interface
- 将 same-transport 下的 interface version 选择对齐 SDK `_find_best_interface()` 的优先级
- 为 legacy 顶层 `url` / `protocolVersion` 形状补齐本地 helper 与 `card:validate` 路径的兼容映射覆盖
- 收平英文文档中残留的 `v1-only` consumer 基线表述

## 验证

- `cd backend && uv run --locked pre-commit run --files app/integrations/a2a_client/client.py app/integrations/a2a_client/protobuf.py tests/client/test_a2a_client_interoperability.py tests/invoke/test_validation_errors_debug_mode.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/client/test_a2a_client.py tests/client/test_a2a_client_interoperability.py tests/invoke/test_validation_errors_debug_mode.py`
- 结果：`85 passed`
- `cd backend && uv run pre-commit run --all-files --config ../.pre-commit-config.yaml`
- `cd backend && uv run pytest`
- 结果：`1152 passed`

## 关联

- Closes #900
- Related #866
