### PR TITLE
refactor(a2a): keep v1 baseline selection clarity (#903)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -65,18 +65,14 @@ Default API prefix: `/api/v1`.
 
 ## Run the MCP Surface
 
-The backend also mounts an authenticated FastMCP surface for hub-assistant.
-This is intended for agent runtimes such as `swival`, not for direct browser use.
+The backend also mounts an authenticated FastMCP surface for hub-assistant. This is intended for agent runtimes such as `swival`, not for direct browser use.
 
 - Mounted paths:
   - `/mcp` for the default read-only tool surface
   - `/mcp-write` for the explicitly write-enabled tool surface
 - Transport: HTTP SSE
 - Auth: delegated bearer token in `Authorization: Bearer <token>`
-- Read-only MCP tools:
-  `hub_assistant.agents.list`, `hub_assistant.agents.get`,
-  `hub_assistant.jobs.list`, `hub_assistant.jobs.get`,
-  `hub_assistant.sessions.list`, `hub_assistant.sessions.get`
+- Read-only MCP tools: `hub_assistant.agents.list`, `hub_assistant.agents.get`, `hub_assistant.jobs.list`, `hub_assistant.jobs.get`, `hub_assistant.sessions.list`, `hub_assistant.sessions.get`
 - Write-enabled MCP tools add:
   `hub_assistant.agents.update_config`, `hub_assistant.jobs.pause`
 
@@ -94,9 +90,7 @@ http://localhost:8000/mcp-write/
 
 ## Run the Swival-Backed Built-In Agent
 
-The backend also exposes a first-wave Hub Assistant surface
-that uses `swival` as the runtime and the authenticated MCP surface as its tool
-backend.
+The backend also exposes a first-wave Hub Assistant surface that uses `swival` as the runtime and the authenticated MCP surface as its tool backend.
 
 - Profile: `GET /api/v1/me/hub-assistant`
 - Run once: `POST /api/v1/me/hub-assistant:run`
@@ -106,10 +100,7 @@ backend.
 - To explicitly enable write tools for one run, send:
   `{"conversationId": "...", "message": "...", "allow_write_tools": true}`
 - Current Hub Assistant tool set:
-  - default read-only:
-    `hub_assistant.agents.list`, `hub_assistant.agents.get`,
-    `hub_assistant.jobs.list`, `hub_assistant.jobs.get`,
-    `hub_assistant.sessions.list`, `hub_assistant.sessions.get`
+  - default read-only: `hub_assistant.agents.list`, `hub_assistant.agents.get`, `hub_assistant.jobs.list`, `hub_assistant.jobs.get`, `hub_assistant.sessions.list`, `hub_assistant.sessions.get`
   - write-enabled only:
     `hub_assistant.agents.update_config`, `hub_assistant.jobs.pause`
 
@@ -142,49 +133,24 @@ export HUB_ASSISTANT_SWIVAL_MCP_BASE_URL=http://127.0.0.1:8000
 
 Notes:
 
-- Preferred production deployment: install the exact `swival` build that you
-  intend to run into the backend Python environment so `uv run python -c "import swival"`
-  succeeds directly.
-- If you currently ship a locally patched `swival` through `uv tool install`,
-  set `HUB_ASSISTANT_SWIVAL_TOOL_EXECUTABLE` to that tool binary (prefer an
-  absolute path). The backend will resolve the tool-managed virtualenv's
-  `site-packages` and import `swival` from there as a compatibility fallback.
-- `HUB_ASSISTANT_SWIVAL_IMPORT_PATHS` remains available as a last-resort
-  development escape hatch, but it is less stable than installing an exact
-  wheel into the backend environment or resolving from an explicitly managed
-  tool executable.
+- Preferred production deployment: install the exact `swival` build that you intend to run into the backend Python environment so `uv run python -c "import swival"` succeeds directly.
+- If you currently ship a locally patched `swival` through `uv tool install`, set `HUB_ASSISTANT_SWIVAL_TOOL_EXECUTABLE` to that tool binary (prefer an absolute path). The backend will resolve the tool-managed virtualenv's `site-packages` and import `swival` from there as a compatibility fallback.
+- `HUB_ASSISTANT_SWIVAL_IMPORT_PATHS` remains available as a last-resort development escape hatch, but it is less stable than installing an exact wheel into the backend environment or resolving from an explicitly managed tool executable.
 - For Gemini, prefer `HUB_ASSISTANT_SWIVAL_PROVIDER=google` instead of `generic`.
 - Let `swival` resolve the API key from `GEMINI_API_KEY` or `OPENAI_API_KEY`.
 - `HUB_ASSISTANT_SWIVAL_BASE_URL` is optional for Gemini and only needed when
   overriding the default Google OpenAI-compatible endpoint.
 - `HUB_ASSISTANT_SWIVAL_MCP_BASE_URL` must be a trusted internal address. The
   Hub Assistant no longer derives its MCP target from request headers.
-- `HUB_ASSISTANT_SWIVAL_RUNTIME_ROOT` controls where the Hub Assistant runtime keeps
-  swival's per-user working state. Each authenticated user gets a dedicated
-  subdirectory under this root, and the runtime no longer uses the shared
-  backend repository directory as its `base_dir`.
-- The Hub Assistant profile now reports `configured=true` only when the required
-  runtime settings are present and `swival` is actually importable from the
-  backend process.
+- `HUB_ASSISTANT_SWIVAL_RUNTIME_ROOT` controls where the Hub Assistant runtime keeps swival's per-user working state. Each authenticated user gets a dedicated subdirectory under this root, and the runtime no longer uses the shared backend repository directory as its `base_dir`.
+- The Hub Assistant profile now reports `configured=true` only when the required runtime settings are present and `swival` is actually importable from the backend process.
 - Hub Assistant write tools are disabled by default and only become available
   for runs that explicitly set `allow_write_tools=true`.
-- Hub Assistant runs now bind their `conversationId` to the normal sessions domain:
-  the thread, user/agent messages, and permission interrupt lifecycle events are
-  persisted under `/me/conversations`, rather than existing only in process
-  memory.
-- When the Hub Assistant returns a permission interrupt, `reply=once` enables
-  write tools only for the resumed turn, while `reply=always` enables
-  auto-approved write tools for the current Hub Assistant conversation until the
-  server-side swival session expires.
-- The swival runtime object itself is still process-local and TTL-managed; this
-  PR persists the durable session history and interrupt lifecycle, not full
-  cross-process swival runtime restoration.
-- If the in-memory swival runtime expires, the backend now best-effort
-  rehydrates the next Hub Assistant session from persisted user/agent turns in the
-  same durable conversation before resuming.
-- The Hub Assistant runtime applies a compatibility shim for older `swival` MCP
-  adapters that still emit private `_mcp_*` tool metadata rejected by Gemini's
-  OpenAI-compatible endpoint.
+- Hub Assistant runs now bind their `conversationId` to the normal sessions domain: the thread, user/agent messages, and permission interrupt lifecycle events are persisted under `/me/conversations`, rather than existing only in process memory.
+- When the Hub Assistant returns a permission interrupt, `reply=once` enables write tools only for the resumed turn, while `reply=always` enables auto-approved write tools for the current Hub Assistant conversation until the server-side swival session expires.
+- The swival runtime object itself is still process-local and TTL-managed; this PR persists the durable session history and interrupt lifecycle, not full cross-process swival runtime restoration.
+- If the in-memory swival runtime expires, the backend now best-effort rehydrates the next Hub Assistant session from persisted user/agent turns in the same durable conversation before resuming.
+- The Hub Assistant runtime applies a compatibility shim for older `swival` MCP adapters that still emit private `_mcp_*` tool metadata rejected by Gemini's OpenAI-compatible endpoint.
 
 ## Backend Structure
 
@@ -293,9 +259,7 @@ Endpoints:
 Credentials:
 
 - Configure `HUB_A2A_TOKEN_ENCRYPTION_KEY` (falls back to `USER_LLM_TOKEN_ENCRYPTION_KEY`).
-- Personal-agent and hub-agent create/update payloads also accept
-  `invoke_metadata_defaults`, which stores agent-level fallback values for
-  declared invoke-metadata contracts.
+- Personal-agent and hub-agent create/update payloads also accept `invoke_metadata_defaults`, which stores agent-level fallback values for declared invoke-metadata contracts.
 
 ## Shared Session Query / Interrupt Callback Compatibility
 
@@ -380,11 +344,8 @@ Validation:
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/sessions/{session_id}:revert`
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/sessions/{session_id}:unrevert`
   - The Hub still does not expose `opencode.sessions.shell`; upstream treats it as a deployment-conditional, boundary-sensitive surface and Hub keeps it diagnostics-only.
-- When an upstream declares invoke-metadata fields, Hub now applies values in
-  this order before outbound invoke: direct request metadata, then
-  session-scoped bindings, then agent-level `invoke_metadata_defaults`.
-- `invokeMetadata` capability diagnostics now expose `status` and `error` so
-  invalid upstream contracts can be distinguished from unsupported runtimes.
+- When an upstream declares invoke-metadata fields, Hub now applies values in this order before outbound invoke: direct request metadata, then session-scoped bindings, then agent-level `invoke_metadata_defaults`.
+- `invokeMetadata` capability diagnostics now expose `status` and `error` so invalid upstream contracts can be distinguished from unsupported runtimes.
 - Reply interrupt callbacks:
   - `POST /api/v1/me/a2a/agents/{agent_id}/extensions/interrupts:recover`
     - body: `{ "sessionId": "ses-123" }`
@@ -476,9 +437,7 @@ The backend now exposes a unified conversation read model for manual, scheduled,
   - `contextId` (A2A context id)
   - `<metadata_key>` (strict upstream session-binding key from `urn:opencode-a2a:opencode-session-binding/v1`, e.g. `opencode_session_id`)
 
-Hub-facing request contracts accept `workingDirectory` directly. The backend
-keeps provider-private working-directory metadata as an outbound adapter detail
-when upstream extensions still require it.
+Hub-facing request contracts accept `workingDirectory` directly. The backend keeps provider-private working-directory metadata as an outbound adapter detail when upstream extensions still require it.
 
 Client-generated chat sessions should use raw UUID conversation IDs, for example `550e8400-e29b-41d4-a716-446655440000`.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -73,8 +73,7 @@ The backend also mounts an authenticated FastMCP surface for hub-assistant. This
 - Transport: HTTP SSE
 - Auth: delegated bearer token in `Authorization: Bearer <token>`
 - Read-only MCP tools: `hub_assistant.agents.list`, `hub_assistant.agents.get`, `hub_assistant.jobs.list`, `hub_assistant.jobs.get`, `hub_assistant.sessions.list`, `hub_assistant.sessions.get`
-- Write-enabled MCP tools add:
-  `hub_assistant.agents.update_config`, `hub_assistant.jobs.pause`
+- Write-enabled MCP tools add: `hub_assistant.agents.update_config`, `hub_assistant.jobs.pause`
 
 Once the API server is running, an MCP client can connect to:
 
@@ -97,12 +96,10 @@ The backend also exposes a first-wave Hub Assistant surface that uses `swival` a
 - Recover pending interrupts: `POST /api/v1/me/hub-assistant/interrupts:recover`
 - Default run mode: read-only
 - Hub Assistant runs are conversation-backed and must include `conversationId`
-- To explicitly enable write tools for one run, send:
-  `{"conversationId": "...", "message": "...", "allow_write_tools": true}`
+- To explicitly enable write tools for one run, send: `{"conversationId": "...", "message": "...", "allow_write_tools": true}`
 - Current Hub Assistant tool set:
   - default read-only: `hub_assistant.agents.list`, `hub_assistant.agents.get`, `hub_assistant.jobs.list`, `hub_assistant.jobs.get`, `hub_assistant.sessions.list`, `hub_assistant.sessions.get`
-  - write-enabled only:
-    `hub_assistant.agents.update_config`, `hub_assistant.jobs.pause`
+  - write-enabled only: `hub_assistant.agents.update_config`, `hub_assistant.jobs.pause`
 
 Required environment variables:
 
@@ -138,14 +135,11 @@ Notes:
 - `HUB_ASSISTANT_SWIVAL_IMPORT_PATHS` remains available as a last-resort development escape hatch, but it is less stable than installing an exact wheel into the backend environment or resolving from an explicitly managed tool executable.
 - For Gemini, prefer `HUB_ASSISTANT_SWIVAL_PROVIDER=google` instead of `generic`.
 - Let `swival` resolve the API key from `GEMINI_API_KEY` or `OPENAI_API_KEY`.
-- `HUB_ASSISTANT_SWIVAL_BASE_URL` is optional for Gemini and only needed when
-  overriding the default Google OpenAI-compatible endpoint.
-- `HUB_ASSISTANT_SWIVAL_MCP_BASE_URL` must be a trusted internal address. The
-  Hub Assistant no longer derives its MCP target from request headers.
+- `HUB_ASSISTANT_SWIVAL_BASE_URL` is optional for Gemini and only needed when overriding the default Google OpenAI-compatible endpoint.
+- `HUB_ASSISTANT_SWIVAL_MCP_BASE_URL` must be a trusted internal address. The Hub Assistant no longer derives its MCP target from request headers.
 - `HUB_ASSISTANT_SWIVAL_RUNTIME_ROOT` controls where the Hub Assistant runtime keeps swival's per-user working state. Each authenticated user gets a dedicated subdirectory under this root, and the runtime no longer uses the shared backend repository directory as its `base_dir`.
 - The Hub Assistant profile now reports `configured=true` only when the required runtime settings are present and `swival` is actually importable from the backend process.
-- Hub Assistant write tools are disabled by default and only become available
-  for runs that explicitly set `allow_write_tools=true`.
+- Hub Assistant write tools are disabled by default and only become available for runs that explicitly set `allow_write_tools=true`.
 - Hub Assistant runs now bind their `conversationId` to the normal sessions domain: the thread, user/agent messages, and permission interrupt lifecycle events are persisted under `/me/conversations`, rather than existing only in process memory.
 - When the Hub Assistant returns a permission interrupt, `reply=once` enables write tools only for the resumed turn, while `reply=always` enables auto-approved write tools for the current Hub Assistant conversation until the server-side swival session expires.
 - The swival runtime object itself is still process-local and TTL-managed; this PR persists the durable session history and interrupt lifecycle, not full cross-process swival runtime restoration.

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -107,6 +107,26 @@ def _is_unsupported_protocol_version(value: str | None) -> bool:
     return isinstance(value, str) and value.strip().startswith("0.3")
 
 
+def _protocol_version_priority(value: str | None) -> tuple[int, tuple[int, ...]]:
+    if not isinstance(value, str):
+        return (0, ())
+
+    stripped = value.strip()
+    if not stripped:
+        return (0, ())
+
+    try:
+        parsed = tuple(int(part) for part in stripped.split("."))
+    except ValueError:
+        return (0, ())
+
+    if parsed and parsed[0] == 1 and all(part == 0 for part in parsed[1:]):
+        return (3, parsed)
+    if parsed and parsed[0] >= 1:
+        return (2, parsed)
+    return (1, parsed)
+
+
 class StaticHeaderInterceptor(ClientCallInterceptor):
     """Interceptor that injects static HTTP headers into every outbound request."""
 
@@ -649,19 +669,57 @@ class A2AClient:
         if not supported_labels:
             supported_labels = [TransportProtocol.JSONRPC.value]
 
-        server_set: list[tuple[str, str]] = []
         skipped_unsupported_protocol_interface = False
-        for iface in getattr(card, "supported_interfaces", None) or []:
+        supported_interfaces = list(getattr(card, "supported_interfaces", None) or [])
+
+        def _select_preferred_interface(
+            protocol_binding: str,
+        ) -> tuple[str, str] | None:
+            best_candidate: tuple[tuple[int, tuple[int, ...], int], str] | None = None
+
+            for index, iface in enumerate(supported_interfaces):
+                transport = normalize_transport_label(
+                    getattr(iface, "protocol_binding", None)
+                )
+                if transport != protocol_binding:
+                    continue
+
+                interface_url = (getattr(iface, "url", "") or "").strip()
+                if not interface_url:
+                    continue
+
+                protocol_version = getattr(iface, "protocol_version", None)
+                if _is_unsupported_protocol_version(protocol_version):
+                    continue
+
+                priority = (
+                    *_protocol_version_priority(protocol_version),
+                    -index,
+                )
+                if best_candidate is None or priority > best_candidate[0]:
+                    best_candidate = (priority, interface_url)
+
+            if best_candidate is None:
+                return None
+
+            return protocol_binding, best_candidate[1]
+
+        server_set: list[tuple[str, str]] = []
+        seen_transports: set[str] = set()
+        for iface in supported_interfaces:
             transport = normalize_transport_label(
                 getattr(iface, "protocol_binding", None)
             )
-            interface_url = (getattr(iface, "url", "") or "").strip()
             protocol_version = getattr(iface, "protocol_version", None)
             if _is_unsupported_protocol_version(protocol_version):
                 skipped_unsupported_protocol_interface = True
+            if not transport or transport in seen_transports:
                 continue
-            if transport and interface_url:
-                server_set.append((transport, interface_url))
+            selected_interface = _select_preferred_interface(transport)
+            if selected_interface is None:
+                continue
+            seen_transports.add(transport)
+            server_set.append(selected_interface)
 
         if self._use_client_preference:
             for transport in client_set:

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, Optional, cast
@@ -125,6 +125,35 @@ def _protocol_version_priority(value: str | None) -> tuple[int, tuple[int, ...]]
     if parsed and parsed[0] >= 1:
         return (2, parsed)
     return (1, parsed)
+
+
+def _select_preferred_interface(
+    supported_interfaces: Sequence[Any],
+    protocol_binding: str,
+) -> tuple[str, str] | None:
+    best_candidate: tuple[tuple[int, tuple[int, ...], int], str] | None = None
+
+    for index, iface in enumerate(supported_interfaces):
+        transport = normalize_transport_label(getattr(iface, "protocol_binding", None))
+        if transport != protocol_binding:
+            continue
+
+        interface_url = (getattr(iface, "url", "") or "").strip()
+        if not interface_url:
+            continue
+
+        protocol_version = getattr(iface, "protocol_version", None)
+        if _is_unsupported_protocol_version(protocol_version):
+            continue
+
+        priority = (*_protocol_version_priority(protocol_version), -index)
+        if best_candidate is None or priority > best_candidate[0]:
+            best_candidate = (priority, interface_url)
+
+    if best_candidate is None:
+        return None
+
+    return protocol_binding, best_candidate[1]
 
 
 class StaticHeaderInterceptor(ClientCallInterceptor):
@@ -672,38 +701,6 @@ class A2AClient:
         skipped_unsupported_protocol_interface = False
         supported_interfaces = list(getattr(card, "supported_interfaces", None) or [])
 
-        def _select_preferred_interface(
-            protocol_binding: str,
-        ) -> tuple[str, str] | None:
-            best_candidate: tuple[tuple[int, tuple[int, ...], int], str] | None = None
-
-            for index, iface in enumerate(supported_interfaces):
-                transport = normalize_transport_label(
-                    getattr(iface, "protocol_binding", None)
-                )
-                if transport != protocol_binding:
-                    continue
-
-                interface_url = (getattr(iface, "url", "") or "").strip()
-                if not interface_url:
-                    continue
-
-                protocol_version = getattr(iface, "protocol_version", None)
-                if _is_unsupported_protocol_version(protocol_version):
-                    continue
-
-                priority = (
-                    *_protocol_version_priority(protocol_version),
-                    -index,
-                )
-                if best_candidate is None or priority > best_candidate[0]:
-                    best_candidate = (priority, interface_url)
-
-            if best_candidate is None:
-                return None
-
-            return protocol_binding, best_candidate[1]
-
         server_set: list[tuple[str, str]] = []
         seen_transports: set[str] = set()
         for iface in supported_interfaces:
@@ -715,7 +712,10 @@ class A2AClient:
                 skipped_unsupported_protocol_interface = True
             if not transport or transport in seen_transports:
                 continue
-            selected_interface = _select_preferred_interface(transport)
+            selected_interface = _select_preferred_interface(
+                supported_interfaces,
+                transport,
+            )
             if selected_interface is None:
                 continue
             seen_transports.add(transport)

--- a/backend/tests/client/test_a2a_client_interoperability.py
+++ b/backend/tests/client/test_a2a_client_interoperability.py
@@ -373,6 +373,60 @@ def test_build_card_resolver_rebases_standard_http_extended_card_path_from_well_
     assert resolver.agent_card_path == "v1/card"
 
 
+def test_resolve_negotiated_transport_target_prefers_exact_v1_interface_within_transport() -> (
+    None
+):
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    card = _build_card(
+        supported_interfaces=[
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-v1-1",
+                protocol_version="1.1.0",
+            ),
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-v1-0",
+                protocol_version="1.0",
+            ),
+        ]
+    )
+
+    selected_transport, selected_url, _, _ = (
+        a2a_client._resolve_negotiated_transport_target(card)
+    )
+
+    assert selected_transport == TransportProtocol.JSONRPC
+    assert selected_url == "http://example-agent.internal:24020/jsonrpc-v1-0"
+
+
+def test_resolve_negotiated_transport_target_prefers_versioned_interface_over_unversioned_one() -> (
+    None
+):
+    a2a_client = A2AClient("http://example-agent.internal:24020")
+    card = _build_card(
+        supported_interfaces=[
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-unversioned",
+                protocol_version=None,
+            ),
+            _build_interface(
+                "JSONRPC",
+                "http://example-agent.internal:24020/jsonrpc-v1-2",
+                protocol_version="1.2.0",
+            ),
+        ]
+    )
+
+    selected_transport, selected_url, _, _ = (
+        a2a_client._resolve_negotiated_transport_target(card)
+    )
+
+    assert selected_transport == TransportProtocol.JSONRPC
+    assert selected_url == "http://example-agent.internal:24020/jsonrpc-v1-2"
+
+
 @pytest.mark.asyncio
 async def test_get_authenticated_extended_agent_card_prefers_sdk_route() -> None:
     public_card = _build_card(

--- a/docs/a2a-consumer-baseline.md
+++ b/docs/a2a-consumer-baseline.md
@@ -27,10 +27,11 @@ Hub should consume peer capabilities in this order:
 
 ### 1. Core Interoperability
 
-The following checks determine whether a peer is basically usable as an A2A v1.0 peer:
+The following checks determine whether a peer is basically usable as a
+Hub-consumable A2A peer:
 
 - `supportedInterfaces` exists and contains at least one usable interface
-- `protocolVersion` is compatible with A2A v1.0 expectations
+- `protocolVersion` is compatible with the Hub consumer baseline
 - authentication requirements are understood
 - transport reachability is acceptable for the selected binding
 
@@ -71,7 +72,8 @@ Hub should treat provider-private contracts as:
 - capability-specific diagnostics
 - runtime negotiation inputs when they are declared and intentionally consumed
 
-Hub should not treat missing provider-private details as proof that the peer is not a usable A2A v1.0 peer.
+Hub should not treat missing provider-private details as proof that the peer is not
+a usable Hub-consumable A2A peer.
 
 ## Minimal Adapter Boundary
 
@@ -95,7 +97,7 @@ Not allowed:
 
 `card:validate` should answer:
 
-- Is this peer basically interoperable as an A2A v1.0 peer?
+- Is this peer basically interoperable under the Hub consumer baseline?
 - Which extensions are declared?
 - Which declared extensions are consumable by Hub?
 - Which contracts are invalid, unsupported, or enhancement-only?

--- a/docs/a2a-consumer-baseline.md
+++ b/docs/a2a-consumer-baseline.md
@@ -27,10 +27,10 @@ Hub should consume peer capabilities in this order:
 
 ### 1. Core Interoperability
 
-The following checks determine whether a peer is basically usable as a Hub-consumable A2A peer:
+The following checks determine whether a peer is basically usable as a Hub-consumable A2A v1.0 peer under the current consumer baseline:
 
 - `supportedInterfaces` exists and contains at least one usable interface
-- `protocolVersion` is compatible with the Hub consumer baseline
+- `protocolVersion` is compatible with core A2A v1.0 expectations
 - authentication requirements are understood
 - transport reachability is acceptable for the selected binding
 
@@ -71,7 +71,7 @@ Hub should treat provider-private contracts as:
 - capability-specific diagnostics
 - runtime negotiation inputs when they are declared and intentionally consumed
 
-Hub should not treat missing provider-private details as proof that the peer is not a usable Hub-consumable A2A peer.
+Hub should not treat missing provider-private details as proof that the peer is not a usable Hub-consumable A2A v1.0 peer.
 
 ## Minimal Adapter Boundary
 
@@ -95,7 +95,7 @@ Not allowed:
 
 `card:validate` should answer:
 
-- Is this peer basically interoperable under the Hub consumer baseline?
+- Is this peer basically interoperable as a Hub-consumable A2A v1.0 peer under the current baseline?
 - Which extensions are declared?
 - Which declared extensions are consumable by Hub?
 - Which contracts are invalid, unsupported, or enhancement-only?

--- a/docs/a2a-consumer-baseline.md
+++ b/docs/a2a-consumer-baseline.md
@@ -27,8 +27,7 @@ Hub should consume peer capabilities in this order:
 
 ### 1. Core Interoperability
 
-The following checks determine whether a peer is basically usable as a
-Hub-consumable A2A peer:
+The following checks determine whether a peer is basically usable as a Hub-consumable A2A peer:
 
 - `supportedInterfaces` exists and contains at least one usable interface
 - `protocolVersion` is compatible with the Hub consumer baseline
@@ -72,8 +71,7 @@ Hub should treat provider-private contracts as:
 - capability-specific diagnostics
 - runtime negotiation inputs when they are declared and intentionally consumed
 
-Hub should not treat missing provider-private details as proof that the peer is not
-a usable Hub-consumable A2A peer.
+Hub should not treat missing provider-private details as proof that the peer is not a usable Hub-consumable A2A peer.
 
 ## Minimal Adapter Boundary
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -149,8 +149,6 @@ The continue payload also includes canonical binding fields:
 - `metadata.provider`
 - `metadata.externalSessionId`
 
-Chat writes `workingDirectory` as a stable Hub field. The backend adapts it to
-legacy provider-private metadata when required.
+Chat writes `workingDirectory` as a stable Hub field. The backend adapts it to legacy provider-private metadata when required.
 
-Model discovery uses the same `workingDirectory` field when the upstream agent
-needs provider-specific context for provider/model listing.
+Model discovery uses the same `workingDirectory` field when the upstream agent needs provider-specific context for provider/model listing.


### PR DESCRIPTION
## Summary

- 在 `1.0-only` 前提下，保留同一 transport 下 interface 选择的确定性排序，避免继续按声明顺序命中
- 保留 consumer baseline / `card:validate` 的边界澄清，明确区分 core interoperability 与 extension diagnostics
- 不引入 `0.3` compat 入口，不放宽主线 validator，不保留 legacy Agent Card 兼容解析

## Related Issues

- Closes #903
- Related #900
- Related #901

## 说明

这不是 `#901` 的继续合并路径。

`#901` 中与 `0.3` downstream peer compatibility 直接相关的实现没有带入此 PR；这里只保留审查后确认仍适合进入主干的部分：

- 同一 transport 下的 interface 选择应更稳定、可解释
- 文档应更准确表达 Hub consumer baseline 的实际边界

## Verification

- `cd backend && uv run --locked pre-commit run --files app/integrations/a2a_client/client.py tests/client/test_a2a_client_interoperability.py ../docs/a2a-consumer-baseline.md --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/client/test_a2a_client.py tests/client/test_a2a_client_interoperability.py`
- 结果：`73 passed`
