### PR TITLE
fix(backend): isolate backend test config bootstrap (#906)

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -32,7 +32,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres # pragma: allowlist secret
+      TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/postgres # pragma: allowlist secret
     defaults:
       run:
         working-directory: backend

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -235,7 +235,7 @@
         "filename": "backend/app/core/config.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 90
       }
     ],
     "backend/tests/auth/test_auth.py": [
@@ -335,5 +335,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-13T08:36:47Z"
+  "generated_at": "2026-05-06T12:24:24Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -235,7 +235,7 @@
         "filename": "backend/app/core/config.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 90
+        "line_number": 94
       }
     ],
     "backend/tests/auth/test_auth.py": [
@@ -335,5 +335,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-06T12:24:24Z"
+  "generated_at": "2026-05-06T12:30:12Z"
 }

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -47,10 +47,14 @@ SUPPORTED_JWT_ALGORITHMS = frozenset(
 def _resolve_settings_env_file() -> str | None:
     """Resolve the dotenv file used by application settings."""
 
-    disable_env_file = os.getenv("A2A_SETTINGS_DISABLE_ENV_FILE", "").strip().lower()
-    if disable_env_file in {"1", "true", "yes", "on"}:
+    env_file = os.getenv("BACKEND_ENV_FILE")
+    if env_file is None:
+        return ".env"
+
+    normalized = env_file.strip()
+    if not normalized:
         return None
-    return ".env"
+    return normalized
 
 
 class Settings(BaseSettings):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,6 +5,7 @@ variable management.
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -12,12 +13,9 @@ from urllib.parse import urlparse
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
-from dotenv import load_dotenv
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy.engine.url import make_url
-
-load_dotenv(override=False)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
@@ -44,6 +42,15 @@ SUPPORTED_JWT_ALGORITHMS = frozenset(
         "ES512",
     }
 )
+
+
+def _resolve_settings_env_file() -> str | None:
+    """Resolve the dotenv file used by application settings."""
+
+    disable_env_file = os.getenv("A2A_SETTINGS_DISABLE_ENV_FILE", "").strip().lower()
+    if disable_env_file in {"1", "true", "yes", "on"}:
+        return None
+    return ".env"
 
 
 class Settings(BaseSettings):
@@ -905,7 +912,7 @@ class Settings(BaseSettings):
     )
 
     model_config = SettingsConfigDict(
-        env_file=".env",
+        env_file=_resolve_settings_env_file(),
         case_sensitive=False,
         extra="ignore",  # Ignore extra fields from environment
     )

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -29,6 +29,7 @@ Backend tests are organized by either business feature or shared concern.
 ## Environment Bootstrap
 
 - Backend tests install a controlled application environment before importing `app.core.config`.
+- The bootstrap sets `BACKEND_ENV_FILE` to an empty value so tests do not load the repo-local `backend/.env`.
 - Use `TEST_DATABASE_URL` or `TEST_DATABASE_NAME` to choose the PostgreSQL database for tests.
 - Use `TEST_SCHEMA_NAME` to override the default schema name.
 - Ambient application settings such as `DATABASE_URL`, `BACKEND_*`, `JWT_*`, and other runtime env vars are cleared during test bootstrap to keep runs reproducible.

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -26,6 +26,13 @@ Backend tests are organized by either business feature or shared concern.
 - `conftest.py`: shared pytest fixtures and configuration
 - `support/`: reusable test helpers such as ASGI client wrappers and model factories
 
+## Environment Bootstrap
+
+- Backend tests install a controlled application environment before importing `app.core.config`.
+- Use `TEST_DATABASE_URL` or `TEST_DATABASE_NAME` to choose the PostgreSQL database for tests.
+- Use `TEST_SCHEMA_NAME` to override the default schema name.
+- Ambient application settings such as `DATABASE_URL`, `BACKEND_*`, `JWT_*`, and other runtime env vars are cleared during test bootstrap to keep runs reproducible.
+
 When adding a new test:
 
 - Put business capability coverage under the matching feature directory.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import importlib
 import os
 import sys
@@ -10,8 +9,6 @@ from typing import AsyncGenerator, Generator
 import pytest
 import pytest_asyncio
 from a2a.types import AgentCard
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -29,48 +26,9 @@ REPO_ROOT = os.path.dirname(PROJECT_ROOT)
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
+from tests.support.env_bootstrap import apply_test_environment
 
-TEST_SCHEMA_NAME = os.getenv("TEST_SCHEMA_NAME", "test_a2a_client_hub_schema")
-os.environ["SCHEMA_NAME"] = TEST_SCHEMA_NAME
-
-# Default DATABASE_URL for local test runs.
-#
-# We intentionally keep this as an opt-out default (setdefault) so CI/dev
-# environments can provide their own DATABASE_URL. Using the current OS user
-# as the default database name matches common local Postgres setups.
-if "DATABASE_URL" not in os.environ:
-    default_db_name = os.getenv("TEST_DATABASE_NAME") or os.getenv("USER") or "postgres"
-    os.environ["DATABASE_URL"] = f"postgresql:///{default_db_name}"
-
-# Ensure encryption keys are available for tests that store encrypted credentials.
-default_test_secret_key = base64.urlsafe_b64encode(b"0" * 32).decode("utf-8")
-os.environ.setdefault("USER_LLM_TOKEN_ENCRYPTION_KEY", default_test_secret_key)
-os.environ.setdefault("HUB_A2A_TOKEN_ENCRYPTION_KEY", default_test_secret_key)
-os.environ.setdefault("WS_TICKET_SECRET_KEY", default_test_secret_key)
-
-# Ensure JWT RS256 configuration is available for tests.
-if "JWT_PRIVATE_KEY_PEM" not in os.environ or "JWT_PUBLIC_KEY_PEM" not in os.environ:
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    private_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    ).decode("utf-8")
-    public_pem = (
-        private_key.public_key()
-        .public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        )
-        .decode("utf-8")
-    )
-    os.environ.setdefault("JWT_ALGORITHM", "RS256")
-    os.environ["JWT_PRIVATE_KEY_PEM"] = private_pem
-    os.environ["JWT_PUBLIC_KEY_PEM"] = public_pem
-    os.environ.setdefault("JWT_ISSUER", "common-compass-test")
-    os.environ.setdefault("JWT_ACCESS_TOKEN_TTL_SECONDS", "1800")
-    os.environ.setdefault("JWT_REFRESH_TOKEN_TTL_SECONDS", "1209600")
-    os.environ.setdefault("AUTH_REFRESH_COOKIE_SECURE", "false")
+apply_test_environment()
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/backend/tests/runtime/test_dotenv_override_behavior.py
+++ b/backend/tests/runtime/test_dotenv_override_behavior.py
@@ -6,7 +6,7 @@ from app.core.config import _resolve_settings_env_file
 def test_settings_env_file_enabled_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("A2A_SETTINGS_DISABLE_ENV_FILE", raising=False)
+    monkeypatch.delenv("BACKEND_ENV_FILE", raising=False)
 
     assert _resolve_settings_env_file() == ".env"
 
@@ -14,6 +14,6 @@ def test_settings_env_file_enabled_by_default(
 def test_settings_env_file_can_be_disabled_for_tests(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("A2A_SETTINGS_DISABLE_ENV_FILE", "true")
+    monkeypatch.setenv("BACKEND_ENV_FILE", "")
 
     assert _resolve_settings_env_file() is None

--- a/backend/tests/runtime/test_dotenv_override_behavior.py
+++ b/backend/tests/runtime/test_dotenv_override_behavior.py
@@ -1,9 +1,19 @@
-from pathlib import Path
+import pytest
+
+from app.core.config import _resolve_settings_env_file
 
 
-def test_config_does_not_override_existing_environment_variables() -> None:
-    config_path = Path(__file__).resolve().parents[2] / "app" / "core" / "config.py"
-    content = config_path.read_text()
+def test_settings_env_file_enabled_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("A2A_SETTINGS_DISABLE_ENV_FILE", raising=False)
 
-    assert "load_dotenv(override=False)" in content
-    assert "load_dotenv(override=True)" not in content
+    assert _resolve_settings_env_file() == ".env"
+
+
+def test_settings_env_file_can_be_disabled_for_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("A2A_SETTINGS_DISABLE_ENV_FILE", "true")
+
+    assert _resolve_settings_env_file() is None

--- a/backend/tests/runtime/test_test_environment_bootstrap.py
+++ b/backend/tests/runtime/test_test_environment_bootstrap.py
@@ -5,7 +5,7 @@ import os
 import pytest
 
 from tests.support.env_bootstrap import (
-    TEST_SETTINGS_DISABLE_ENV_FILE,
+    TEST_BACKEND_ENV_FILE,
     apply_test_environment,
 )
 
@@ -22,7 +22,7 @@ def test_apply_test_environment_replaces_ambient_application_settings(
 
     apply_test_environment()
 
-    assert os.environ[TEST_SETTINGS_DISABLE_ENV_FILE] == "true"
+    assert os.environ[TEST_BACKEND_ENV_FILE] == ""
     assert os.environ["APP_ENV"] == "development"
     assert os.environ["DATABASE_URL"] == "postgresql://localhost/test_db"
     assert os.environ["SCHEMA_NAME"] == "isolated_schema"

--- a/backend/tests/runtime/test_test_environment_bootstrap.py
+++ b/backend/tests/runtime/test_test_environment_bootstrap.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.support.env_bootstrap import (
+    TEST_SETTINGS_DISABLE_ENV_FILE,
+    apply_test_environment,
+)
+
+
+def test_apply_test_environment_replaces_ambient_application_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://prod.example.com/prod")
+    monkeypatch.setenv("BACKEND_HOST", "0.0.0.0")
+    monkeypatch.setenv("JWT_ISSUER", "prod-issuer")
+    monkeypatch.setenv("AUTH_REFRESH_COOKIE_SECURE", "true")
+    monkeypatch.setenv("TEST_DATABASE_URL", "postgresql://localhost/test_db")
+    monkeypatch.setenv("TEST_SCHEMA_NAME", "isolated_schema")
+
+    apply_test_environment()
+
+    assert os.environ[TEST_SETTINGS_DISABLE_ENV_FILE] == "true"
+    assert os.environ["APP_ENV"] == "development"
+    assert os.environ["DATABASE_URL"] == "postgresql://localhost/test_db"
+    assert os.environ["SCHEMA_NAME"] == "isolated_schema"
+    assert os.environ["JWT_ISSUER"] == "common-compass-test"
+    assert os.environ["AUTH_REFRESH_COOKIE_SECURE"] == "false"
+    assert "BACKEND_HOST" not in os.environ
+
+
+def test_apply_test_environment_uses_local_database_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("TEST_DATABASE_URL", raising=False)
+    monkeypatch.delenv("TEST_DATABASE_NAME", raising=False)
+    monkeypatch.setenv("USER", "bootstrap-user")
+
+    apply_test_environment()
+
+    assert os.environ["DATABASE_URL"] == "postgresql:///bootstrap-user"

--- a/backend/tests/support/env_bootstrap.py
+++ b/backend/tests/support/env_bootstrap.py
@@ -6,7 +6,7 @@ import os
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-TEST_SETTINGS_DISABLE_ENV_FILE = "A2A_SETTINGS_DISABLE_ENV_FILE"
+TEST_BACKEND_ENV_FILE = "BACKEND_ENV_FILE"
 
 _AMBIENT_SETTING_PREFIXES = (
     "A2A_",
@@ -20,8 +20,8 @@ _AMBIENT_SETTING_PREFIXES = (
 
 _AMBIENT_SETTING_NAMES = {
     "APP_ENV",
+    TEST_BACKEND_ENV_FILE,
     "DATABASE_URL",
-    TEST_SETTINGS_DISABLE_ENV_FILE,
     "FIRST_USER_SUPERUSER",
     "HUB_A2A_TOKEN_ENCRYPTION_KEY",
     "INVITATION_CODE_LENGTH",
@@ -77,7 +77,7 @@ def apply_test_environment() -> None:
 
     _clear_ambient_application_settings()
 
-    os.environ[TEST_SETTINGS_DISABLE_ENV_FILE] = "true"
+    os.environ[TEST_BACKEND_ENV_FILE] = ""
     os.environ["APP_ENV"] = "development"
     os.environ["SCHEMA_NAME"] = os.getenv(
         "TEST_SCHEMA_NAME", "test_a2a_client_hub_schema"

--- a/backend/tests/support/env_bootstrap.py
+++ b/backend/tests/support/env_bootstrap.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import base64
+import os
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+TEST_SETTINGS_DISABLE_ENV_FILE = "A2A_SETTINGS_DISABLE_ENV_FILE"
+
+_AMBIENT_SETTING_PREFIXES = (
+    "A2A_",
+    "AUTH_",
+    "BACKEND_",
+    "DATABASE_",
+    "HUB_ASSISTANT_",
+    "JWT_",
+    "WS_",
+)
+
+_AMBIENT_SETTING_NAMES = {
+    "APP_ENV",
+    "DATABASE_URL",
+    TEST_SETTINGS_DISABLE_ENV_FILE,
+    "FIRST_USER_SUPERUSER",
+    "HUB_A2A_TOKEN_ENCRYPTION_KEY",
+    "INVITATION_CODE_LENGTH",
+    "LOG_FORMAT",
+    "REQUIRE_INVITATION_FOR_REGISTRATION",
+    "SCHEMA_NAME",
+    "USER_LLM_TOKEN_ENCRYPTION_KEY",
+    "UVICORN_WORKERS",
+}
+
+
+def _is_ambient_setting_name(name: str) -> bool:
+    return name in _AMBIENT_SETTING_NAMES or any(
+        name.startswith(prefix) for prefix in _AMBIENT_SETTING_PREFIXES
+    )
+
+
+def _clear_ambient_application_settings() -> None:
+    for name in list(os.environ):
+        if _is_ambient_setting_name(name):
+            os.environ.pop(name, None)
+
+
+def _resolve_test_database_url() -> str:
+    explicit_database_url = os.getenv("TEST_DATABASE_URL")
+    if explicit_database_url:
+        return explicit_database_url
+
+    default_db_name = os.getenv("TEST_DATABASE_NAME") or os.getenv("USER") or "postgres"
+    return f"postgresql:///{default_db_name}"
+
+
+def _build_test_jwt_key_pair() -> tuple[str, str]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return private_pem, public_pem
+
+
+def apply_test_environment() -> None:
+    """Install a controlled application environment for backend tests."""
+
+    _clear_ambient_application_settings()
+
+    os.environ[TEST_SETTINGS_DISABLE_ENV_FILE] = "true"
+    os.environ["APP_ENV"] = "development"
+    os.environ["SCHEMA_NAME"] = os.getenv(
+        "TEST_SCHEMA_NAME", "test_a2a_client_hub_schema"
+    )
+    os.environ["DATABASE_URL"] = _resolve_test_database_url()
+
+    default_test_secret_key = base64.urlsafe_b64encode(b"0" * 32).decode("utf-8")
+    os.environ["USER_LLM_TOKEN_ENCRYPTION_KEY"] = default_test_secret_key
+    os.environ["HUB_A2A_TOKEN_ENCRYPTION_KEY"] = default_test_secret_key
+    os.environ["WS_TICKET_SECRET_KEY"] = default_test_secret_key
+
+    private_pem = os.getenv("TEST_JWT_PRIVATE_KEY_PEM")
+    public_pem = os.getenv("TEST_JWT_PUBLIC_KEY_PEM")
+    if not private_pem or not public_pem:
+        private_pem, public_pem = _build_test_jwt_key_pair()
+
+    os.environ["JWT_ALGORITHM"] = "RS256"
+    os.environ["JWT_PRIVATE_KEY_PEM"] = private_pem
+    os.environ["JWT_PUBLIC_KEY_PEM"] = public_pem
+    os.environ["JWT_ISSUER"] = "common-compass-test"
+    os.environ["JWT_ACCESS_TOKEN_TTL_SECONDS"] = "1800"
+    os.environ["JWT_REFRESH_TOKEN_TTL_SECONDS"] = "1209600"
+    os.environ["AUTH_REFRESH_COOKIE_SECURE"] = "false"


### PR DESCRIPTION
## 关联 Issue
- Closes #906

## 变更说明
- 移除 `backend/app/core/config.py` 在模块导入期执行的 `load_dotenv(...)`，避免 backend 配置在 import 阶段提前吸收宿主环境输入
- 保留 `Settings` 的文件型环境加载能力，但将其收敛为通用 bootstrap 配置 `BACKEND_ENV_FILE`；测试侧通过将其置空来禁用 repo 本地 `backend/.env`，而不是把测试专用开关写入业务源码接口
- 将 backend 测试启动环境提取到 `tests/support/env_bootstrap.py`，在导入 `app.core.config` 前先清理 ambient application env，再仅回填受控测试变量
- 补充回归测试，覆盖 `.env` 文件加载开关、污染环境隔离，以及依赖数据库 fixture 的 runtime 路径
- 更新测试文档，明确 `TEST_DATABASE_URL`、`TEST_DATABASE_NAME`、`TEST_SCHEMA_NAME` 与 `BACKEND_ENV_FILE` 在测试 bootstrap 中的职责

## 相关提交
- `tests(backend): isolate test config bootstrap (#906)`
- `refactor(backend): generalize env file bootstrap override (#906)`
- `docs(tests): document backend env file bootstrap (#906)`

## 关系审查
- 当前 PR 与 `#906` 的关系应为 `Closes`，因为代码已经直接实现该 issue 的目标与验收标准
- 未发现需要在本 PR 中额外标记为 `closes` 或 `related` 的其它 open issues；将不相关 issue 绑定进来会扩大 PR 语义边界

## 验证结果
- `cd backend && uv run --locked pre-commit run --files app/core/config.py tests/README.md tests/conftest.py tests/runtime/test_dotenv_override_behavior.py tests/runtime/test_test_environment_bootstrap.py tests/support/env_bootstrap.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/runtime/test_dotenv_override_behavior.py tests/runtime/test_test_environment_bootstrap.py tests/runtime/test_settings_security_baseline.py tests/runtime/test_main_startup.py tests/runtime/test_ws_ticket_cleanup.py`
