### PR TITLE
refactor(stream): remove source-hint snapshot heuristics (#889)

### DIFF
--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -84,7 +84,6 @@ INFLIGHT_CANCEL_TERMINAL_ERROR_CODES = {
     "invalid_task_id",
 }
 PRIMARY_TEXT_LANE_ID = "primary_text"
-PRIMARY_TEXT_SNAPSHOT_SOURCES = frozenset({"final_snapshot", "finalize_snapshot"})
 
 
 def parse_conversation_id(value: str) -> UUID:
@@ -685,10 +684,6 @@ def write_block_cursor_state(metadata: dict[str, Any], cursor: dict[str, int]) -
         "last_block_seq": int(max(cursor.get("last_block_seq", 0), 0)),
         "active_block_seq": int(max(cursor.get("active_block_seq", 0), 0)),
     }
-
-
-def is_primary_text_snapshot_source(source: str | None) -> bool:
-    return normalize_non_empty_text(source) in PRIMARY_TEXT_SNAPSHOT_SOURCES
 
 
 def render_block_item(

--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -83,7 +83,6 @@ INFLIGHT_CANCEL_TERMINAL_ERROR_CODES = {
     "task_not_cancelable",
     "invalid_task_id",
 }
-PRIMARY_TEXT_LANE_ID = "primary_text"
 
 
 def parse_conversation_id(value: str) -> UUID:
@@ -217,7 +216,7 @@ def normalize_block_type(raw_type: str | None) -> str:
 
 
 def is_primary_text_lane(lane_id: str | None) -> bool:
-    return normalize_non_empty_text(lane_id) == PRIMARY_TEXT_LANE_ID
+    return normalize_non_empty_text(lane_id) == "primary_text"
 
 
 def normalize_interrupt_lifecycle_event(

--- a/backend/app/features/sessions/common.py
+++ b/backend/app/features/sessions/common.py
@@ -83,6 +83,7 @@ INFLIGHT_CANCEL_TERMINAL_ERROR_CODES = {
     "task_not_cancelable",
     "invalid_task_id",
 }
+PRIMARY_TEXT_LANE_ID = "primary_text"
 PRIMARY_TEXT_SNAPSHOT_SOURCES = frozenset({"final_snapshot", "finalize_snapshot"})
 
 
@@ -214,6 +215,10 @@ def normalize_block_type(raw_type: str | None) -> str:
     }:
         return normalized
     return normalized
+
+
+def is_primary_text_lane(lane_id: str | None) -> bool:
+    return normalize_non_empty_text(lane_id) == PRIMARY_TEXT_LANE_ID
 
 
 def normalize_interrupt_lifecycle_event(

--- a/backend/app/features/sessions/history_projection_blocks.py
+++ b/backend/app/features/sessions/history_projection_blocks.py
@@ -21,7 +21,7 @@ MIN_REASONING_OVERLAP_WORD_LENGTH = 5
 
 
 def _default_lane_id(block_type: str) -> str:
-    return session_common.PRIMARY_TEXT_LANE_ID if block_type == "text" else block_type
+    return "primary_text" if block_type == "text" else block_type
 
 
 def normalize_message_block_specs(

--- a/backend/app/features/sessions/history_projection_blocks.py
+++ b/backend/app/features/sessions/history_projection_blocks.py
@@ -21,7 +21,7 @@ MIN_REASONING_OVERLAP_WORD_LENGTH = 5
 
 
 def _default_lane_id(block_type: str) -> str:
-    return "primary_text" if block_type == "text" else block_type
+    return session_common.PRIMARY_TEXT_LANE_ID if block_type == "text" else block_type
 
 
 def normalize_message_block_specs(
@@ -130,13 +130,10 @@ def _normalize_block_operation(
     operation: str | None,
     *,
     append: bool,
-    source: str | None,
 ) -> str:
     normalized = normalize_non_empty_text(operation)
     if normalized in BLOCK_OPERATION_TYPES:
         return normalized
-    if session_common.is_primary_text_snapshot_source(source):
-        return "replace"
     return "append" if append else "replace"
 
 
@@ -259,7 +256,6 @@ class SessionHistoryBlockProjectionService:
         normalized_operation = _normalize_block_operation(
             operation,
             append=append,
-            source=normalized_source,
         )
         normalized_base_seq = (
             int(base_seq) if isinstance(base_seq, int) and base_seq > 0 else None
@@ -294,13 +290,14 @@ class SessionHistoryBlockProjectionService:
                 message_id=agent_message_id,
                 block_type="text",
             )
+        targets_primary_text_snapshot_slot = (
+            normalized_type == "text"
+            and session_common.is_primary_text_lane(normalized_lane_id)
+            and normalized_operation in {"replace", "finalize"}
+        )
         normalized_block_id = normalize_non_empty_text(block_id)
         if not normalized_block_id:
-            if (
-                normalized_type == "text"
-                and session_common.is_primary_text_snapshot_source(normalized_source)
-                and latest_text_block is not None
-            ):
+            if targets_primary_text_snapshot_slot and latest_text_block is not None:
                 normalized_block_id = str(latest_text_block.block_id)
             elif (
                 active_block is not None
@@ -319,11 +316,7 @@ class SessionHistoryBlockProjectionService:
         )
 
         normalized_content = str(content or "")
-        if (
-            normalized_operation == "replace"
-            and normalized_type == "text"
-            and session_common.is_primary_text_snapshot_source(normalized_source)
-        ):
+        if normalized_operation == "replace" and targets_primary_text_snapshot_slot:
             latest_reasoning_block = (
                 await block_store.find_last_block_for_message_and_type(
                     db,

--- a/backend/app/features/sessions/history_projection_messages.py
+++ b/backend/app/features/sessions/history_projection_messages.py
@@ -513,10 +513,10 @@ class SessionHistoryMessageService:
                     cast(str | None, existing_agent_blocks[0].block_type)
                 )
                 == "text"
-                and normalize_non_empty_text(
-                    cast(str | None, existing_agent_blocks[0].source)
+                and session_common.is_primary_text_lane(
+                    cast(str | None, existing_agent_blocks[0].lane_id)
                 )
-                in {"final_snapshot", "finalize_snapshot"}
+                and bool(existing_agent_blocks[0].is_finished)
             )
             if can_upsert_snapshot:
                 await self._support.upsert_single_text_block(

--- a/backend/tests/invoke/test_invoke_stream_persistence.py
+++ b/backend/tests/invoke/test_invoke_stream_persistence.py
@@ -272,7 +272,6 @@ async def test_persist_local_outcome_keeps_typed_blocks_after_stream_completion(
                     "shared": {
                         "stream": {
                             "blockType": "text",
-                            "source": "final_snapshot",
                             "messageId": "msg-stream-1",
                             "eventId": "evt-text-2",
                             "seq": 4,
@@ -742,7 +741,6 @@ async def test_persist_local_outcome_keeps_typed_blocks_when_upstream_reuses_art
                         "shared": {
                             "stream": {
                                 "blockType": "text",
-                                "source": "final_snapshot",
                                 "messageId": "msg-stream-shared",
                                 "eventId": "evt-shared-3",
                                 "seq": 3,

--- a/backend/tests/sessions/test_session_hub_service_history.py
+++ b/backend/tests/sessions/test_session_hub_service_history.py
@@ -329,7 +329,7 @@ async def test_interleaved_reasoning_final_snapshot_rewrites_primary_text_slot(
         append=False,
         is_finished=True,
         event_id="evt-3",
-        source="final_snapshot",
+        source=None,
     )
     await async_db_session.flush()
 

--- a/docs/contracts/stream-block-operation-contract.md
+++ b/docs/contracts/stream-block-operation-contract.md
@@ -26,6 +26,10 @@ Each block update must be normalized to the following logical shape:
 - `isFinished`: Compatibility flag. Canonical semantics are driven by `op`.
 - `source`: Diagnostic-only source hint.
 
+Upstream `source` hints remain advisory diagnostics only. Repo-local persistence may
+still stamp internal markers such as `finalize_snapshot`, but canonical reducers
+and projections must not require peers to emit snapshot-specific `source` values.
+
 ## State Machine Rules
 
 - `append`: Extend the existing block identified by `blockId`.


### PR DESCRIPTION
## 关联 Issue
- Closes #889

## 变更说明
- 将 session history block projection 中对 snapshot `source` hint 的 replace / target-block 决策收敛为 canonical `op + lane` 语义，不再依赖上游 `source=final_snapshot/finalize_snapshot`
- 将 message history fallback upsert 的 snapshot 判断从 `source` 改为 canonical block 状态（`lane_id=primary_text` 且已完成）
- 删除已不再使用的 snapshot source helper，避免 `#889` 看起来仍保留未清理的行为入口
- 调整回归测试，覆盖“上游不再发送 snapshot source hint 时，typed block 持久化与历史回放仍然稳定”
- 更新流式 block contract 文档，明确上游 `source` 仅为 diagnostic hint；仓内允许写本地 `finalize_snapshot` 标记，但 canonical reducer/projection 不再要求上游提供 snapshot 型 `source`

## 相关提交
- `refactor(stream): drop snapshot source-hint heuristics (#889)`
- `refactor(stream): remove unused snapshot source helpers (#889)`

## 是否已改到位
- 就 `#889` 当前定义的范围而言，已改到位。
- 本次已收掉会影响 chat stream 主链与历史投影主路径的 `source` 行为依赖。
- 剩余对 `source` 的读取保留在流式 payload 解析层，用于诊断/提示，不再驱动 snapshot 覆盖语义。

## 剩余 `source` 用法审查
- 继续保留：`backend/app/features/invoke/stream_payloads.py` 中的 `extract_artifact_source(...)`
  - 用途：读取上游 `source` hint 并透传为 diagnostic/source hint
  - 结论：当前可保留，不属于 `#889` 要移除的行为级依赖
- 已移除：history projection 与 message fallback 中基于 `final_snapshot/finalize_snapshot` 的 replace / snapshot 判断

## 关系审查
- 本 PR 与 `#889` 的关系应为 `Closes`，因为当前改动已经完成 issue 描述中的核心目标与验收方向
- 未发现需要在本 PR 中额外使用 `related` / `closes` 绑定的其它高度相关 open issues

## 验证结果
- `cd backend && uv run --locked pre-commit run --files app/features/sessions/common.py app/features/sessions/history_projection_blocks.py app/features/sessions/history_projection_messages.py tests/invoke/test_invoke_stream_persistence.py tests/sessions/test_session_hub_service_history.py ../docs/contracts/stream-block-operation-contract.md --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/invoke/test_invoke_stream_persistence.py tests/sessions/test_session_hub_service_history.py tests/sessions/test_me_sessions_routes.py tests/sessions/test_unified_session_domain_routes.py`
