### PR TITLE
fix(a2a): support typed-details upstream errors

### DIFF
--- a/backend/app/integrations/a2a_error_contract.py
+++ b/backend/app/integrations/a2a_error_contract.py
@@ -37,6 +37,9 @@ ERROR_DATA_TYPE_TO_ERROR_CODE: dict[str, str] = {
     "invalid_pagination_mode": "invalid_params",
 }
 
+_ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo"
+_BAD_REQUEST_TYPE = "type.googleapis.com/google.rpc.BadRequest"
+
 _MISSING_PARAM_MESSAGE_PATTERNS = (
     re.compile(
         r"(?P<names>[A-Za-z][A-Za-z0-9_]*(?:\s*[/,]\s*[A-Za-z][A-Za-z0-9_]*)*)\s+required\b",
@@ -50,7 +53,12 @@ _MISSING_PARAM_MESSAGE_PATTERNS = (
 
 _SAFE_UPSTREAM_DATA_KEYS = frozenset(
     {
+        "@type",
+        "description",
+        "domain",
         "type",
+        "metadata",
+        "fieldViolations",
         "field",
         "fields",
         "param",
@@ -61,9 +69,9 @@ _SAFE_UPSTREAM_DATA_KEYS = frozenset(
         "missing_fields",
         "missing_params",
         "missingParams",
+        "reason",
         "required",
         "required_fields",
-        "reason",
         "hint",
         "details",
     }
@@ -125,9 +133,28 @@ def normalize_error_data_type(error: Mapping[str, Any] | Any) -> str | None:
     data = (
         error.get("data") if isinstance(error, Mapping) and "data" in error else error
     )
-    if not isinstance(data, Mapping):
+    if isinstance(data, Mapping):
+        return normalize_error_token(data.get("type"))
+    if not isinstance(data, list):
         return None
-    return normalize_error_token(data.get("type"))
+
+    for item in data:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("@type") == _ERROR_INFO_TYPE:
+            reason = normalize_error_token(item.get("reason"))
+            if reason:
+                return reason
+            metadata = item.get("metadata")
+            if isinstance(metadata, Mapping):
+                metadata_type = normalize_error_token(metadata.get("type"))
+                if metadata_type:
+                    return metadata_type
+            continue
+        item_type = normalize_error_token(item.get("type"))
+        if item_type:
+            return item_type
+    return None
 
 
 def map_upstream_error_code(
@@ -233,6 +260,31 @@ def _coerce_missing_params(value: Any) -> list[dict[str, Any]]:
     return items
 
 
+def _coerce_missing_params_from_field_violations(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+
+    items: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        field_name = item.get("field")
+        if not isinstance(field_name, str) or not field_name.strip():
+            continue
+        description = item.get("description")
+        if isinstance(description, str):
+            lowered = description.strip().lower()
+            if "missing" not in lowered and "required" not in lowered:
+                continue
+        normalized_name = field_name.strip()
+        if normalized_name in seen_names:
+            continue
+        seen_names.add(normalized_name)
+        items.append({"name": normalized_name, "required": True})
+    return items
+
+
 def extract_missing_params(*, data: Any, message: str | None) -> list[dict[str, Any]]:
     if isinstance(data, Mapping):
         for key in (
@@ -250,6 +302,24 @@ def extract_missing_params(*, data: Any, message: str | None) -> list[dict[str, 
             resolved = _coerce_missing_params(data.get(key))
             if resolved:
                 return resolved
+    elif isinstance(data, list):
+        for item in data:
+            if not isinstance(item, Mapping):
+                continue
+            if item.get("@type") == _ERROR_INFO_TYPE:
+                metadata = item.get("metadata")
+                resolved = extract_missing_params(data=metadata, message=None)
+                if resolved:
+                    return resolved
+            if item.get("@type") == _BAD_REQUEST_TYPE:
+                resolved = _coerce_missing_params_from_field_violations(
+                    item.get("fieldViolations")
+                )
+                if resolved:
+                    return resolved
+            resolved = extract_missing_params(data=item, message=None)
+            if resolved:
+                return resolved
 
     if not message:
         return []
@@ -262,10 +332,10 @@ def extract_missing_params(*, data: Any, message: str | None) -> list[dict[str, 
 
 
 def sanitize_upstream_error_data(value: Any, *, depth: int = 0) -> Any:
-    if depth >= 3:
-        return None
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
+    if depth >= 4:
+        return None
     if isinstance(value, list):
         sanitized_items = [
             sanitize_upstream_error_data(item, depth=depth + 1) for item in value

--- a/backend/tests/client/test_a2a_error_contract.py
+++ b/backend/tests/client/test_a2a_error_contract.py
@@ -55,6 +55,28 @@ def test_build_protocol_error_from_jsonrpc_error_normalizes_uppercase_wire_types
     assert error.code == -32003
 
 
+def test_build_protocol_error_from_jsonrpc_error_reads_typed_details_reason() -> None:
+    error = build_protocol_error_from_jsonrpc_error(
+        {
+            "code": -32001,
+            "message": "Session is missing",
+            "data": [
+                {
+                    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                    "reason": "SESSION_NOT_FOUND",
+                    "domain": "a2a-protocol.org",
+                    "metadata": {},
+                }
+            ],
+        },
+        fallback_message="fallback",
+        http_status=404,
+    )
+
+    assert error.error_code == "session_not_found"
+    assert error.code == -32001
+
+
 def test_map_upstream_error_code_normalizes_uppercase_fine_grained_wire_types() -> None:
     assert (
         map_upstream_error_code(
@@ -95,6 +117,50 @@ def test_build_upstream_error_details_from_protocol_error_extracts_missing_param
     assert details.upstream_error == {
         "message": "project_id/channel_id required",
         "data": {"missing_params": ["project_id", "channel_id"]},
+    }
+
+
+def test_build_upstream_error_details_from_protocol_error_extracts_typed_details_missing_params() -> (
+    None
+):
+    details = build_upstream_error_details_from_protocol_error(
+        A2APeerProtocolError(
+            "project_id/channel_id required",
+            error_code="peer_protocol_error",
+            rpc_code=-32602,
+            data=[
+                {
+                    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                    "reason": "INVALID_PARAMS",
+                    "domain": "a2a-protocol.org",
+                    "metadata": {
+                        "missing_params": ["project_id", "channel_id"],
+                    },
+                }
+            ],
+        ),
+        default_error_code="upstream_stream_error",
+    )
+
+    assert details.error_code == "invalid_params"
+    assert details.source == "upstream_a2a"
+    assert details.jsonrpc_code == -32602
+    assert details.missing_params == (
+        {"name": "project_id", "required": True},
+        {"name": "channel_id", "required": True},
+    )
+    assert details.upstream_error == {
+        "message": "project_id/channel_id required",
+        "data": [
+            {
+                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                "reason": "INVALID_PARAMS",
+                "domain": "a2a-protocol.org",
+                "metadata": {
+                    "missing_params": ["project_id", "channel_id"],
+                },
+            }
+        ],
     }
 
 


### PR DESCRIPTION
## 背景
- 后端依赖已升级到 `a2a-sdk==1.0.3`。
- 上游 1.0.3 对 JSON-RPC / REST 错误细节的处理更贴近 A2A 1.0 规范，`error.data` 可能表现为 typed-details 数组，而不再只是一层扁平字典。
- 现有仓库实现对上游错误的归一化主要面向字典结构，存在丢失 `missing_params`、细粒度 `reason/type` 与 `metadata` 的风险。

## 本次改动
- 扩展后端 A2A 上游错误归一化逻辑，支持从 `google.rpc.ErrorInfo` / `google.rpc.BadRequest` typed-details 中提取错误类型与缺失参数。
- 调整上游错误数据清洗逻辑，保留 typed-details 下 `metadata.missing_params` 所需的安全字段。
- 补充回归测试，覆盖 typed-details 场景下的错误码映射与 `missing_params` 提取。

## 审查结论
- 本 PR 的代码变动与本次依赖升级后的实际兼容风险一致，范围收敛，未引入额外行为面。
- 现有实现继续保持仓库既有的“只接受兼容的上游错误字段并做受限透传”策略，方向合理。
- 当前未发现明显的需求偏差、冗余逻辑或新的安全回退点。

## 风险与边界
- 本 PR 只修正 typed-details 兼容问题，不改变仓库当前对仅 `0.3.x` 协议接口的拒绝策略。
- 未顺带处理前端依赖树中的低危开发依赖告警；该部分需要独立升级路径评估。

## 验证
- `cd backend && uv run --locked pre-commit run --files app/integrations/a2a_error_contract.py tests/client/test_a2a_error_contract.py --config ../.pre-commit-config.yaml`
- `cd backend && uv run --locked pytest tests/client/test_a2a_error_contract.py tests/client/test_a2a_client.py -k 'structured_protocol_error_details or a2a_error_contract or typed_details or missing_params'`
- `cd backend && uv run --locked pre-commit run --all-files --config ../.pre-commit-config.yaml`
