### PR TITLE
fix(a2a): adapt to spec-rooted http-json endpoints (#941)

### DIFF
--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -78,6 +78,9 @@ from app.utils.outbound_url import (
 
 logger = get_logger(__name__)
 
+# A2A 1.0 resolves HTTP+JSON REST paths from the advertised interface URL;
+# protocol version is negotiated via the A2A-Version header, so the
+# authenticated extended agent card lives at the service root.
 AUTHENTICATED_EXTENDED_AGENT_CARD_HTTP_PATH = "/extendedAgentCard"
 _TEXT_PAYLOAD_KEYS = (
     "content",

--- a/backend/app/integrations/a2a_client/client.py
+++ b/backend/app/integrations/a2a_client/client.py
@@ -78,7 +78,7 @@ from app.utils.outbound_url import (
 
 logger = get_logger(__name__)
 
-AUTHENTICATED_EXTENDED_AGENT_CARD_HTTP_PATH = "/v1/card"
+AUTHENTICATED_EXTENDED_AGENT_CARD_HTTP_PATH = "/extendedAgentCard"
 _TEXT_PAYLOAD_KEYS = (
     "content",
     "message",

--- a/backend/tests/client/test_a2a_client_interoperability.py
+++ b/backend/tests/client/test_a2a_client_interoperability.py
@@ -410,7 +410,7 @@ def test_build_card_resolver_uses_root_base_for_standard_http_extended_card_path
     )
 
     assert resolver.base_url == "http://example-agent.internal:24020"
-    assert resolver.agent_card_path == "v1/card"
+    assert resolver.agent_card_path == "extendedAgentCard"
 
 
 def test_build_card_resolver_rebases_standard_http_extended_card_path_from_well_known_card_url() -> (
@@ -426,7 +426,7 @@ def test_build_card_resolver_rebases_standard_http_extended_card_path_from_well_
     )
 
     assert resolver.base_url == "http://example-agent.internal:24020"
-    assert resolver.agent_card_path == "v1/card"
+    assert resolver.agent_card_path == "extendedAgentCard"
 
 
 def test_resolve_negotiated_transport_target_prefers_exact_v1_interface_within_transport() -> (

--- a/backend/tests/extensions/a2a_extensions_service_support.py
+++ b/backend/tests/extensions/a2a_extensions_service_support.py
@@ -484,7 +484,7 @@ def _wire_contract_extension_fixture(
             "agent/getAuthenticatedExtendedCard",
             "tasks/pushNotificationConfig/get",
         ),
-        core_http_endpoints=("GET /v1/tasks",),
+        core_http_endpoints=("GET /tasks",),
         extension_jsonrpc_methods=(
             "shared.sessions.list",
             "shared.sessions.get",

--- a/backend/tests/extensions/test_wire_contract_extension_discovery.py
+++ b/backend/tests/extensions/test_wire_contract_extension_discovery.py
@@ -48,7 +48,7 @@ def test_resolve_wire_contract_supports_declared_contract() -> None:
                 "additional_transports": ["JSON-RPC"],
                 "core": {
                     "jsonrpc_methods": ["agent/getAuthenticatedExtendedCard"],
-                    "http_endpoints": ["GET /v1/tasks"],
+                    "http_endpoints": ["GET /tasks"],
                 },
                 "extensions": {
                     "jsonrpc_methods": ["providers.list", "models.list"],
@@ -105,7 +105,7 @@ def test_resolve_wire_contract_accepts_current_opencode_uri() -> None:
                 "additional_transports": ["JSON-RPC"],
                 "core": {
                     "jsonrpc_methods": ["agent/getAuthenticatedExtendedCard"],
-                    "http_endpoints": ["GET /v1/tasks"],
+                    "http_endpoints": ["GET /tasks"],
                 },
                 "extensions": {
                     "jsonrpc_methods": [],
@@ -145,7 +145,7 @@ def test_resolve_wire_contract_accepts_current_opencode_wire_contract_uri() -> N
                 "additional_transports": ["JSON-RPC"],
                 "core": {
                     "jsonrpc_methods": ["agent/getAuthenticatedExtendedCard"],
-                    "http_endpoints": ["GET /v1/tasks"],
+                    "http_endpoints": ["GET /tasks"],
                 },
                 "extensions": {
                     "jsonrpc_methods": [],
@@ -185,7 +185,7 @@ def test_resolve_wire_contract_accepts_current_codex_uri() -> None:
                 "additional_transports": ["JSON-RPC"],
                 "core": {
                     "jsonrpc_methods": ["tasks/get"],
-                    "http_endpoints": ["POST /v1/message:send"],
+                    "http_endpoints": ["POST /message:send"],
                 },
                 "extensions": {
                     "jsonrpc_methods": ["codex.sessions.list"],
@@ -220,7 +220,7 @@ def test_resolve_wire_contract_rejects_invalid_conditional_map() -> None:
                 "additional_transports": ["JSON-RPC"],
                 "core": {
                     "jsonrpc_methods": ["agent/getAuthenticatedExtendedCard"],
-                    "http_endpoints": ["GET /v1/tasks"],
+                    "http_endpoints": ["GET /tasks"],
                 },
                 "extensions": {
                     "jsonrpc_methods": ["providers.list"],


### PR DESCRIPTION
## 概述

适配两个下游仓库移除 HTTP+JSON `/v1` 前缀的变更（A2A 1.0 以接口 URL 为 REST 根路径，协议版本通过 `A2A-Version` 头协商）：

- `opencode-a2a`：#498（`POST /message:send`、`GET /tasks`、`GET /extendedAgentCard` 等）
- `codex-a2a`：4ecc96d（`GET /extendedAgentCard` 替代原 `GET /v1/card`）

本仓库通过 `a2a-sdk` 发起 HTTP+JSON 调用，SDK REST transport 以接口 URL 为根拼接 `/message:send`、`/tasks`、`/extendedAgentCard`（无 `/v1`），因此运行期调用无需改动；需要适配的是 hub 侧硬编码路径与契约测试夹具。

## 变更内容

- `backend/app/integrations/a2a_client/client.py`：`AUTHENTICATED_EXTENDED_AGENT_CARD_HTTP_PATH` 从 `/v1/card` 更新为 `/extendedAgentCard`（覆盖扩展卡 HTTP 回退获取与 card resolver 基准路径推导），并补充根路径语义注释。
- `backend/tests/client/test_a2a_client_interoperability.py`：同步更新 resolver 路径断言。
- `backend/tests/extensions/test_wire_contract_extension_discovery.py`、`backend/tests/extensions/a2a_extensions_service_support.py`：wire-contract HTTP 端点夹具从 `/v1/...` 更新为根路径（`GET /tasks`、`POST /message:send`），与下游新契约一致。

hub 自身 `/api/v1` 控制面前缀语义不变。

## 审查结论

- SDK REST transport（`a2a/client/transports/rest.py`）确认以接口 URL 为根解析路径；wire-contract 解析（`a2a_extensions/wire_contract.py`）只做字符串归一化、无 `/v1` 前缀假设，根路径端点可正常消费。
- 全仓库无其他硬编码 `/v1/...` A2A 端点引用；本仓库文档仅含 hub 自身 `/api/v1` 控制面，无需文档改动。
- 旧 `codex-a2a`（仍服务 `/v1/card`）的 HTTP 扩展卡回退路径会 404，但扩展卡首选 JSON-RPC `GetExtendedAgentCard`（POST /），旧实例不受影响；`/v1/card` 为 adapter 私有非标准路径，不保留双路径回退。

## 相关提交

- `0aabce8` fix(a2a): adapt to spec-rooted http-json endpoints (#941)
- `3b6b89f` docs(a2a): explain root-based extended card path rationale (#941)
- `20af990` Merge main into fix/adapt-http-json-root-paths (#941)（含 `8cf23db` 依赖审计修复，a2a-sdk 1.1.0 → 1.1.2）

## 验证证据

- `pre-commit run --files <4 个变更文件> --config ../.pre-commit-config.yaml`：全部 Passed。
- `pytest tests/client/test_a2a_client_interoperability.py tests/extensions -q`：合并 main 后全部通过（220 tests，0 failures）。
- 完整 `pre-commit run --all-files`（合并 main、`uv sync --extra dev --locked` + `npm install` 后）：全部 Passed，包括 backend mypy、前端 eslint/tsc/unused-exports。

Closes #941
